### PR TITLE
fix: TUI arrow keys misread as quit on Unix terminals

### DIFF
--- a/src/agentsweep/ui/keys.py
+++ b/src/agentsweep/ui/keys.py
@@ -39,6 +39,7 @@ def _read_key_windows() -> str:
 
 
 def _read_key_unix() -> str:
+    import os
     import tty
     import termios
     import select
@@ -47,26 +48,30 @@ def _read_key_unix() -> str:
     old = termios.tcgetattr(fd)
     try:
         tty.setcbreak(fd)
-        ch = sys.stdin.read(1)
-        if ch == "\x1b":
-            # Check for CSI sequence (arrow keys: ESC [ A/B)
-            ready, _, _ = select.select([sys.stdin], [], [], 0.05)
-            if ready:
-                ch2 = sys.stdin.read(1)
-                if ch2 == "[":
-                    ready2, _, _ = select.select([sys.stdin], [], [], 0.05)
-                    if ready2:
-                        ch3 = sys.stdin.read(1)
-                        if ch3 == "A":
-                            return UP
-                        if ch3 == "B":
-                            return DOWN
-            return QUIT
-        if ch in ("\r", "\n"):
+        # Read at the raw fd level with os.read, NOT sys.stdin.read. Python's
+        # buffered stdin drains the whole escape sequence into a userspace
+        # buffer on the first read, so a later select() on the fd reports "no
+        # more input" and every arrow key gets misread as a bare ESC (quit).
+        # os.read keeps the fd and select() in agreement.
+        ch = os.read(fd, 1)
+        if ch == b"\x1b":
+            ready, _, _ = select.select([fd], [], [], 0.05)
+            if not ready:
+                return QUIT  # bare ESC key
+            # Drain the rest of the sequence. Arrows are ESC [ A/B (CSI) or
+            # ESC O A/B (SS3, sent in application-cursor-key mode, e.g. some
+            # GNOME/xterm configs).
+            rest = os.read(fd, 16)
+            if rest in (b"[A", b"OA"):
+                return UP
+            if rest in (b"[B", b"OB"):
+                return DOWN
+            return OTHER  # other escape sequence (F-keys, Home, …); ignore
+        if ch in (b"\r", b"\n"):
             return ENTER
-        if ch == " ":
+        if ch == b" ":
             return SPACE
-        if ch in ("q", "Q"):
+        if ch in (b"q", b"Q"):
             return QUIT
         return OTHER
     finally:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2,6 +2,13 @@
 parallel file-scan path added in _scan_all (pipeline.py Task 7)."""
 from __future__ import annotations
 
+import io
+import os
+import pty
+import sys
+import termios
+import threading
+import time
 from unittest.mock import patch
 
 import pytest
@@ -32,6 +39,59 @@ def test_raw_input_unavailable_in_test_subprocess(monkeypatch):
     # RAW_INPUT_AVAILABLE was set at import time, reflect that.
     assert _keys.RAW_INPUT_AVAILABLE is False
 
+# ── keys._read_key_unix real byte parsing (pty regression) ────────────────────
+
+_BYTE_SEQ_CASES = [
+    (b"\x1b[A", _keys.UP),     # CSI up
+    (b"\x1b[B", _keys.DOWN),   # CSI down
+    (b"\x1bOA", _keys.UP),     # SS3 up (application-cursor-key mode)
+    (b"\x1bOB", _keys.DOWN),   # SS3 down
+    (b"\x1b", _keys.QUIT),     # bare ESC key
+    (b"\r", _keys.ENTER),
+    (b" ", _keys.SPACE),
+    (b"q", _keys.QUIT),
+]
+
+def _feed_keys_when_raw(master_fd, slave_fd, data):
+    # Wait until _read_key_unix switches the slave out of canonical mode
+    # (setcbreak clears ICANON) before writing, so the bytes are neither
+    # discarded by setcbreak(TCSAFLUSH) nor held by the canonical line
+    # discipline waiting for a newline.
+    for _ in range(400):
+        if not (termios.tcgetattr(slave_fd)[3] & termios.ICANON):
+            break
+        time.sleep(0.005)
+    os.write(master_fd, data)
+
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="unix key reader")
+@pytest.mark.parametrize("seq,expected", _BYTE_SEQ_CASES)
+def test_read_key_unix_parses_real_byte_sequences(seq, expected, monkeypatch):
+    """Drive the real fd-level parser through a pty.
+
+    Regression guard: an arrow key arrives as a multi-byte escape sequence.
+    Reading via buffered sys.stdin drained the whole sequence into a userspace
+    buffer, so select() on the fd reported no tail and every arrow was misread
+    as a bare ESC (quit). sys.stdin below is a *buffered* TextIOWrapper — the
+    exact shape that triggered the bug — so this fails if the parser regresses
+    to sys.stdin.read.
+    """
+    master, slave = pty.openpty()
+    # Buffered TextIOWrapper over the slave: the exact stdin shape that
+    # triggered the original bug.
+    stdin = io.TextIOWrapper(
+        io.BufferedReader(io.FileIO(slave, "r", closefd=False)), encoding="utf-8"
+    )
+    monkeypatch.setattr(sys, "stdin", stdin)
+    feeder = threading.Thread(target=_feed_keys_when_raw, args=(master, slave, seq))
+    feeder.start()
+    try:
+        assert _keys._read_key_unix() == expected
+    finally:
+        feeder.join()
+        os.close(master)
+        os.close(slave)
 
 # ── picker._run_menu single-select ───────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

On the interactive TUI (`agentsweep` with no args → arrow-key menu), every **Up/Down** press behaved like Esc/Ctrl-C: in a submenu it backed out to the menu, and a second press quit the app. Reproduced on a real pty on Linux (GNOME Terminal) — **all** arrow keys returned `QUIT`.

## Root cause

`src/agentsweep/ui/keys.py::_read_key_unix` mixed Python's **buffered** `sys.stdin.read(1)` with `select()` on the **raw fd**:

- An arrow key is a 3-byte escape sequence (`ESC [ A`). The first `sys.stdin.read(1)` triggers a chunked read that pulls all 3 bytes off the kernel fd into the `TextIOWrapper`'s userspace buffer, returns `ESC`, and leaves `[A` buffered.
- The next `select.select([sys.stdin], …)` polls the kernel fd, which is now empty → "no more input" → the code falls through to `return QUIT`.

Buffered reads and `select`-on-fd were never in agreement, so every arrow was misread as a bare Esc. Secondary gap: SS3-mode arrows (`ESC O A`, emitted in application-cursor-key mode by some GNOME/xterm configs) were never handled.

This is timing/buffering sensitive, which is why it surfaced on some terminals and not others.

## Fix

- Read at the raw fd with `os.read(fd, …)` so the fd and `select()` stay consistent.
- Handle both **CSI** (`ESC [ A/B`) and **SS3** (`ESC O A/B`) arrows.
- Bare `ESC` still quits; any other escape sequence (F-keys, Home, …) is now ignored instead of quitting.

## Why this slipped through

Every existing TUI test stubs `read_key` to return key constants, so the byte-level parser was never exercised. Added `test_read_key_unix_parses_real_byte_sequences`: a `pty`-driven, parametrized regression test over CSI/SS3 arrows, bare Esc, Enter, Space, and `q`. It feeds bytes from a thread only after `setcbreak` clears `ICANON` (avoids the `TCSAFLUSH` input-discard race) and drives a **buffered** `TextIOWrapper` stdin — the exact shape that triggered the bug — so a regression back to `sys.stdin.read` fails the test.

## Verification

- `tests/test_tui.py`: 24 passed (16 existing + 8 new cases).
- Full suite: **368 passed**.
- Manual: `uv run agentsweep` → ↑/↓ now move the menu highlight; Enter selects; q/Esc quits.

## Scope

Two files: `src/agentsweep/ui/keys.py` (fix) and `tests/test_tui.py` (regression test). No changes to the redactor or write path.

This fixes #4 