### PR TITLE
fix: create .bak backups 0600 and add a purge verb for them

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ menu entirely and behaves exactly as documented below.
 | `agentsweep scan` | Scan only — read-only, no files are modified (default when no verb given) |
 | `agentsweep fix` | Scan, then offer to redact findings in place (type `REDACT` to confirm) |
 | `agentsweep undo` | Restore all `.bak` backups, reverting any previous redaction |
+| `agentsweep purge` | Delete all `.bak` backups once the leaked keys are rotated (permanent — `undo` stops working) |
 | `agentsweep --version` / `-V` | Print the installed version |
 | `agentsweep --update` | Check PyPI for a newer release |
 
@@ -209,7 +210,7 @@ A redactor that corrupts your history is strictly worse than the leak it's fixin
 1. **Redaction happens in parsed JSON, not on raw bytes.** Secrets are replaced as string *values* inside the parsed structure, then re-serialized. Structural damage is impossible by construction.
 2. **Atomic writes.** Every rewrite goes: temp file → `fsync()` → `os.replace()` over the original. A crash at any instant leaves either the complete old file or the complete new file — never a torn write.
 3. **Post-write validation.** Before committing, the new content must pass a format-aware check: JSONL — every non-empty line parses as JSON and the line count matches the original; whole-file JSON — the document parses; markdown/plaintext — the line count matches the original; SQLite — the rewritten copy passes `PRAGMA integrity_check`. If the check fails, the write aborts and the original is untouched.
-4. **`.bak` backup by default.** Refuses to run if a `.bak` already exists (so prior backups can't be clobbered).
+4. **`.bak` backup by default.** Created owner-readable only (mode `0600`) since it holds the pre-redaction secrets; refuses to run if a `.bak` already exists (so prior backups can't be clobbered).
 5. **Path containment.** Refuses any target that doesn't resolve inside one of the source's history trees (e.g. Windsurf's User dir and its `~/.codeium/windsurf/memories/`).
 6. **Symlink rejection.** Refuses symlinks outright.
 7. **mtime window.** Refuses files modified in the last 60 seconds (likely an active session). `--force` overrides.
@@ -231,6 +232,14 @@ If you need to restore a single file manually (e.g. you deleted the undo command
 
 ```bash
 mv session.jsonl.bak session.jsonl
+```
+
+The backups hold the **pre-redaction originals — plaintext secrets**, so a sweep isn't finished until the leaked keys are rotated and the backups are gone. Once you've rotated:
+
+```bash
+agentsweep purge                       # delete Claude Code backups (asks first)
+agentsweep purge --source windsurf     # delete a specific source's backups
+agentsweep purge --yes                 # non-interactive (scripts / CI)
 ```
 
 ## What's detected

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -6,6 +6,7 @@ Usage shapes, all supported:
     agentsweep scan [opts]     scan only
     agentsweep fix  [opts]     redact (guided + confirmed on a terminal)
     agentsweep undo [opts]     restore .bak backups
+    agentsweep purge [opts]    delete .bak backups (after rotating the keys)
     agentsweep --fix ...       legacy flag form, kept working as an alias
     agentsweep --update        check PyPI for a newer version
 
@@ -23,7 +24,7 @@ from pathlib import Path
 from . import __version__, ui
 from .sources import SOURCES
 
-VERBS = {"scan", "fix", "undo"}
+VERBS = {"scan", "fix", "undo", "purge"}
 
 _PYPI_URL = "https://pypi.org/pypi/agentsweep/json"
 
@@ -153,6 +154,10 @@ def main(argv: list[str] | None = None) -> int:
             from .pipeline import undo
             return undo(_parse_undo(rest))
 
+        if verb == "purge":
+            from .pipeline import purge
+            return purge(_parse_purge(rest))
+
         args = _parse_run(verb, rest)
         _background_update_notice(args)
         from .pipeline import run
@@ -226,6 +231,21 @@ def _parse_undo(rest: list[str]) -> argparse.Namespace:
         description="Restore *.jsonl.bak backups over their redacted files.",
     )
     _add_common(ap)
+    return ap.parse_args(rest)
+
+
+def _parse_purge(rest: list[str]) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        prog="agentsweep purge",
+        description="Delete *.bak backups once the leaked keys are rotated. "
+                    "The backups hold the pre-redaction originals, so this "
+                    "is permanent — `agentsweep undo` stops working for "
+                    "them.",
+    )
+    _add_common(ap)
+    ap.add_argument("--yes", action="store_true",
+                    help="Skip the confirmation prompt (required when not "
+                         "running on a terminal).")
     return ap.parse_args(rest)
 
 

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -473,7 +473,10 @@ def purge(args) -> int:
     a sweep isn't finished until they're gone. Deleting them is permanent
     (``undo`` stops working for those files), so this prompts on a
     terminal and refuses without ``--yes`` everywhere else.
-    Exit 0 on success or nothing-to-do, 2 if refused or any delete failed.
+
+    Exit codes: 0 on success, nothing-to-do, or an interactive ``n``
+    (backups kept — a no-op, matching ``undo``); 2 when non-interactive
+    without ``--yes`` (refused to act blind) or if any delete failed.
     """
     source_cls = SOURCES[args.source]
     source: Source = source_cls(root=args.root) if args.root else source_cls()

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -466,6 +466,58 @@ def undo(args) -> int:
     return 0 if errors == 0 else 2
 
 
+def purge(args) -> int:
+    """Delete agentsweep .bak backups once the leaked keys are rotated.
+
+    The backups hold the pre-redaction originals — plaintext secrets — so
+    a sweep isn't finished until they're gone. Deleting them is permanent
+    (``undo`` stops working for those files), so this prompts on a
+    terminal and refuses without ``--yes`` everywhere else.
+    Exit 0 on success or nothing-to-do, 2 if refused or any delete failed.
+    """
+    source_cls = SOURCES[args.source]
+    source: Source = source_cls(root=args.root) if args.root else source_cls()
+    roots = [r for r in source.roots() if r.exists()]
+    if not roots:
+        print(f"No history root at {source.root}", file=sys.stderr)
+        return 0
+    backups = sorted({p for root in roots
+                      for pat in _BACKUP_GLOBS
+                      for p in root.rglob(pat)})
+    if not backups:
+        print(f"No .bak backups found under {source.root}", file=sys.stderr)
+        return 0
+
+    if not getattr(args, "yes", False):
+        interactive = (sys.stdin.isatty() and ui.console.is_terminal
+                       if hasattr(sys.stdin, "isatty") else False)
+        if not interactive:
+            print("purge permanently deletes the pre-redaction originals; "
+                  "re-run with --yes to confirm.", file=sys.stderr)
+            return 2
+        print(f"  {len(backups)} backup(s) found under {source.root}")
+        print("  they hold the PRE-redaction originals — deleting them is "
+              "permanent and `undo` will no longer work")
+        try:
+            if input("  delete them permanently? [y/N]: "
+                     ).strip().lower() != "y":
+                ui.warn_line("cancelled — backups kept as-is")
+                return 0
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+
+    errors = 0
+    for bak in backups:
+        try:
+            bak.unlink()
+            ui.redact_row("ok", ui.rel(bak, source.root), "backup deleted")
+        except OSError as e:
+            ui.redact_row("fail", ui.rel(bak, source.root), str(e))
+            errors += 1
+    return 0 if errors == 0 else 2
+
+
 def _redact_all(
     source: Source,
     found_by_file: dict,

--- a/src/agentsweep/redactor.py
+++ b/src/agentsweep/redactor.py
@@ -145,12 +145,22 @@ def safe_write(path: Path, new_content: str | bytes,
     backup_path: Path | None = None
     if backup:
         backup_path = path.with_name(path.name + ".bak")
-        if backup_path.exists():
+        try:
+            # O_EXCL makes the no-clobber check race-free; 0o600 keeps the
+            # pre-redaction plaintext secrets in the backup unreadable to
+            # other local users regardless of the umask.
+            bak_fd = os.open(
+                str(backup_path),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+        except FileExistsError:
             raise SafetyError(
                 f"Backup already exists: {backup_path}. "
                 f"Resolve manually before re-running."
-            )
-        backup_path.write_bytes(original_bytes)
+            ) from None
+        with os.fdopen(bak_fd, "wb") as bak_file:
+            bak_file.write(original_bytes)
 
     fd, tmp_name = tempfile.mkstemp(
         dir=str(path.parent),

--- a/tests/test_backup_hygiene.py
+++ b/tests/test_backup_hygiene.py
@@ -1,0 +1,122 @@
+"""Backup hygiene: .bak permissions and the `purge` verb.
+
+The .bak files safe_write leaves behind hold the pre-redaction
+originals — plaintext secrets. Two gaps closed here:
+
+1. Backups were created via Path.write_bytes, i.e. with default-umask
+   permissions (usually world-readable). They are now opened with
+   O_CREAT | O_EXCL and mode 0o600, which also makes the existing
+   no-clobber check race-free.
+2. The documented final step of a sweep — "rotate the keys, then delete
+   the .bak files" — had no command. `agentsweep purge` deletes the
+   backups for a source (all roots, all backup globs), prompting on a
+   terminal and refusing without --yes everywhere else.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.pipeline import purge  # noqa: E402
+from agentsweep.redactor import SafetyError, safe_write  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    # Keep the audit log (and Windsurf secondary-tree discovery) away from
+    # the real home directory.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    base = {"source": "aider", "root": None, "yes": False}
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="POSIX permission bits are not meaningful on Windows")
+def test_backup_is_created_owner_only(tmp_path: Path, monkeypatch) -> None:
+    target = tmp_path / "session.jsonl"
+    target.write_text('{"a": "secret"}\n', encoding="utf-8")
+    # A permissive umask must not leak into the backup's mode.
+    old_umask = os.umask(0o000)
+    try:
+        record = safe_write(target, '{"a": "[REDACTED]"}\n', backup=True)
+    finally:
+        os.umask(old_umask)
+    assert record.backup is not None
+    mode = stat.S_IMODE(record.backup.stat().st_mode)
+    assert mode == 0o600, f"backup mode is {oct(mode)}, expected 0o600"
+
+
+def test_backup_no_clobber_still_enforced(tmp_path: Path) -> None:
+    target = tmp_path / "session.jsonl"
+    target.write_text('{"a": 1}\n', encoding="utf-8")
+    bak = tmp_path / "session.jsonl.bak"
+    bak.write_text("previous backup", encoding="utf-8")
+    with pytest.raises(SafetyError, match="Backup already exists"):
+        safe_write(target, '{"a": 2}\n', backup=True)
+    assert bak.read_text(encoding="utf-8") == "previous backup"
+    assert target.read_text(encoding="utf-8") == '{"a": 1}\n'
+
+
+def test_purge_deletes_backups_with_yes(tmp_path: Path) -> None:
+    root = tmp_path / "work"
+    repo = root / "proj"
+    repo.mkdir(parents=True)
+    hist = repo / ".aider.chat.history.md"
+    hist.write_text("# redacted\n", encoding="utf-8")
+    bak = repo / ".aider.chat.history.md.bak"
+    bak.write_text("# original with secret\n", encoding="utf-8")
+
+    code = purge(_ns(root=root, yes=True))
+    assert code == 0
+    assert not bak.exists()
+    assert hist.exists()  # only backups are deleted, never the histories
+
+
+def test_purge_noninteractive_refuses_without_yes(tmp_path: Path) -> None:
+    root = tmp_path / "work"
+    root.mkdir()
+    bak = root / ".aider.chat.history.md.bak"
+    bak.write_text("# original with secret\n", encoding="utf-8")
+
+    # Under pytest stdin is not a tty, so this is the script path.
+    code = purge(_ns(root=root, yes=False))
+    assert code == 2
+    assert bak.exists()  # nothing deleted without explicit consent
+
+
+def test_purge_nothing_to_do(tmp_path: Path) -> None:
+    root = tmp_path / "work"
+    root.mkdir()
+    assert purge(_ns(root=root, yes=True)) == 0
+
+
+def test_purge_covers_secondary_roots(tmp_path: Path) -> None:
+    # Windsurf memories live outside the User root (under the isolated
+    # home); purge must glob backups there too, like undo does.
+    from agentsweep.sources import WindsurfSource  # noqa: PLC0415
+
+    user_root = tmp_path / "Windsurf" / "User"
+    user_root.mkdir(parents=True)
+    memories = tmp_path / ".codeium" / "windsurf" / "memories"
+    memories.mkdir(parents=True)
+    bak = memories / "global_rules.md.bak"
+    bak.write_text("- aws key was here\n", encoding="utf-8")
+
+    source = WindsurfSource(root=user_root)
+    assert any(bak.is_relative_to(r) for r in source.roots())
+
+    code = purge(_ns(source="windsurf", root=user_root, yes=True))
+    assert code == 0
+    assert not bak.exists()


### PR DESCRIPTION
Last item from the same audit as #2 and #3 — the `.bak` files themselves.

## The problem

Every redaction leaves a `.bak` holding the **pre-redaction original — the plaintext secret**. Two gaps:

1. **Backups were world-readable.** `safe_write` created them with `Path.write_bytes`, i.e. default-umask permissions (usually `0644`). The history file you just cleaned may be locked down, but its secret-bearing backup wasn't.
2. **No way to finish the sweep.** The README's own workflow ends with "rotate the keys, then delete the `.bak` files" — but there was no command for that last step, only a manual `rm` across every source root (including the secondary trees like `~/.codeium/windsurf/memories/`, which are easy to forget).

## The fix

- `safe_write` opens the backup with `O_CREAT | O_EXCL` and mode `0o600`. Side benefit: the existing "refuse to clobber an existing `.bak`" check is now race-free instead of check-then-write.
- New **`agentsweep purge`** verb — the counterpart to `undo`. Same backup discovery (all of the source's `roots()`, all backup globs), but deletes instead of restores. Since this permanently destroys the originals, it prompts on a terminal and **refuses without `--yes`** when non-interactive (exit 2, nothing deleted) — unlike `undo`, which is safe to run blind.

README updated: verb table, corruption-prevention invariant #4 (0600), and a post-rotation section showing the `purge` flow.

## Tests

`383 passed` (6 new in `tests/test_backup_hygiene.py`):

- backup is created `0600` even under a `0000` umask (POSIX; skipped on Windows where mode bits aren't meaningful)
- the no-clobber refusal still works and leaves both files untouched
- `purge --yes` deletes backups and never touches the histories
- non-interactive `purge` without `--yes` refuses with exit 2 and deletes nothing
- nothing-to-do exits 0
- backups in a secondary root (Windsurf memories outside the User dir) are found and purged

Also verified end-to-end through the real CLI in a throwaway `$HOME`: `fix` produces a `600` backup, bare `purge` refuses, `purge --yes` removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
