### PR TITLE
fix: SQLite sources were redacted in place with no backup while reporting failure

### DIFF
--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -414,8 +414,13 @@ def _write_text(path: Path, text: str) -> None:
         print(f"Could not write {path}: {e}", file=sys.stderr)
 
 
+# Backup patterns undo restores: JSONL transcripts plus the SQLite stores
+# (Cursor/Windsurf *.vscdb, OpenCode opencode.db).
+_BACKUP_GLOBS = ("*.jsonl.bak", "*.vscdb.bak", "*.db.bak")
+
+
 def undo(args) -> int:
-    """Restore *.jsonl.bak backups over their redacted files.
+    """Restore agentsweep .bak backups over their redacted files.
 
     Scriptable: prompts for confirmation only on an interactive terminal.
     Exit 0 on success or nothing-to-do, 2 if any restore failed.
@@ -425,7 +430,8 @@ def undo(args) -> int:
     if not source.root.exists():
         print(f"No history root at {source.root}", file=sys.stderr)
         return 0
-    backups = sorted(source.root.rglob("*.jsonl.bak"))
+    backups = sorted({p for pat in _BACKUP_GLOBS
+                      for p in source.root.rglob(pat)})
     if not backups:
         print(f"No .bak backups found under {source.root}", file=sys.stderr)
         return 0

--- a/src/agentsweep/redactor.py
+++ b/src/agentsweep/redactor.py
@@ -74,12 +74,17 @@ def safety_check(path: Path, source_root: Path, force: bool = False) -> None:
             )
 
 
-def safe_write(path: Path, new_content: str, backup: bool = True) -> WriteRecord:
+def safe_write(path: Path, new_content: str | bytes,
+               backup: bool = True) -> WriteRecord:
     """Atomically replace `path`'s content with `new_content`.
 
     Guarantees:
-      - Post-write validation: every non-empty line in the new content must
-        parse as JSON, and the line count must match the original.
+      - Post-write validation (str content): every non-empty line in the new
+        content must parse as JSON, and the line count must match the
+        original. bytes content is the contract for binary formats (SQLite),
+        where line-oriented checks are meaningless — the producing source
+        MUST validate the bytes itself (e.g. PRAGMA integrity_check on the
+        rewritten copy) before handing them over.
       - Atomic replacement: writes to a sibling tempfile with fsync, then
         os.replace. A crash at any point leaves either the complete old file
         or the complete new file on disk — never a torn write.
@@ -89,21 +94,25 @@ def safe_write(path: Path, new_content: str, backup: bool = True) -> WriteRecord
         SHA256 of both versions.
     """
     original_bytes = path.read_bytes()
-    original_text = original_bytes.decode("utf-8")
     original_hash = _sha256(original_bytes)
 
-    new_bytes = new_content.encode("utf-8")
+    if isinstance(new_content, bytes):
+        new_bytes = new_content
+    else:
+        new_bytes = new_content.encode("utf-8")
+
+        _validate_jsonl(new_content)
+
+        original_text = original_bytes.decode("utf-8")
+        original_line_count = len(original_text.splitlines(keepends=True))
+        new_line_count = len(new_content.splitlines(keepends=True))
+        if original_line_count != new_line_count:
+            raise SafetyError(
+                f"Line count changed after redaction "
+                f"({original_line_count} -> {new_line_count}); refusing to write"
+            )
+
     new_hash = _sha256(new_bytes)
-
-    _validate_jsonl(new_content)
-
-    original_line_count = len(original_text.splitlines(keepends=True))
-    new_line_count = len(new_content.splitlines(keepends=True))
-    if original_line_count != new_line_count:
-        raise SafetyError(
-            f"Line count changed after redaction "
-            f"({original_line_count} -> {new_line_count}); refusing to write"
-        )
 
     backup_path: Path | None = None
     if backup:

--- a/src/agentsweep/sources.py
+++ b/src/agentsweep/sources.py
@@ -4,10 +4,12 @@ import json
 import os
 import sqlite3
 import sys
+import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Iterator
 
+from .redactor import SafetyError
 from .preflight import (
     CLAUDE_CODE_MARKERS,
     CODEX_MARKERS,
@@ -65,13 +67,17 @@ class Source(ABC):
         self,
         path: Path,
         redactions: list[tuple[int, KeyPath, str]],
-    ) -> str:
+    ) -> str | bytes:
         """Produce the new file content with string values replaced.
 
-        Each redaction is (line_number, keypath, new_string). The returned
-        string is the full file content to write. Implementations MUST preserve
-        structure (line count, JSON validity, line endings) so the redactor's
-        post-write validation passes.
+        Each redaction is (line_number, keypath, new_string). The return
+        value is the full file content to write — str for text formats,
+        bytes for binary formats like SQLite. Implementations MUST NOT
+        modify `path` itself; the redactor owns the backup and the atomic
+        write. str content MUST preserve structure (line count, JSON
+        validity, line endings) so the redactor's post-write validation
+        passes; bytes content MUST be validated by the implementation
+        (e.g. PRAGMA integrity_check) before it is returned.
         """
 
 
@@ -225,6 +231,103 @@ def _line_ending(line: str) -> str:
     return ""
 
 
+def _redact_sqlite_copy(path: Path, redactions: list, columns_fn) -> bytes:
+    """Apply SQLite redactions to a temp copy of `path` and return its bytes.
+
+    The production database is never touched here — the pipeline writes the
+    returned bytes back through redactor.safe_write, which owns the .bak
+    backup, the atomic replace and the audit record (the same contract as
+    text sources). Steps:
+
+      1. Snapshot `path` into a sibling tempfile via sqlite's backup API
+         (page-consistent, checkpoints any WAL into the copy).
+      2. Run the UPDATEs against the copy with secure_delete on, then
+         VACUUM, so the replaced plaintext cannot survive in freelist or
+         page slack space — this is a secret-removal tool, "deleted but
+         still on disk" defeats the point.
+      3. Gate on PRAGMA integrity_check before returning the copy's bytes.
+
+    `columns_fn(con)` returns the source's whitelisted (table, column)
+    pairs; redactions targeting anything outside that whitelist are skipped.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".redact")
+    os.close(fd)
+    tmp = Path(tmp_name)
+    try:
+        try:
+            src_con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        except sqlite3.Error as e:
+            raise SafetyError(f"Cannot open {path} read-only: {e}") from e
+        try:
+            dst_con = sqlite3.connect(str(tmp))
+            try:
+                src_con.backup(dst_con)
+                dst_con.execute("PRAGMA secure_delete = ON")
+                allowed = set(columns_fn(dst_con))
+                _apply_sqlite_updates(dst_con, redactions, allowed)
+                dst_con.commit()
+                dst_con.execute("VACUUM")
+                row = dst_con.execute("PRAGMA integrity_check").fetchone()
+                if row is None or row[0] != "ok":
+                    raise SafetyError(
+                        f"Redacted copy of {path.name} failed "
+                        f"integrity_check; refusing to write")
+            finally:
+                dst_con.close()
+        finally:
+            src_con.close()
+        return tmp.read_bytes()
+    except sqlite3.Error as e:
+        raise SafetyError(
+            f"SQLite error while redacting {path.name}: {e}") from e
+    finally:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+
+
+def _apply_sqlite_updates(
+    con: sqlite3.Connection,
+    redactions: list,
+    allowed: set[tuple[str, str]],
+) -> None:
+    """Run redaction UPDATEs on `con`. Keypath encoding per SQLite row:
+    [table, rowid, column] (+ JSON sub-path when the column holds JSON)."""
+    for _line_num, kp, new_val in redactions:
+        if len(kp) < 3:
+            continue
+        table, rowid, col = kp[0], kp[1], kp[2]
+        if (table, col) not in allowed:
+            continue
+        sub_kp = kp[3:]
+        if not sub_kp:
+            # Direct column value
+            con.execute(
+                f"UPDATE {table} SET {col} = ? WHERE rowid = ?",  # noqa: S608 (whitelisted)
+                (new_val, rowid),
+            )
+        else:
+            # JSON-embedded value: read, patch, write back
+            cur = con.execute(
+                f"SELECT {col} FROM {table} WHERE rowid = ?",  # noqa: S608 (whitelisted)
+                (rowid,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                continue
+            try:
+                obj = json.loads(row[0])
+            except (json.JSONDecodeError, TypeError):
+                continue
+            _set_by_path(obj, sub_kp, new_val)
+            con.execute(
+                f"UPDATE {table} SET {col} = ? WHERE rowid = ?",  # noqa: S608 (whitelisted)
+                (json.dumps(obj, ensure_ascii=False), rowid),
+            )
+
+
 class OpenCodeSource(Source):
     """OpenCode (sst/opencode) — history stored in a SQLite database at
     ~/.local/share/opencode/opencode.db, or (legacy) as JSON files under
@@ -317,9 +420,10 @@ class OpenCodeSource(Source):
         self,
         path: Path,
         redactions: list[tuple[int, KeyPath, str]],
-    ) -> str:
+    ) -> str | bytes:
         if path == self._db_path():
-            return self._apply_redactions_sqlite(path, redactions)
+            return _redact_sqlite_copy(path, redactions,
+                                       self._sqlite_text_columns)
         return self._apply_redactions_json(path, redactions)
 
     # --- SQLite scanning ------------------------------------------------
@@ -380,60 +484,6 @@ class OpenCodeSource(Source):
             for col in cols:
                 pairs.append((table, col))
         return pairs
-
-    # --- SQLite redaction -----------------------------------------------
-
-    def _apply_redactions_sqlite(
-        self,
-        path: Path,
-        redactions: list[tuple[int, KeyPath, str]],
-    ) -> str:
-        """Apply redactions directly to the SQLite DB rows.
-
-        Returns the original DB content read as bytes, decoded as latin-1
-        (a no-op passthrough that satisfies the pipeline's write-back
-        contract).  The actual mutations are applied via UPDATE statements.
-        """
-        try:
-            con = sqlite3.connect(str(path))
-        except sqlite3.OperationalError:
-            return path.read_bytes().decode("latin-1")
-        try:
-            for _line_num, kp, new_val in redactions:
-                if len(kp) < 3:
-                    continue
-                table, rowid, col = kp[0], kp[1], kp[2]
-                sub_kp = kp[3:]
-                if not sub_kp:
-                    # Direct column value
-                    con.execute(
-                        f"UPDATE {table} SET {col} = ? WHERE rowid = ?",  # noqa: S608
-                        (new_val, rowid),
-                    )
-                else:
-                    # JSON-embedded value: read, patch, write back
-                    cur = con.execute(
-                        f"SELECT {col} FROM {table} WHERE rowid = ?",  # noqa: S608
-                        (rowid,),
-                    )
-                    row = cur.fetchone()
-                    if row is None:
-                        continue
-                    try:
-                        obj = json.loads(row[0])
-                    except (json.JSONDecodeError, TypeError):
-                        continue
-                    _set_by_path(obj, sub_kp, new_val)
-                    con.execute(
-                        f"UPDATE {table} SET {col} = ? WHERE rowid = ?",  # noqa: S608
-                        (json.dumps(obj, ensure_ascii=False), rowid),
-                    )
-            con.commit()
-        finally:
-            con.close()
-        # Return the (now mutated) file bytes decoded as latin-1 so the
-        # pipeline can write it back via path.write_text(content, "latin-1").
-        return path.read_bytes().decode("latin-1")
 
     # --- JSON (legacy) scanning/redaction --------------------------------
 
@@ -554,43 +604,9 @@ class _VSCodeSqliteSource(Source):
         self,
         path: Path,
         redactions: list[tuple[int, KeyPath, str]],
-    ) -> str:
-        try:
-            con = sqlite3.connect(str(path))
-        except sqlite3.OperationalError:
-            return path.read_bytes().decode("latin-1")
-        try:
-            for _line_num, kp, new_val in redactions:
-                if len(kp) < 3:
-                    continue
-                table, rowid, col = kp[0], kp[1], kp[2]
-                sub_kp = kp[3:]
-                if not sub_kp:
-                    con.execute(
-                        f"UPDATE {table} SET {col} = ? WHERE rowid = ?",  # noqa: S608
-                        (new_val, rowid),
-                    )
-                else:
-                    cur = con.execute(
-                        f"SELECT {col} FROM {table} WHERE rowid = ?",  # noqa: S608
-                        (rowid,),
-                    )
-                    row = cur.fetchone()
-                    if row is None:
-                        continue
-                    try:
-                        obj = json.loads(row[0])
-                    except (json.JSONDecodeError, TypeError):
-                        continue
-                    _set_by_path(obj, sub_kp, new_val)
-                    con.execute(
-                        f"UPDATE {table} SET {col} = ? WHERE rowid = ?",  # noqa: S608
-                        (json.dumps(obj, ensure_ascii=False), rowid),
-                    )
-            con.commit()
-        finally:
-            con.close()
-        return path.read_bytes().decode("latin-1")
+    ) -> bytes:
+        return _redact_sqlite_copy(path, redactions,
+                                   self._sqlite_text_columns)
 
 
 class CursorSource(_VSCodeSqliteSource):
@@ -662,7 +678,7 @@ class CursorSource(_VSCodeSqliteSource):
         self,
         path: Path,
         redactions: list[tuple[int, KeyPath, str]],
-    ) -> str:
+    ) -> str | bytes:
         if path.suffix == ".jsonl":
             return _apply_jsonl_redactions(path, redactions)
         return super().apply_redactions(path, redactions)
@@ -730,7 +746,7 @@ class WindsurfSource(_VSCodeSqliteSource):
         self,
         path: Path,
         redactions: list[tuple[int, KeyPath, str]],
-    ) -> str:
+    ) -> str | bytes:
         if path.suffix == ".md":
             return _apply_plaintext_redactions(path, redactions)
         return super().apply_redactions(path, redactions)

--- a/tests/test_sqlite_redaction.py
+++ b/tests/test_sqlite_redaction.py
@@ -1,0 +1,152 @@
+"""End-to-end redaction tests for the SQLite-backed sources (Cursor /
+Windsurf *.vscdb, OpenCode opencode.db).
+
+Regression coverage for the redact-without-backup bug: apply_redactions
+used to UPDATE the production database in place and then hand a latin-1
+passthrough of the (already mutated) file to safe_write, which always
+failed its UTF-8/JSONL checks — the redaction had silently happened, but
+the run reported FAIL, no .bak existed, no audit record was written, and
+undo had nothing to restore. The fix makes apply_redactions side-effect
+free (it rewrites a temp copy and returns bytes), so safe_write owns the
+backup and the atomic replace for SQLite exactly as it does for JSONL.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.pipeline import _build_redactions, _scan_file, undo  # noqa: E402
+from agentsweep.redactor import safe_write  # noqa: E402
+from agentsweep.sources import CursorSource, OpenCodeSource  # noqa: E402
+
+SECRET = "AKIAIOSFODNN7EXAMPLE"  # AWS's documented example access key id
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    # Keep the audit log (and Cursor's ~/.cursor transcript discovery)
+    # away from the real home directory.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+
+def _make_vscdb(db: Path) -> bytes:
+    """Build a minimal Cursor-style state.vscdb with one secret embedded in
+    a JSON blob (cursorDiskKV) and one as a bare column value (ItemTable),
+    covering both UPDATE branches. Returns the original file bytes."""
+    db.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT)")
+    con.execute(
+        "INSERT INTO cursorDiskKV VALUES (?, ?)",
+        ("bubbleId:1", json.dumps({"text": f"my key is {SECRET} btw"})),
+    )
+    con.execute("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)")
+    con.execute("INSERT INTO ItemTable VALUES (?, ?)", ("chat", f"plain {SECRET}"))
+    con.commit()
+    con.close()
+    return db.read_bytes()
+
+
+def _redact(source, f: Path):
+    """Mirror the pipeline's scan -> redactions -> apply composition."""
+    _, items, _, _ = _scan_file(source, f, ignores=None)
+    assert items, "fixture secret should be detected"
+    return source.apply_redactions(f, _build_redactions(items))
+
+
+def test_cursor_fix_backs_up_original_and_redacts(tmp_path: Path) -> None:
+    root = tmp_path / "User"
+    db = root / "globalStorage" / "state.vscdb"
+    original = _make_vscdb(db)
+    source = CursorSource(root=root)
+    assert db in source.files()
+
+    new_content = _redact(source, db)
+
+    # apply_redactions must be side-effect free on the production file...
+    assert isinstance(new_content, bytes)
+    assert db.read_bytes() == original
+
+    record = safe_write(db, new_content, backup=True)
+
+    # ...so the .bak written by safe_write is the true pre-redaction original.
+    bak = db.with_name(db.name + ".bak")
+    assert record.backup == bak
+    assert bak.read_bytes() == original
+
+    redacted = db.read_bytes()
+    # Gone from live rows AND from freelist/slack space (secure_delete+VACUUM).
+    assert SECRET.encode() not in redacted
+
+    con = sqlite3.connect(db)
+    assert con.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    values = [r[0] for r in con.execute("SELECT value FROM cursorDiskKV")]
+    values += [r[0] for r in con.execute("SELECT value FROM ItemTable")]
+    con.close()
+    assert all(SECRET not in v for v in values)
+    assert sum("[REDACTED:" in v for v in values) == 2  # both branches hit
+    # The JSON blob is still parseable JSON after the in-JSON patch.
+    blob = json.loads(values[0])
+    assert "[REDACTED:" in blob["text"]
+
+
+def test_opencode_db_fix_backs_up_original_and_redacts(tmp_path: Path) -> None:
+    root = tmp_path / "opencode"
+    db = root / "opencode.db"
+    db.parent.mkdir(parents=True)
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE part (id TEXT, content TEXT)")
+    con.execute(
+        "INSERT INTO part VALUES (?, ?)",
+        ("p1", json.dumps({"type": "text", "text": f"token {SECRET}"})),
+    )
+    con.commit()
+    con.close()
+    original = db.read_bytes()
+
+    source = OpenCodeSource(root=root)
+    assert source.files() == [db]
+
+    new_content = _redact(source, db)
+    assert isinstance(new_content, bytes)
+    assert db.read_bytes() == original
+
+    safe_write(db, new_content, backup=True)
+    assert db.with_name(db.name + ".bak").read_bytes() == original
+    assert SECRET.encode() not in db.read_bytes()
+    con = sqlite3.connect(db)
+    assert con.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    con.close()
+
+
+def test_undo_restores_vscdb_backup(tmp_path: Path) -> None:
+    root = tmp_path / "User"
+    db = root / "globalStorage" / "state.vscdb"
+    original = _make_vscdb(db)
+    source = CursorSource(root=root)
+    safe_write(db, _redact(source, db), backup=True)
+    assert db.read_bytes() != original
+
+    code = undo(argparse.Namespace(source="cursor", root=root))
+    assert code == 0
+    assert db.read_bytes() == original
+    assert not db.with_name(db.name + ".bak").exists()
+
+
+def test_safe_write_bytes_skips_line_validation(tmp_path: Path) -> None:
+    # bytes content is the binary-format contract: no JSONL/line-count
+    # checks, no UTF-8 decode of the original.
+    target = tmp_path / "state.vscdb"
+    target.write_bytes(b"SQLite format 3\x00" + b"\xde\xad\xbe\xef" * 8)
+    new = b"SQLite format 3\x00" + b"\x00" * 32
+    record = safe_write(target, new, backup=False)
+    assert target.read_bytes() == new
+    assert record.backup is None


### PR DESCRIPTION
## The bug

For the SQLite-backed sources (Cursor / Windsurf `state.vscdb`, OpenCode `opencode.db`), `--fix` silently redacted the production database **with no backup, while reporting failure**:

1. `apply_redactions` connected to the production DB and **committed its UPDATEs in place**, then returned the file bytes decoded as latin-1 as a "passthrough" for the pipeline.
2. `safe_write` then read that (already mutated) file and failed every time — a real SQLite file doesn't survive `.decode("utf-8")`, and even when it does, `_validate_jsonl` rejects binary content. (Had both somehow passed, re-encoding the latin-1 str as UTF-8 would have corrupted the DB on write.)

Net effect of a real `fix` run on Cursor/Windsurf/OpenCode:

- the REDACT row shows **fail** — but the redaction already happened;
- **no `.bak` is created**, so the pre-redaction original is unrecoverable;
- no audit record is written;
- `undo` has nothing to restore (and only globbed `*.jsonl.bak` anyway).

The composition was never exercised in tests — `apply_redactions` and `safe_write` each pass their isolated tests; only their combination is broken.

## The fix

`apply_redactions` for SQLite sources is now **side-effect free**, so `safe_write` owns the backup and the atomic replace for SQLite exactly as it does for JSONL. New shared helper `_redact_sqlite_copy`:

1. snapshots the DB into a sibling tempfile via sqlite's backup API (page-consistent, checkpoints any WAL into the copy);
2. runs the UPDATEs against the **copy**, with `PRAGMA secure_delete=ON` and a `VACUUM` afterwards — so the replaced plaintext can't survive in freelist/slack pages, which matters for a secret-removal tool;
3. gates on `PRAGMA integrity_check` and returns the copy's bytes.

`safe_write` accepts `str | bytes`: bytes skip the line-oriented JSONL checks (the producer has already integrity-checked the result) but keep everything else — backup-from-true-original, fsync + `os.replace` atomicity, and the audit record. A failed redaction now leaves the production DB untouched, and a successful one has a real `.bak`.

Also in this PR:

- `undo` now restores `*.vscdb.bak` / `*.db.bak` in addition to `*.jsonl.bak`, so the backups this fix starts creating are actually restorable.
- Defense in depth: the UPDATE loop validates `(table, column)` against the source's whitelist before interpolating identifiers into SQL.
- The duplicated UPDATE logic in `OpenCodeSource._apply_redactions_sqlite` and `_VSCodeSqliteSource.apply_redactions` is factored into one helper.

## Tests

Four new end-to-end tests in `tests/test_sqlite_redaction.py` covering the full scan → `_build_redactions` → `apply_redactions` → `safe_write` composition for Cursor and OpenCode (both the JSON-blob and bare-column UPDATE branches), `undo` restoring a `.vscdb.bak`, and the bytes contract of `safe_write`. The Cursor test asserts the three properties the bug violated: the production file is untouched until `safe_write`, the `.bak` equals the pre-redaction original, and the secret is gone from the raw file bytes (not just from live rows).

`python -m pytest tests/ -q` → 360 passed (356 before, +4 new).

Found while auditing the codebase; happy to adjust scope or style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
