### PR TITLE
feat: detect Discord bot tokens (id.timestamp.hmac base64url)

### DIFF
--- a/scripts/rules_drift.py
+++ b/scripts/rules_drift.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 """Rules-drift checker: compare agentsweep detection rules against upstream gitleaks.
 
 Fetches the canonical gitleaks config and reports three buckets:
@@ -74,6 +74,7 @@ OURS_TO_GITLEAKS: dict[str, str | None] = {
     "pypi-token": "pypi-upload-token",
     "sendgrid": "sendgrid-api-token",
     "twilio": "twilio-api-key",
+    "discord-bot-token": None,  # gitleaks ships no dedicated bot-token regex
     # --- ported from gitleaks (see the ported block in scanner.py) ---
     '1password-secret-key': '1password-secret-key',
     '1password-service-account-token': '1password-service-account-token',

--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -66,6 +66,13 @@ RULES: list[tuple[str, str, re.Pattern]] = [
         re.compile(r"\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}\b")),
     ("twilio", "Twilio API key",
         re.compile(r"\bSK[0-9a-fA-F]{32}\b")),
+    ("discord-bot-token", "Discord bot token",
+        # id.timestamp.hmac in base64url. The first segment is base64 of the
+        # bot's snowflake (a decimal id), so it always begins M/N/O — that
+        # anchor keeps this off JWTs (eyJ…) and other dotted tokens. No
+        # keyword literal anywhere → the prefilter extractor returns () and
+        # the rule always runs.
+        re.compile(r"\b[MNO][\w-]{23,27}\.[\w-]{6,7}\.[\w-]{27,40}(?![\w-])")),
     # --- ported from gitleaks (see scripts/rules_drift.py mapping) ---
     ('1password-secret-key', '1Password secret key',
         re.compile('\\bA3-[A-Z0-9]{6}-(?:(?:[A-Z0-9]{11})|(?:[A-Z0-9]{6}-[A-Z0-9]{5}))-[A-Z0-9]{5}-[A-Z0-9]{5}-[A-Z0-9]{5}\\b')),
@@ -697,6 +704,7 @@ ROTATION_GUIDANCE: dict[str, str] = {
     "pypi-token": "Revoke: https://pypi.org/manage/account/token/",
     "sendgrid": "Rotate: https://app.sendgrid.com/settings/api_keys",
     "twilio": "Rotate: https://console.twilio.com/us1/account/keys-credentials/api-keys",
+    "discord-bot-token": "Reset: https://discord.com/developers/applications (your app > Bot > Reset Token)",
     # --- ported from gitleaks (see scripts/rules_drift.py mapping) ---
     '1password-secret-key': 'Rotate: regenerate the Secret Key in your 1Password account profile (https://support.1password.com/secret-key/)',
     '1password-service-account-token': 'Revoke: https://my.1password.com/developer (Service Accounts > revoke token)',

--- a/tests/test_ported_rules.py
+++ b/tests/test_ported_rules.py
@@ -1,4 +1,4 @@
-﻿"""Tests for the detection rules ported from the gitleaks rule pack.
+"""Tests for the detection rules ported from the gitleaks rule pack.
 
 FIXTURES embeds one synthetic (non-live) example secret per ported rule and
 asserts the full scan pipeline -- including overlap dedupe -- attributes it
@@ -232,3 +232,44 @@ def test_rotation_guidance_present_or_cli_default_applies() -> None:
     assert not missing, f"rules lacking guidance: {missing}"
     stale = sorted(set(ROTATION_GUIDANCE) - rule_ids)
     assert not stale, f"guidance for rules that no longer exist: {stale}"
+
+
+# Discord bot tokens are a native rule (no gitleaks equivalent), so they live
+# here as dedicated cases rather than in FIXTURES. Tokens are split across
+# adjacent string literals so this file never holds a contiguous token-shaped
+# string (push-protection hygiene, same as FIXTURES).
+_DISCORD_CLASSIC = "NzkyNzE1NDU0MTk2MDg4ODQy" ".X-hvzA." "Ovy4MCQywSkoMRRclStW4xAYK7I"
+_DISCORD_NEW = "MTk4NjIyNDgzNDcxOTI1MjQ4" ".GhAbCd." "7y8aBcDeFgHiJkLmNoPqRsTuVwXyZ012345678"
+
+
+@pytest.mark.parametrize("token", [_DISCORD_CLASSIC, _DISCORD_NEW])
+def test_discord_bot_token_detected(token: str) -> None:
+    assert any(f.rule == "discord-bot-token" for f in scan_text(token)), (
+        f"discord-bot-token not reported for {token!r}"
+    )
+    # ...and when embedded in a realistic env assignment with quotes.
+    assert any(
+        f.rule == "discord-bot-token"
+        for f in scan_text(f'DISCORD_TOKEN="{token}"')
+    )
+
+
+@pytest.mark.parametrize("text", [
+    # A JWT shares the dotted shape but starts with eyJ, never M/N/O.
+    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abcDEFghiJKLmnoPQRstuvWXYz12",
+    # 40-char git SHA: no dots, no [MNO]-anchored base64 triple.
+    "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    # Final segment too short to be a real bot token.
+    "NzkyNzE1NDU0MTk2MDg4ODQy" ".X-hvzA." "tooShort123",
+])
+def test_discord_bot_token_no_false_positive(text: str) -> None:
+    assert not any(f.rule == "discord-bot-token" for f in scan_text(text))
+
+
+def test_discord_keyword_hex_stays_api_token() -> None:
+    # The legacy keyword+64-hex rule (discord-api-token) must keep owning this
+    # shape; the new dotted bot-token rule must not fire on it.
+    hit = "discord_token = " + "0123456789abcdef" * 4
+    rules = {f.rule for f in scan_text(hit)}
+    assert "discord-api-token" in rules
+    assert "discord-bot-token" not in rules


### PR DESCRIPTION
## What

Adds a native `discord-bot-token` detection rule for the real Discord **bot token** format (`id.timestamp.hmac`, base64url).

## Why

The existing `discord-api-token` rule (ported from gitleaks) only fires on a 64-char **hex** secret sitting next to the literal `discord`:

```
(?i)[\w.-]{0,50}?(?:discord)...(=|:|=>)...([a-f0-9]{64})...
```

That shape is effectively a client-secret/hex matcher — it never matches an actual bot token, which is dotted base64url (`<snowflake-b64>.<timestamp-b64>.<hmac>`). Verified before this change: a real-shaped bot token went undetected standalone, as `DISCORD_TOKEN=...`, and inside an `Authorization: Bot ...` header.

## How

```
\b[MNO][\w-]{23,27}\.[\w-]{6,7}\.[\w-]{27,40}(?![\w-])
```

- The first segment is base64 of the bot's decimal snowflake, so it always begins `M`/`N`/`O`. That anchor keeps the rule off JWTs (`eyJ...`) and other dotted tokens (mapbox `pk....`, dynatrace `dt0c01....`).
- No keyword literal anywhere, so the prefilter extractor returns `()` and the rule lands in `_ALWAYS_RUN` — confirmed lossless by the existing prefilter tests.

## Changes

- `scanner.py` — new `RULES` entry + `ROTATION_GUIDANCE` (Developer Portal -> Bot -> Reset Token).
- `scripts/rules_drift.py` — mapped to `None` (gitleaks ships no dedicated bot-token regex; `rules_snapshot.json` is unchanged because `build_snapshot` drops `None` mappings).
- `tests/test_ported_rules.py` — positive (classic `24.6.27` + new 38-char hmac; bare and `DISCORD_TOKEN="..."`) and negative (JWT, 40-char git SHA, too-short hmac) cases, plus a guard that `discord` + 64-hex still attributes to `discord-api-token`, not the new rule.

## Verification

- Full suite: **383 passed**.
- End-to-end `scan_text` smoke: a bot token is now reported as **Discord bot token** (masked) standalone, in an env assignment, and in a `Bot` auth header.

The existing `discord-api-token` rule is untouched — it keeps covering the 64-hex case; this only adds the missing bot-token format.
