### PR TITLE
chore: add pull-request and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Something in a scan / fix / undo / purge run went wrong
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug!
+
+        ⚠️ **agentsweep handles real secrets.** Never paste a real API key, token,
+        database URL, seed phrase, or the raw contents of a history file. Mask
+        anything sensitive (e.g. `sk-...REDACTED`). A reproduction with a
+        *synthetic* example secret is ideal.
+  - type: input
+    id: version
+    attributes:
+      label: agentsweep version
+      description: Output of `agentsweep --version`
+      placeholder: "0.1.5"
+    validations:
+      required: true
+  - type: dropdown
+    id: command
+    attributes:
+      label: Which command were you running?
+      options:
+        - scan
+        - fix
+        - undo
+        - purge
+        - interactive menu
+        - other / not sure
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: Source / agent
+      description: e.g. claude-code, codex, opencode, cursor, windsurf — or a custom `--root`
+      placeholder: claude-code
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: The command you ran, what you expected, and what you got (with secrets masked).
+      placeholder: |
+        $ agentsweep fix --source claude-code
+        ... output / traceback (secrets masked) ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS + version, Python version, and how you installed agentsweep.
+      placeholder: |
+        OS: Windows 11 / macOS 14 / Ubuntu 24.04
+        Python: 3.12.8
+        Install: uv tool install agentsweep  (or pipx / pip -e)
+    validations:
+      required: true
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety
+      options:
+        - label: This report contains no real secrets or raw history-file contents
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Report a security vulnerability (privately)
+    url: https://github.com/Ishannaik/agent-sweep/security/advisories/new
+    about: Please report security issues through a private GitHub security advisory, not a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature / source / rule request
+description: Request a new agent source, a new detection rule, or another enhancement
+title: "[feat]: "
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of request is this?
+      options:
+        - New agent source (a coding agent whose history isn't scanned yet)
+        - New detection rule (a secret type not yet caught)
+        - Other enhancement
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the request
+      description: |
+        - **New source:** where does the agent store its history (path + format: JSONL, JSON, SQLite, Markdown)?
+        - **New rule:** what does the secret look like? Include a *synthetic, non-live* example and how the key is rotated/revoked.
+        - **Enhancement:** what should change and what's the use case?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else?
+      description: Links, docs, or context that would help (no real secrets, please).
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety
+      options:
+        - label: Any example secrets here are synthetic / non-live
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for contributing to agentsweep! Fill in the sections below.
+Keep PRs focused — one concern per PR (a CI fix and a feature should be
+two PRs). See CLAUDE.md for the project's conventions.
+-->
+
+## What & why
+
+<!-- One or two sentences: what this changes and why. Link any issue, e.g. "Closes #12". -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New agent source
+- [ ] New detection rule
+- [ ] Feature / enhancement
+- [ ] Refactor / docs / chore
+
+## Testing
+
+<!-- How did you verify this? Paste the relevant `pytest` summary. -->
+
+```
+# pytest output here
+```
+
+## Checklist
+
+- [ ] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13)
+- [ ] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
+- [ ] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail)
+- [ ] **New detection rule?** Added to `RULES` **and** `ROTATION_GUIDANCE` **and** a fixture/test, with every regex quantifier bounded (no unbounded `.*`), and the keyword pre-filter kept lossless
+- [ ] **New source?** Registered in `SOURCES` with process markers, a menu entry, and a round-trip test (see CLAUDE.md → "Adding a new Source")
+- [ ] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths)
+- [ ] Did not re-introduce `force-include` in `pyproject.toml`


### PR DESCRIPTION
## What

Adds the standard GitHub community templates the repo was missing.

- **`PULL_REQUEST_TEMPLATE.md`** — a focused-PR checklist that mirrors the CLAUDE.md invariants: green matrix CI (Linux **and** Windows), no real secrets in commits, redaction write-path guarantees, the new-rule trio (`RULES` + `ROTATION_GUIDANCE` + fixture, bounded regex), the new-source requirements, machine-clean `--json`, and "don't re-introduce `force-include`".
- **`ISSUE_TEMPLATE/bug_report.yml`** — structured bug form that **warns against pasting real secrets** and collects version / command / source / environment.
- **`ISSUE_TEMPLATE/feature_request.yml`** — new-source / new-rule / enhancement form.
- **`ISSUE_TEMPLATE/config.yml`** — disables blank issues and routes security reports to a **private** GitHub security advisory.

## Notes

- All three YAML forms validated with `yaml.safe_load`.
- No code touched — repo meta only.
