### PR TITLE
fix: --fix now works (and fails closed) for markdown and whole-file JSON sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ A redactor that corrupts your history is strictly worse than the leak it's fixin
 
 1. **Redaction happens in parsed JSON, not on raw bytes.** Secrets are replaced as string *values* inside the parsed structure, then re-serialized. Structural damage is impossible by construction.
 2. **Atomic writes.** Every rewrite goes: temp file → `fsync()` → `os.replace()` over the original. A crash at any instant leaves either the complete old file or the complete new file — never a torn write.
-3. **Post-write validation.** Before committing, every non-empty line in the new content must parse as JSON, and the line count must match the original. If either check fails, the write aborts and the original is untouched.
+3. **Post-write validation.** Before committing, the new content must pass a format-aware check: JSONL — every non-empty line parses as JSON and the line count matches the original; whole-file JSON — the document parses; markdown/plaintext — the line count matches the original; SQLite — the rewritten copy passes `PRAGMA integrity_check`. If the check fails, the write aborts and the original is untouched.
 4. **`.bak` backup by default.** Refuses to run if a `.bak` already exists (so prior backups can't be clobbered).
-5. **Path containment.** Refuses any target that doesn't resolve inside the source's root.
+5. **Path containment.** Refuses any target that doesn't resolve inside one of the source's history trees (e.g. Windsurf's User dir and its `~/.codeium/windsurf/memories/`).
 6. **Symlink rejection.** Refuses symlinks outright.
 7. **mtime window.** Refuses files modified in the last 60 seconds (likely an active session). `--force` overrides.
 8. **Running-process check.** Refuses if a Claude Code process appears to be running. `--force` overrides.

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -414,9 +414,11 @@ def _write_text(path: Path, text: str) -> None:
         print(f"Could not write {path}: {e}", file=sys.stderr)
 
 
-# Backup patterns undo restores: JSONL transcripts plus the SQLite stores
-# (Cursor/Windsurf *.vscdb, OpenCode opencode.db).
-_BACKUP_GLOBS = ("*.jsonl.bak", "*.vscdb.bak", "*.db.bak")
+# Backup patterns undo restores: JSONL transcripts, whole-file JSON and
+# markdown histories, plus the SQLite stores (Cursor/Windsurf *.vscdb,
+# OpenCode opencode.db, Hermes/Goose *.db).
+_BACKUP_GLOBS = ("*.jsonl.bak", "*.json.bak", "*.md.bak",
+                 "*.vscdb.bak", "*.db.bak")
 
 
 def undo(args) -> int:
@@ -427,11 +429,13 @@ def undo(args) -> int:
     """
     source_cls = SOURCES[args.source]
     source: Source = source_cls(root=args.root) if args.root else source_cls()
-    if not source.root.exists():
+    roots = [r for r in source.roots() if r.exists()]
+    if not roots:
         print(f"No history root at {source.root}", file=sys.stderr)
         return 0
-    backups = sorted({p for pat in _BACKUP_GLOBS
-                      for p in source.root.rglob(pat)})
+    backups = sorted({p for root in roots
+                      for pat in _BACKUP_GLOBS
+                      for p in root.rglob(pat)})
     if not backups:
         print(f"No .bak backups found under {source.root}", file=sys.stderr)
         return 0
@@ -478,7 +482,7 @@ def _redact_all(
     for path, items in found_by_file.items():
         display = ui.rel(path, source.root)
         try:
-            safety_check(path, source.root, force=force)
+            safety_check(path, source.roots(), force=force)
         except SafetyError as e:
             rows.append(("skip", display, str(e)))
             errors += 1
@@ -487,7 +491,8 @@ def _redact_all(
         redactions = _build_redactions(items)
         try:
             new_content = source.apply_redactions(path, redactions)
-            record = safe_write(path, new_content, backup=backup)
+            record = safe_write(path, new_content, backup=backup,
+                                fmt=source.content_format(path))
             note = f".bak: {record.backup.name}" if record.backup else "no backup"
             rows.append(("ok", display, note))
         except SafetyError as e:

--- a/src/agentsweep/redactor.py
+++ b/src/agentsweep/redactor.py
@@ -5,6 +5,7 @@ import json
 import os
 import tempfile
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -37,30 +38,42 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def safety_check(path: Path, source_root: Path, force: bool = False) -> None:
+def safety_check(path: Path, source_root: Path | Iterable[Path],
+                 force: bool = False) -> None:
     """Raise SafetyError if `path` is not safe to modify.
 
-    Refuses: paths outside source_root, symlinks, and files modified within
-    MIN_AGE_SECONDS (likely an active session). `force=True` bypasses only the
-    mtime check; path-containment and symlink checks are never bypassed.
+    Refuses: paths outside the source's root(s), symlinks, and files modified
+    within MIN_AGE_SECONDS (likely an active session). `force=True` bypasses
+    only the mtime check; path-containment and symlink checks are never
+    bypassed. `source_root` may be a single Path or, for sources whose
+    history spans several trees (Cursor agent transcripts, Windsurf
+    memories), an iterable of them — containment in any one suffices.
     """
+    roots = [source_root] if isinstance(source_root, Path) else list(source_root)
+
     try:
         resolved = path.resolve(strict=True)
     except (OSError, RuntimeError) as e:
         raise SafetyError(f"Cannot resolve path: {e}") from e
 
-    try:
-        root_resolved = source_root.resolve(strict=True)
-    except (OSError, RuntimeError) as e:
-        raise SafetyError(f"Cannot resolve source root: {e}") from e
+    resolved_roots: list[Path] = []
+    for root in roots:
+        try:
+            resolved_roots.append(root.resolve(strict=True))
+        except (OSError, RuntimeError):
+            continue  # a secondary tree may legitimately not exist
+    if not resolved_roots:
+        raise SafetyError("Cannot resolve any source root")
 
-    try:
-        resolved.relative_to(root_resolved)
-    except ValueError as e:
+    contained = any(
+        resolved == r or r in resolved.parents for r in resolved_roots
+    )
+    if not contained:
         raise SafetyError(
-            f"Refusing to modify path outside source root: {path} "
-            f"(resolves to {resolved}, root is {root_resolved})"
-        ) from e
+            f"Refusing to modify path outside source root(s): {path} "
+            f"(resolves to {resolved}, root(s): "
+            f"{', '.join(str(r) for r in resolved_roots)})"
+        )
 
     if path.is_symlink():
         raise SafetyError(f"Refusing to modify symlink: {path}")
@@ -75,16 +88,23 @@ def safety_check(path: Path, source_root: Path, force: bool = False) -> None:
 
 
 def safe_write(path: Path, new_content: str | bytes,
-               backup: bool = True) -> WriteRecord:
+               backup: bool = True, fmt: str = "jsonl") -> WriteRecord:
     """Atomically replace `path`'s content with `new_content`.
 
     Guarantees:
-      - Post-write validation (str content): every non-empty line in the new
-        content must parse as JSON, and the line count must match the
-        original. bytes content is the contract for binary formats (SQLite),
-        where line-oriented checks are meaningless — the producing source
-        MUST validate the bytes itself (e.g. PRAGMA integrity_check on the
-        rewritten copy) before handing them over.
+      - Post-write validation (str content), selected by `fmt`:
+          "jsonl" — every non-empty line must parse as JSON and the line
+                    count must match the original (the default);
+          "json"  — the whole content must parse as one JSON document
+                    (re-serialization may legitimately reflow lines, so no
+                    line-count check);
+          "text"  — the line count must match the original (markdown and
+                    plaintext histories, where redaction replaces whole
+                    lines 1:1).
+        bytes content is the contract for binary formats (SQLite), where
+        these checks are meaningless — the producing source MUST validate
+        the bytes itself (e.g. PRAGMA integrity_check on the rewritten
+        copy) before handing them over; `fmt` is ignored.
       - Atomic replacement: writes to a sibling tempfile with fsync, then
         os.replace. A crash at any point leaves either the complete old file
         or the complete new file on disk — never a torn write.
@@ -101,16 +121,24 @@ def safe_write(path: Path, new_content: str | bytes,
     else:
         new_bytes = new_content.encode("utf-8")
 
-        _validate_jsonl(new_content)
-
-        original_text = original_bytes.decode("utf-8")
-        original_line_count = len(original_text.splitlines(keepends=True))
-        new_line_count = len(new_content.splitlines(keepends=True))
-        if original_line_count != new_line_count:
+        if fmt == "jsonl":
+            _validate_jsonl(new_content)
+        elif fmt == "json":
+            _validate_json(new_content)
+        elif fmt != "text":
             raise SafetyError(
-                f"Line count changed after redaction "
-                f"({original_line_count} -> {new_line_count}); refusing to write"
+                f"Unknown content format {fmt!r}; refusing to write"
             )
+
+        if fmt != "json":
+            original_text = original_bytes.decode("utf-8")
+            original_line_count = len(original_text.splitlines(keepends=True))
+            new_line_count = len(new_content.splitlines(keepends=True))
+            if original_line_count != new_line_count:
+                raise SafetyError(
+                    f"Line count changed after redaction "
+                    f"({original_line_count} -> {new_line_count}); refusing to write"
+                )
 
     new_hash = _sha256(new_bytes)
 
@@ -159,6 +187,16 @@ def safe_write(path: Path, new_content: str | bytes,
     )
     _append_audit(record)
     return record
+
+
+def _validate_json(content: str) -> None:
+    try:
+        json.loads(content)
+    except json.JSONDecodeError as e:
+        raise SafetyError(
+            f"Post-redaction validation failed: content is not valid JSON "
+            f"({e.msg} at line {e.lineno} col {e.colno}). Refusing to write."
+        ) from e
 
 
 def _validate_jsonl(content: str) -> None:

--- a/src/agentsweep/sources/_base.py
+++ b/src/agentsweep/sources/_base.py
@@ -50,11 +50,33 @@ class Source(ABC):
         value is the full file content to write — str for text formats,
         bytes for binary formats like SQLite. Implementations MUST NOT
         modify `path` itself; the redactor owns the backup and the atomic
-        write. str content MUST preserve structure (line count, JSON
-        validity, line endings) so the redactor's post-write validation
-        passes; bytes content MUST be validated by the implementation
-        (e.g. PRAGMA integrity_check) before it is returned.
+        write. str content MUST satisfy the validation declared by
+        content_format() for this path (JSONL, whole-file JSON, or
+        line-count-preserving text); bytes content MUST be validated by
+        the implementation (e.g. PRAGMA integrity_check) before it is
+        returned.
         """
+
+    def content_format(self, path: Path) -> str:
+        """Declare how the redactor must validate str content for `path`.
+
+        One of "jsonl" (the default: every line parses as JSON, line count
+        preserved), "json" (the whole file parses as one JSON document) or
+        "text" (markdown/plaintext: line count preserved). Only consulted
+        when apply_redactions returns str — bytes returns are validated by
+        the source itself before being handed over.
+        """
+        return "jsonl"
+
+    def roots(self) -> list[Path]:
+        """Every directory tree this source's files may live under.
+
+        Most sources have exactly one (self.root); sources whose history
+        spans extra trees (Cursor agent transcripts, Windsurf memories)
+        override this. files() must stay within these — the redactor's
+        path-containment check and undo's backup discovery rely on it.
+        """
+        return [self.root]
 
 
 class JsonlSource(Source):

--- a/src/agentsweep/sources/_core.py
+++ b/src/agentsweep/sources/_core.py
@@ -14,8 +14,14 @@ from ..preflight import (
     CODEX_MARKERS,
     OPENCODE_MARKERS,
 )
-from ._base import JsonlSource, KeyPath, Source, _line_ending, _set_by_path, _walk_json, _walk_json_with_base
-from ._helpers import _redact_sqlite_copy
+from ._base import JsonlSource, KeyPath, Source, _walk_json_with_base
+from ._helpers import (
+    _apply_json_file_redactions,
+    _apply_plaintext_redactions,
+    _iter_json_file_strings,
+    _iter_plaintext_lines,
+    _redact_sqlite_copy,
+)
 
 
 class ClaudeCodeSource(JsonlSource):
@@ -120,7 +126,7 @@ class OpenCodeSource(Source):
         if path == self._db_path():
             yield from self._iter_strings_sqlite(path)
         else:
-            yield from self._iter_strings_json(path)
+            yield from _iter_json_file_strings(path)
 
     def apply_redactions(
         self,
@@ -129,7 +135,12 @@ class OpenCodeSource(Source):
     ) -> str | bytes:
         if path == self._db_path():
             return _redact_sqlite_copy(path, redactions, self._sqlite_text_columns)
-        return self._apply_redactions_json(path, redactions)
+        return _apply_json_file_redactions(path, redactions)
+
+    def content_format(self, path: Path) -> str:
+        # Only consulted for str returns, i.e. the legacy storage/*.json
+        # files; the SQLite path returns source-validated bytes.
+        return "json"
 
     def _iter_strings_sqlite(self, path: Path) -> Iterator[tuple[int, KeyPath, str]]:
         try:
@@ -180,35 +191,6 @@ class OpenCodeSource(Source):
                 pairs.append((table, col))
         return pairs
 
-    def _iter_strings_json(self, path: Path) -> Iterator[tuple[int, KeyPath, str]]:
-        try:
-            text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            return
-        try:
-            obj = json.loads(text)
-        except json.JSONDecodeError:
-            return
-        yield from _walk_json(obj, [], 1)
-
-    def _apply_redactions_json(
-        self,
-        path: Path,
-        redactions: list[tuple[int, KeyPath, str]],
-    ) -> str:
-        try:
-            text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            return ""
-        try:
-            obj = json.loads(text)
-        except json.JSONDecodeError:
-            return text
-        for _line_num, kp, new_val in redactions:
-            _set_by_path(obj, kp, new_val)
-        return json.dumps(obj, ensure_ascii=False, indent=2)
-
-
 class AiderSource(Source):
     """Aider CLI — per-repo Markdown history files named .aider.chat.history.md.
 
@@ -242,30 +224,14 @@ class AiderSource(Source):
                 yield p
 
     def iter_strings(self, path: Path) -> Iterator[tuple[int, KeyPath, str]]:
-        try:
-            text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            return
-        for i, line in enumerate(text.splitlines(), 1):
-            if line.strip():
-                yield (i, [i], line)
+        yield from _iter_plaintext_lines(path)
 
     def apply_redactions(
         self,
         path: Path,
         redactions: list[tuple[int, KeyPath, str]],
     ) -> str:
-        try:
-            text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            return ""
-        lines = text.splitlines(keepends=True)
-        by_line: dict[int, str] = {ln: nv for ln, _kp, nv in redactions}
-        out: list[str] = []
-        for i, line in enumerate(lines, 1):
-            if i in by_line:
-                ending = _line_ending(line)
-                out.append(by_line[i] + ending)
-            else:
-                out.append(line)
-        return "".join(out)
+        return _apply_plaintext_redactions(path, redactions)
+
+    def content_format(self, path: Path) -> str:
+        return "text"

--- a/src/agentsweep/sources/_extended.py
+++ b/src/agentsweep/sources/_extended.py
@@ -89,8 +89,11 @@ class ClineSource(Source):
         self,
         path: Path,
         redactions: list[tuple[int, KeyPath, str]],
-    ) -> bytes:
+    ) -> str:
         return _apply_json_file_redactions(path, redactions)
+
+    def content_format(self, path: Path) -> str:
+        return "json"
 
 
 class GeminiCliSource(JsonlSource):
@@ -99,6 +102,7 @@ class GeminiCliSource(JsonlSource):
     File layout:
       ~/.gemini/tmp/<project_slug>/chats/session-<date>-<id>.jsonl
       ~/.gemini/tmp/<project_slug>/chats/<parent_id>/session-*.jsonl  (subagents)
+      ~/.gemini/tmp/<project_slug>/chats/*.json  (checkpoints, whole-file JSON)
 
     The GEMINI_CLI_HOME env var overrides the home directory base.
     """
@@ -141,6 +145,26 @@ class GeminiCliSource(JsonlSource):
         for p in tmp.rglob("*.json"):
             if p.is_file() and "chats" in p.parts:
                 yield p
+
+    def iter_strings(self, path: Path) -> Iterator[tuple[int, KeyPath, str]]:
+        # Checkpoint *.json files are one pretty-printed document — the
+        # line-by-line JSONL parser would silently yield nothing for them.
+        if path.suffix == ".json":
+            yield from _iter_json_file_strings(path)
+        else:
+            yield from super().iter_strings(path)
+
+    def apply_redactions(
+        self,
+        path: Path,
+        redactions: list[tuple[int, KeyPath, str]],
+    ) -> str:
+        if path.suffix == ".json":
+            return _apply_json_file_redactions(path, redactions)
+        return super().apply_redactions(path, redactions)
+
+    def content_format(self, path: Path) -> str:
+        return "json" if path.suffix == ".json" else "jsonl"
 
 
 class ContinueSource(Source):
@@ -197,8 +221,11 @@ class ContinueSource(Source):
         self,
         path: Path,
         redactions: list[tuple[int, KeyPath, str]],
-    ) -> bytes:
+    ) -> str:
         return _apply_json_file_redactions(path, redactions)
+
+    def content_format(self, path: Path) -> str:
+        return "json"
 
 
 class GitHubCopilotSource(Source):
@@ -298,7 +325,10 @@ class GitHubCopilotSource(Source):
         self,
         path: Path,
         redactions: list[tuple[int, KeyPath, str]],
-    ) -> str | bytes:
+    ) -> str:
         if path.suffix == ".jsonl":
             return _apply_jsonl_redactions(path, redactions)
         return _apply_json_file_redactions(path, redactions)
+
+    def content_format(self, path: Path) -> str:
+        return "jsonl" if path.suffix == ".jsonl" else "json"

--- a/src/agentsweep/sources/_helpers.py
+++ b/src/agentsweep/sources/_helpers.py
@@ -174,24 +174,31 @@ def _iter_json_file_strings(path: Path) -> Iterator[tuple[int, KeyPath, str]]:
 def _apply_json_file_redactions(
     path: Path,
     redactions: list[tuple[int, KeyPath, str]],
-) -> bytes:
-    """Apply redactions to a whole-file JSON, returning bytes.
+) -> str:
+    """Apply redactions to a whole-file JSON document, returning str.
 
-    Returns bytes so safe_write skips JSONL per-line validation (which
-    would reject indent=2 multi-line JSON). Structure is validated here
-    by the json.loads → json.dumps round-trip.
+    The pipeline writes the result with fmt="json", so safe_write
+    independently re-validates it as one JSON document. Read or parse
+    failures raise SafetyError: by redaction time the file has already
+    scanned as valid JSON, so anything else is a race or corruption —
+    fail closed rather than silently writing empty or unredacted content.
     """
     try:
         text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return b""
+    except (OSError, UnicodeDecodeError) as e:
+        raise SafetyError(
+            f"Cannot re-read {path.name} for redaction: {e}") from e
     try:
         obj = json.loads(text)
-    except json.JSONDecodeError:
-        return text.encode("utf-8")
+    except json.JSONDecodeError as e:
+        raise SafetyError(
+            f"{path.name} is no longer valid JSON; refusing to redact") from e
     for _line_num, kp, new_val in redactions:
         _set_by_path(obj, kp, new_val)
-    return json.dumps(obj, ensure_ascii=False, indent=2).encode("utf-8")
+    out = json.dumps(obj, ensure_ascii=False, indent=2)
+    if text.endswith("\n"):
+        out += "\n"
+    return out
 
 
 def _iter_plaintext_lines(path: Path) -> Iterator[tuple[int, KeyPath, str]]:
@@ -208,16 +215,19 @@ def _iter_plaintext_lines(path: Path) -> Iterator[tuple[int, KeyPath, str]]:
 def _apply_plaintext_redactions(
     path: Path,
     redactions: list[tuple[int, KeyPath, str]],
-) -> bytes:
-    """Apply line-level redactions to a plain-text file, returning bytes.
+) -> str:
+    """Apply line-level redactions to a plain-text file, returning str.
 
-    Returns bytes so safe_write skips JSONL per-line validation (which
-    would reject Markdown and other non-JSON text formats).
+    The pipeline writes the result with fmt="text", so safe_write enforces
+    that the line count is unchanged (redaction replaces whole lines 1:1).
+    Read failures raise SafetyError — fail closed rather than silently
+    writing empty content.
     """
     try:
         text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return b""
+    except (OSError, UnicodeDecodeError) as e:
+        raise SafetyError(
+            f"Cannot re-read {path.name} for redaction: {e}") from e
     lines = text.splitlines(keepends=True)
     by_line: dict[int, str] = {ln: nv for ln, _kp, nv in redactions}
     out: list[str] = []
@@ -227,4 +237,4 @@ def _apply_plaintext_redactions(
             out.append(by_line[i] + ending)
         else:
             out.append(line)
-    return "".join(out).encode("utf-8")
+    return "".join(out)

--- a/src/agentsweep/sources/_vscode.py
+++ b/src/agentsweep/sources/_vscode.py
@@ -139,6 +139,9 @@ class CursorSource(_VSCodeSqliteSource):
     def _agent_transcripts_root(self) -> Path:
         return Path.home() / ".cursor" / "projects"
 
+    def roots(self) -> list[Path]:
+        return [self.root, self._agent_transcripts_root()]
+
     def files(self) -> list[Path]:
         result: list[Path] = []
         if self.root.exists():
@@ -207,6 +210,9 @@ class WindsurfSource(_VSCodeSqliteSource):
     def _memories_root(self) -> Path:
         return Path.home() / ".codeium" / "windsurf" / "memories"
 
+    def roots(self) -> list[Path]:
+        return [self.root, self._memories_root()]
+
     def files(self) -> list[Path]:
         result: list[Path] = []
         if self.root.exists():
@@ -241,3 +247,8 @@ class WindsurfSource(_VSCodeSqliteSource):
         if path.suffix == ".md":
             return _apply_plaintext_redactions(path, redactions)
         return super().apply_redactions(path, redactions)
+
+    def content_format(self, path: Path) -> str:
+        # .md memories are plaintext; .vscdb redactions return
+        # source-validated bytes (fmt unused).
+        return "text" if path.suffix == ".md" else "jsonl"

--- a/tests/test_text_format_redaction.py
+++ b/tests/test_text_format_redaction.py
@@ -1,0 +1,243 @@
+"""End-to-end --fix tests for the non-JSONL text formats (Aider markdown,
+Windsurf memory .md, OpenCode legacy / Cline / Gemini checkpoint .json).
+
+Regression coverage for two composition bugs:
+
+1. safe_write validated every str as JSONL, so markdown and pretty-printed
+   whole-file JSON could never be written — --fix reported FAIL for half
+   the advertised sources. The byte-returning workaround helpers skipped
+   validation entirely and failed open (b"" on a read error would have
+   truncated the file; original text on a parse error reported "redacted"
+   while the secret stayed). safe_write is now format-aware (fmt=
+   "jsonl"/"json"/"text", declared by Source.content_format) and the
+   helpers fail closed with SafetyError.
+
+2. Files in a source's secondary tree (Windsurf memories under ~/.codeium,
+   Cursor agent transcripts under ~/.cursor) were scanned but could never
+   be fixed: safety_check refused them as outside source.root, and undo
+   never globbed there. Sources now declare every tree via roots().
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.pipeline import _redact_all, _scan_file, undo  # noqa: E402
+from agentsweep.redactor import SafetyError, safe_write  # noqa: E402
+from agentsweep.sources import (  # noqa: E402
+    AiderSource,
+    ClineSource,
+    GeminiCliSource,
+    OpenCodeSource,
+    WindsurfSource,
+)
+from agentsweep.sources._helpers import _apply_json_file_redactions  # noqa: E402
+
+SECRET = "AKIAIOSFODNN7EXAMPLE"  # AWS's documented example access key id
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    # Keep the audit log (and the Windsurf/Cursor secondary-tree discovery)
+    # away from the real home directory.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+
+def _scan(source, f: Path):
+    """Mirror the pipeline's SCAN stage for a single file."""
+    _, items, _, _ = _scan_file(source, f, ignores=None)
+    assert items, "fixture secret should be detected"
+    return {f: items}
+
+
+def test_aider_markdown_fix_end_to_end(tmp_path: Path) -> None:
+    root = tmp_path / "work"
+    repo = root / "proj"
+    repo.mkdir(parents=True)
+    hist = repo / ".aider.chat.history.md"
+    hist.write_text(
+        "# aider chat started at 2026-06-12\n\n"
+        f"#### does {SECRET} look valid to you?\n"
+        "That looks like an AWS access key id.\n",
+        encoding="utf-8",
+    )
+    original = hist.read_text(encoding="utf-8")
+    source = AiderSource(root=root)
+    assert hist in source.files()
+
+    rows, errors = _redact_all(source, _scan(source, hist),
+                               backup=True, force=True)
+    # Before: always ("fail", ..., "line 1 is not valid JSON ...").
+    assert errors == 0
+    assert rows[0][0] == "ok"
+
+    after = hist.read_text(encoding="utf-8")
+    assert SECRET not in after
+    assert "[REDACTED:" in after
+    assert len(after.splitlines()) == len(original.splitlines())
+    assert "That looks like an AWS access key id." in after
+    assert hist.with_name(hist.name + ".bak").read_text(
+        encoding="utf-8") == original
+
+
+def test_opencode_legacy_json_fix_end_to_end(tmp_path: Path) -> None:
+    root = tmp_path / "opencode"
+    msgdir = root / "storage" / "session" / "message"
+    msgdir.mkdir(parents=True)
+    f = msgdir / "msg_001.json"
+    f.write_text(json.dumps(
+        {"role": "user",
+         "parts": [{"type": "text", "text": f"my key is {SECRET}"}]},
+        indent=2) + "\n", encoding="utf-8")
+    original = f.read_text(encoding="utf-8")
+    source = OpenCodeSource(root=root)
+    assert source.files() == [f]
+
+    rows, errors = _redact_all(source, _scan(source, f),
+                               backup=True, force=True)
+    assert errors == 0
+    assert rows[0][0] == "ok"
+
+    after = f.read_text(encoding="utf-8")
+    assert SECRET not in after
+    json.loads(after)  # still one valid JSON document
+    assert after.endswith("\n")  # trailing newline preserved
+    assert f.with_name(f.name + ".bak").read_text(encoding="utf-8") == original
+
+
+def test_cline_task_json_fix_end_to_end(tmp_path: Path) -> None:
+    root = tmp_path / "saoudrizwan.claude-dev"
+    task = root / "tasks" / "171"
+    task.mkdir(parents=True)
+    f = task / "api_conversation_history.json"
+    f.write_text(json.dumps([
+        {"role": "user",
+         "content": [{"type": "text", "text": f"use {SECRET} for s3"}]},
+    ], indent=2), encoding="utf-8")
+    original = f.read_text(encoding="utf-8")
+    source = ClineSource(root=root)
+    assert source.files() == [f]
+
+    rows, errors = _redact_all(source, _scan(source, f),
+                               backup=True, force=True)
+    assert errors == 0
+    assert rows[0][0] == "ok"
+    after = f.read_text(encoding="utf-8")
+    assert SECRET not in after
+    json.loads(after)
+    assert f.with_name(f.name + ".bak").read_text(encoding="utf-8") == original
+
+
+def test_gemini_checkpoint_json_is_scanned_and_fixed(tmp_path: Path) -> None:
+    root = tmp_path / ".gemini"
+    chats = root / "tmp" / "proj-1" / "chats"
+    chats.mkdir(parents=True)
+    f = chats / "checkpoint-main.json"
+    f.write_text(json.dumps(
+        [{"role": "user", "parts": [{"text": f"key {SECRET}"}]}], indent=2),
+        encoding="utf-8")
+    source = GeminiCliSource(root=root)
+    assert f in source.files()
+
+    # Regression: the inherited line-by-line JSONL parser yielded nothing
+    # for pretty-printed checkpoint files, so secrets in them were
+    # invisible to the scan.
+    assert any(SECRET in v for _, _, v in source.iter_strings(f))
+
+    rows, errors = _redact_all(source, _scan(source, f),
+                               backup=True, force=True)
+    assert errors == 0
+    assert rows[0][0] == "ok"
+    after = f.read_text(encoding="utf-8")
+    assert SECRET not in after
+    json.loads(after)
+
+
+def test_windsurf_memory_fix_outside_user_root_and_undo(tmp_path: Path) -> None:
+    user_root = tmp_path / "Windsurf" / "User"
+    user_root.mkdir(parents=True)
+    memories = tmp_path / ".codeium" / "windsurf" / "memories"  # isolated home
+    memories.mkdir(parents=True)
+    mem = memories / "global_rules.md"
+    mem.write_text(
+        f"# memories\n\n- aws key is {SECRET}\n- prefers tabs\n",
+        encoding="utf-8",
+    )
+    original = mem.read_text(encoding="utf-8")
+    source = WindsurfSource(root=user_root)
+    assert mem in source.files()
+
+    rows, errors = _redact_all(source, _scan(source, mem),
+                               backup=True, force=True)
+    # Before roots(): always ("skip", ..., "outside source root").
+    assert errors == 0
+    assert rows[0][0] == "ok"
+
+    after = mem.read_text(encoding="utf-8")
+    assert SECRET not in after
+    assert "- prefers tabs" in after
+    assert len(after.splitlines()) == len(original.splitlines())
+    bak = mem.with_name(mem.name + ".bak")
+    assert bak.read_text(encoding="utf-8") == original
+
+    # undo must discover .md.bak in the secondary tree as well.
+    code = undo(argparse.Namespace(source="windsurf", root=user_root))
+    assert code == 0
+    assert mem.read_text(encoding="utf-8") == original
+    assert not bak.exists()
+
+
+def test_safe_write_json_fmt_validates_whole_document(tmp_path: Path) -> None:
+    target = tmp_path / "session.json"
+    target.write_text('{\n  "a": 1\n}\n', encoding="utf-8")
+    with pytest.raises(SafetyError, match="not valid JSON"):
+        safe_write(target, '{\n  "a": 1,,\n}\n', backup=True, fmt="json")
+    # Validation failures must leave no trace: original intact, no .bak.
+    assert target.read_text(encoding="utf-8") == '{\n  "a": 1\n}\n'
+    assert not target.with_name(target.name + ".bak").exists()
+
+    record = safe_write(target, '{\n  "a": 2\n}\n', backup=True, fmt="json")
+    assert record.backup is not None
+    assert target.read_text(encoding="utf-8") == '{\n  "a": 2\n}\n'
+
+
+def test_safe_write_text_fmt_keeps_line_count_guarantee(tmp_path: Path) -> None:
+    target = tmp_path / "notes.md"
+    target.write_text("# title\nsecret here\nbye\n", encoding="utf-8")
+    with pytest.raises(SafetyError, match="Line count changed"):
+        safe_write(target, "# title\nbye\n", backup=True, fmt="text")
+    assert not target.with_name(target.name + ".bak").exists()
+
+    # Non-JSON content is accepted when the line count is preserved —
+    # the exact case the old JSONL-only validation made impossible.
+    safe_write(target, "# title\n[REDACTED]\nbye\n", backup=True, fmt="text")
+    assert target.read_text(encoding="utf-8") == "# title\n[REDACTED]\nbye\n"
+
+
+def test_safe_write_unknown_fmt_refused(tmp_path: Path) -> None:
+    target = tmp_path / "x.yaml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    with pytest.raises(SafetyError, match="Unknown content format"):
+        safe_write(target, "a: 2\n", backup=True, fmt="yaml")
+    assert target.read_text(encoding="utf-8") == "a: 1\n"
+
+
+def test_json_helper_fails_closed(tmp_path: Path) -> None:
+    # A read failure must raise, not hand safe_write content that would
+    # truncate the file (the old helper returned b"" here).
+    with pytest.raises(SafetyError, match="Cannot re-read"):
+        _apply_json_file_redactions(tmp_path, [])  # a directory
+
+    # A parse failure must raise, not silently return the original
+    # unredacted text (which reported "redacted" while the secret stayed).
+    bad = tmp_path / "broken.json"
+    bad.write_text('{"a": ', encoding="utf-8")
+    with pytest.raises(SafetyError, match="no longer valid JSON"):
+        _apply_json_file_redactions(bad, [])


### PR DESCRIPTION
Follow-up to #2, same audit. This makes `--fix` actually work — and fail closed — for the text sources that aren't JSONL.

## The problem

`safe_write` validates every `str` it gets as JSONL (per-line `json.loads` + line count). That's exactly right for transcripts, but it means:

1. **Aider markdown and OpenCode legacy JSON could never be fixed.** Both still return `str` (markdown lines / `indent=2` JSON), so every `--fix` run ends in `Post-redaction validation failed: line 1 is not valid JSON`. Fail-closed, but the feature silently doesn't exist for those sources.
2. **The `bytes` workaround fails open.** `_apply_json_file_redactions` / `_apply_plaintext_redactions` return `bytes` specifically so `safe_write` skips validation. But on a read error they return `b""` — which `safe_write` would happily write, truncating the history file to zero bytes (with a `.bak`, but still). On a parse error the JSON helper returns the *original text*, so the run reports `ok` while the secret is still in the file. And the plaintext path ends up with no validation at all.
3. **Gemini `chats/*.json` checkpoints were invisible.** `files()` globs them, but the inherited line-by-line JSONL parser yields nothing for a pretty-printed document — so secrets in checkpoints were never scanned, let alone fixed.
4. **Windsurf memories and Cursor agent transcripts were scanned but unfixable.** They live outside `source.root` (`~/.codeium/windsurf/memories/`, `~/.cursor/projects/`), so `safety_check` refused every one of them as "outside source root", and `undo` never globbed those trees either.

## The fix

**`safe_write` is format-aware instead of bypassed.** New `fmt` parameter, default `"jsonl"` (behavior unchanged for every existing call):

| fmt | post-write validation |
|---|---|
| `jsonl` | every non-empty line parses as JSON + line count preserved (as before) |
| `json` | the whole content parses as one JSON document (re-serialization may reflow lines, so no line-count check) |
| `text` | line count preserved (redaction replaces whole lines 1:1) |
| *bytes* | unchanged: source must validate itself (SQLite `integrity_check`), `fmt` ignored |

Sources declare the format per path via a new `Source.content_format(path)` (default `"jsonl"`). The helpers now return `str` and go through `safe_write`'s independent re-validation, and they raise `SafetyError` on read/parse failures instead of returning `b""`/original text — by redaction time the file already scanned as valid, so anything else is a race or corruption and must abort the write, not sneak through it.

**Multi-root sources declare their trees.** New `Source.roots()` (default `[self.root]`); Cursor adds `~/.cursor/projects`, Windsurf adds `~/.codeium/windsurf/memories`. `safety_check` accepts containment in any declared root (path-containment and symlink rules unchanged otherwise), and `undo` discovers backups across all roots, with `*.json.bak` and `*.md.bak` added to the globs.

**Concrete behavior changes**
- Aider `.aider.chat.history.md`: fix works (line-count-guarded), undo restores.
- OpenCode legacy `storage/**/*.json`: fix works, output re-validated as JSON, trailing newline preserved.
- Cline / Continue / Copilot `.json`: same write path as before, but now independently re-validated by `safe_write` and fail-closed on errors.
- Gemini `chats/*.json` checkpoints: now actually scanned (whole-file JSON) and fixable.
- Windsurf memories + Cursor transcripts: fixable and undo-able for the first time.

README's corruption-prevention list updated to describe the format-aware validation and multi-tree containment.

## Tests

`369 passed` (360 existing + 9 new in `tests/test_text_format_redaction.py`):

- end-to-end `_redact_all` fix for Aider markdown, OpenCode legacy JSON, Cline task JSON, Gemini checkpoint JSON, and a Windsurf memory **outside** the User root (each: row `ok`, `.bak` == original, secret gone, structure preserved)
- `undo` restores the Windsurf memory from the secondary tree
- regression: Gemini checkpoint strings are visible to `iter_strings`
- fail-closed: invalid JSON → `SafetyError` with original intact and no `.bak`; `fmt="text"` line-count enforcement; unknown `fmt` refused; helper raises on unreadable/unparseable input instead of returning `b""`/original

Also verified manually through the real CLI (`fix` + `undo` against a throwaway `$HOME`): aider markdown redacts cleanly, the Windsurf memory redacts with backup + audit entry, and `undo` restores it byte-identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
