### PR TITLE
refactor: collapse menu elif ladders to dispatch tables, dedup redact rendering

### DIFF
--- a/src/agentsweep/menu.py
+++ b/src/agentsweep/menu.py
@@ -20,6 +20,35 @@ from pathlib import Path
 from . import __version__, ui
 from .pipeline import _suggest_paths
 
+# Menu actions that map straight to a cli verb invocation, with no extra
+# control flow. Both the TUI and the numbered menu dispatch off this single
+# table, so adding/retargeting an action is a one-line edit instead of a new
+# branch in two parallel ladders.
+_SIMPLE_ACTIONS: dict[str, list[str]] = {
+    "redact": ["fix", "--source", "claude-code"],
+    "undo": ["undo", "--source", "claude-code"],
+    "json": ["scan", "--source", "claude-code", "--json"],
+}
+# Numbered-fallback keys onto the same action names.
+_NUMBERED_ACTIONS: dict[str, str] = {"3": "redact", "4": "undo", "5": "json"}
+
+
+def _check_updates_interactive() -> None:
+    """Synchronous 'check for updates', shared by both interactive menus."""
+    from .cli import check_for_update, _version_tuple
+
+    print("  checking for updates…")
+    latest, err = check_for_update(timeout=5)
+    if err is not None:
+        ui.warn_line(f"could not reach PyPI — {err}")
+    elif _version_tuple(latest) > _version_tuple(__version__):
+        print(
+            f"  agentsweep {latest} is available — run: "
+            f"uv tool upgrade agentsweep  (or: pip install --upgrade agentsweep)"
+        )
+    else:
+        print(f"  agentsweep {__version__} is up to date")
+
 
 def _passive_update_check() -> None:
     """Fire a background thread to check PyPI for a newer version.
@@ -98,31 +127,12 @@ def _run_tui_menu(main) -> int:
                     main(["scan", "--source", name])
             _pause()
 
-        elif action == "redact":
-            main(["fix", "--source", "claude-code"])
-            _pause()
-
-        elif action == "undo":
-            main(["undo", "--source", "claude-code"])
-            _pause()
-
-        elif action == "json":
-            main(["scan", "--source", "claude-code", "--json"])
+        elif action in _SIMPLE_ACTIONS:
+            main(_SIMPLE_ACTIONS[action])
             _pause()
 
         elif action == "updates":
-            from .cli import check_for_update, _version_tuple
-            print("  checking for updates…")
-            latest, err = check_for_update(timeout=5)
-            if err is not None:
-                ui.warn_line(f"could not reach PyPI — {err}")
-            elif _version_tuple(latest) > _version_tuple(__version__):
-                print(
-                    f"  agentsweep {latest} is available — run: "
-                    f"uv tool upgrade agentsweep  (or: pip install --upgrade agentsweep)"
-                )
-            else:
-                print(f"  agentsweep {__version__} is up to date")
+            _check_updates_interactive()
             _pause()
 
 
@@ -154,25 +164,10 @@ def _run_numbered_menu(main) -> int:
             root = _ask_folder()
             if root is not None:
                 main(["scan", "--root", str(root)])
-        elif choice == "3":
-            main(["fix", "--source", "claude-code"])
-        elif choice == "4":
-            main(["undo", "--source", "claude-code"])
-        elif choice == "5":
-            main(["scan", "--source", "claude-code", "--json"])
+        elif choice in _NUMBERED_ACTIONS:
+            main(_SIMPLE_ACTIONS[_NUMBERED_ACTIONS[choice]])
         elif choice == "6":
-            from .cli import check_for_update, _version_tuple
-            print("  checking for updates…")
-            latest, err = check_for_update(timeout=5)
-            if err is not None:
-                ui.warn_line(f"could not reach PyPI — {err}")
-            elif _version_tuple(latest) > _version_tuple(__version__):
-                print(
-                    f"  agentsweep {latest} is available — run: "
-                    f"uv tool upgrade agentsweep  (or: pip install --upgrade agentsweep)"
-                )
-            else:
-                print(f"  agentsweep {__version__} is up to date")
+            _check_updates_interactive()
         elif choice in {"7", "q", "quit", "exit"}:
             return 0
         else:

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import difflib
 import json
+import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -135,6 +136,15 @@ def run(args, *, _findings_out: list | None = None) -> int:
         force=args.force,
     )
 
+    return _render_redact_result(rows, errors, found_by_file)
+
+
+def _render_redact_result(rows, errors: int, found_by_file: dict) -> int:
+    """Render the REDACT + ROTATE stage lines and rows for a redaction run.
+
+    Shared by run() and redact_findings() so the two never drift. Returns the
+    exit code: 0 if every write succeeded, else 2.
+    """
     ok_count = sum(1 for status, _, _ in rows if status == "ok")
     if errors == 0:
         ui.stage(4, "ok", "REDACT", f"{ok_count}/{len(rows)} file(s) rewritten")
@@ -150,7 +160,6 @@ def run(args, *, _findings_out: list | None = None) -> int:
     else:
         ui.stage(5, "warn", "ROTATE", "nothing redacted", "these keys are still live")
     ui.rotation_panel(_rotation_items(found_by_file))
-
     return 0 if errors == 0 else 2
 
 
@@ -174,22 +183,7 @@ def redact_findings(args, source: Source, found_by_file: dict) -> int:
         backup=not args.no_backup,
         force=args.force,
     )
-    ok_count = sum(1 for status, _, _ in rows if status == "ok")
-    if errors == 0:
-        ui.stage(4, "ok", "REDACT", f"{ok_count}/{len(rows)} file(s) rewritten")
-    elif ok_count:
-        ui.stage(4, "warn", "REDACT", f"{ok_count}/{len(rows)} file(s) rewritten")
-    else:
-        ui.stage(4, "fail", "REDACT", f"0/{len(rows)} file(s) rewritten")
-    for status, path_display, note in rows:
-        ui.redact_row(status, path_display, note)
-
-    if ok_count:
-        ui.stage(5, "warn", "ROTATE", "redacted locally", "keys live until rotated")
-    else:
-        ui.stage(5, "warn", "ROTATE", "nothing redacted", "these keys are still live")
-    ui.rotation_panel(_rotation_items(found_by_file))
-    return 0 if errors == 0 else 2
+    return _render_redact_result(rows, errors, found_by_file)
 
 
 def _suggest_paths(missing: Path) -> list[str]:
@@ -457,7 +451,6 @@ def undo(args) -> int:
     for bak in backups:
         original = bak.with_name(bak.name[: -len(".bak")])
         try:
-            import os
             os.replace(bak, original)
             ui.redact_row("ok", ui.rel(original, source.root), "restored from .bak")
         except OSError as e:

--- a/src/agentsweep/ui/picker.py
+++ b/src/agentsweep/ui/picker.py
@@ -27,48 +27,6 @@ def _check(selected: bool, target: "console") -> str:  # type: ignore[valid-type
     return "x" if selected else " "
 
 
-def _render_rows(
-    rows: list[tuple[str, str]],  # (label, hint)
-    focus: int,
-    checked: set[int] | None = None,
-    is_button: set[int] | None = None,
-) -> Table:
-    """Build a Rich Table for a picker panel."""
-    grid = Table.grid(padding=(0, 1))
-    grid.add_column(width=3, justify="center")  # check / bullet
-    grid.add_column()                             # label
-    grid.add_column(style="dim")                  # hint
-
-    for i, (label, hint) in enumerate(rows):
-        focused = (i == focus)
-        is_btn = is_button and i in is_button
-
-        if focused and is_btn:
-            lbl_style = "bold white on red"
-            pfx = ""
-        elif focused:
-            lbl_style = "bold white on red"
-            pfx = ""
-        else:
-            lbl_style = "white"
-            pfx = ""
-
-        if checked is not None and i not in (is_button or set()):
-            ch = _check(i in checked, console)
-            prefix_text = Text(f"[{ch}]", style=("bold red" if i in checked else "dim"))
-        elif is_btn and i in (is_button or set()):
-            prefix_text = Text("", style="")
-        else:
-            prefix_text = Text("", style="")
-
-        lbl_text = Text(_safe(console, label), style=lbl_style)
-        hint_text = Text(_safe(console, hint), style="dim")
-
-        grid.add_row(prefix_text, lbl_text, hint_text)
-
-    return grid
-
-
 def _run_menu(
     title: str,
     rows: list[tuple[str, str]],
@@ -197,11 +155,6 @@ def source_picker() -> list[str] | None:
     from ..sources import SOURCES  # late import: avoids top-level cycle
 
     source_entries: list[tuple[str, str]] = [
-        (src.display_name, f"~/{src.name}")
-        for src in (SOURCES[k]() for k in SOURCES)
-    ]
-    # Add display_name without instantiating (cheaper)
-    source_entries = [
         (SOURCES[k].display_name, k)
         for k in SOURCES
     ]


### PR DESCRIPTION
## What

Code-quality cleanup from the elif/dedup audit — **behavior-preserving**, no functional change.

### `menu.py` — the "endless elif" fix
Both the TUI and numbered-fallback menus dispatched simple actions through two parallel `if/elif` ladders, and the entire "check for updates" block was copy-pasted into each.
- The action→argv mapping is now one shared `_SIMPLE_ACTIONS` table (`_NUMBERED_ACTIONS` maps the numbered keys onto the same names).
- The duplicated update check is extracted to `_check_updates_interactive()`.
- `scan` and `updates` keep explicit branches — they carry real control flow (picker loop, network check), so they're correctly *not* table-ified.

### `pipeline.py` — dedup + tidy
- The REDACT+ROTATE stage-rendering block was duplicated verbatim between `run()` and `redact_findings()`; extracted to `_render_redact_result()`.
- Hoisted the per-iteration `import os` in `undo()` to module scope.

### `ui/picker.py` — dead code
- Deleted `_render_rows()` (40 lines, never referenced anywhere — confirmed by repo-wide grep).
- Removed the first `source_entries` comprehension, which instantiated all 13 Source classes only to discard the list and rebuild it from class attributes.

## Verification
- Full suite: **369 passed, 8 skipped** (identical to baseline).
- `ruff check` clean on all three files (the one repo-wide `E731` is pre-existing code this PR doesn't touch).
- Net: **46 insertions, 105 deletions.**

## Deliberately left alone
The `scanner.py` RULES ordering, the keyword-prefilter fallback, the `SOURCES` registry, and the `keys.py` escape-sequence parsing — all load-bearing or intentional per CLAUDE.md. The medium-risk SQLite-walk and VS Code path-resolver de-dups are noted for a follow-up but not included here.
