### PR TITLE
fix: move pty/termios imports inside unix-only functions to fix Windows CI

### DIFF
--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import io
 import os
-import pty
 import sys
-import termios
 import threading
 import time
 from unittest.mock import patch
@@ -53,6 +51,7 @@ _BYTE_SEQ_CASES = [
 ]
 
 def _feed_keys_when_raw(master_fd, slave_fd, data):
+    import termios
     # Wait until _read_key_unix switches the slave out of canonical mode
     # (setcbreak clears ICANON) before writing, so the bytes are neither
     # discarded by setcbreak(TCSAFLUSH) nor held by the canonical line
@@ -77,6 +76,7 @@ def test_read_key_unix_parses_real_byte_sequences(seq, expected, monkeypatch):
     exact shape that triggered the bug — so this fails if the parser regresses
     to sys.stdin.read.
     """
+    import pty
     master, slave = pty.openpty()
     # Buffered TextIOWrapper over the slave: the exact stdin shape that
     # triggered the original bug.


### PR DESCRIPTION
## Problem

`tests/test_tui.py` imports `pty` and `termios` at module level. Both are Unix-only stdlib modules that do not exist on Windows. This causes a `ModuleNotFoundError` during collection on all three Windows CI jobs, failing 3 of the 6 matrix runs on the two most recent commits.

The parametrized pty test already carries `@pytest.mark.skipif(sys.platform == "win32", ...)`, but pytest skip markers run after import, so they cannot prevent the collection error.

## Fix

Move `import pty` and `import termios` inside the two functions that actually use them (`_feed_keys_when_raw` and `test_read_key_unix_parses_real_byte_sequences`). All other tests in the file are cross-platform and now collect correctly on Windows.

## Result

- Before: 3/6 CI jobs fail (all Windows matrix entries) with `ModuleNotFoundError: No module named 'termios'`
- After: 367 passed, 10 skipped (pty tests correctly skipped on Windows, all other tests run)

Verified locally on Windows (Python 3.13).
