### PR TITLE
Add `list-sources` verb to discover supported agents on this machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ menu entirely and behaves exactly as documented below.
 | `agentsweep fix` | Scan, then offer to redact findings in place (type `REDACT` to confirm) |
 | `agentsweep undo` | Restore all `.bak` backups, reverting any previous redaction |
 | `agentsweep purge` | Delete all `.bak` backups once the leaked keys are rotated (permanent — `undo` stops working) |
+| `agentsweep list-sources` | List every supported agent and show which ones have history on this machine (read-only) |
 | `agentsweep --version` / `-V` | Print the installed version |
 | `agentsweep --update` | Check PyPI for a newer release |
 
@@ -156,6 +157,17 @@ agentsweep scan --source github-copilot-chat  # GitHub Copilot Chat history
 agentsweep scan --source openclaw             # OpenClaw ~/.openclaw/
 agentsweep scan --source hermes               # Hermes Agent ~/.hermes/state.db
 agentsweep scan --source goose                # Goose ~/.local/share/goose/
+```
+
+Not sure which agents you have installed? `list-sources` prints every supported
+source, its history location, and whether that history exists on this machine —
+so you know which `--source` values are worth scanning. It reads nothing and
+writes nothing.
+
+```bash
+agentsweep list-sources             # all 29 sources + which are on disk
+agentsweep list-sources --detected  # only the ones found on this machine
+agentsweep list-sources --json      # machine-readable (for scripts/CI)
 ```
 
 Override the default root directory to scan any arbitrary folder:

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -7,6 +7,7 @@ Usage shapes, all supported:
     agentsweep fix  [opts]     redact (guided + confirmed on a terminal)
     agentsweep undo [opts]     restore .bak backups
     agentsweep purge [opts]    delete .bak backups (after rotating the keys)
+    agentsweep list-sources    list supported agents + which are on this machine
     agentsweep --fix ...       legacy flag form, kept working as an alias
     agentsweep --update        check PyPI for a newer version
 
@@ -139,6 +140,10 @@ def main(argv: list[str] | None = None) -> int:
     if argv and argv[0] in ("--update",):
         return _run_update_check()
 
+    if argv and argv[0] == "list-sources":
+        from .pipeline import list_sources
+        return list_sources(_parse_list_sources(argv[1:]))
+
     if not argv and _interactive():
         from .menu import run_menu
         try:
@@ -223,6 +228,19 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
     args = ap.parse_args(rest)
     args.fix = (verb == "fix")
     return args
+
+
+def _parse_list_sources(rest: list[str]) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        prog="agentsweep list-sources",
+        description="List every supported agent source and whether its "
+                    "history root exists on this machine. Read-only.",
+    )
+    ap.add_argument("--json", action="store_true",
+                    help="Emit the source list as JSON to stdout.")
+    ap.add_argument("--detected", action="store_true",
+                    help="Show only sources whose history root exists here.")
+    return ap.parse_args(rest)
 
 
 def _parse_undo(rest: list[str]) -> argparse.Namespace:

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -214,6 +214,55 @@ def redact_findings(args, source: Source, found_by_file: dict, *,
     return _render_redact_result(rows, errors, found_by_file)
 
 
+def _source_rows() -> list[dict]:
+    """Describe every registered source: key, name, default root, detection.
+
+    ``detected`` is True when the source's default history root exists on this
+    machine — a cheap, deterministic install signal (no directory walk, no file
+    reads). Instantiating a source only computes its default_root(); it never
+    touches history contents, so this stays fast and side-effect free.
+    """
+    rows: list[dict] = []
+    for key, cls in SOURCES.items():
+        try:
+            src = cls()
+            root = src.root
+            detected = root.exists()
+        except Exception:
+            root, detected = None, False
+        rows.append({
+            "source": key,
+            "display": getattr(cls, "display_name", key),
+            "experimental": bool(getattr(cls, "experimental", False)),
+            "root": str(root) if root is not None else "",
+            "detected": detected,
+        })
+    return rows
+
+
+def list_sources(args) -> int:
+    """List every supported agent source and whether its history root exists.
+
+    Read-only and side-effect free — reads no history, writes nothing. Always
+    exits 0. With ``--detected`` only sources found on this machine are shown;
+    with ``--json`` the list is emitted as machine-readable JSON to stdout.
+    """
+    rows = _source_rows()
+    if getattr(args, "detected", False):
+        rows = [r for r in rows if r["detected"]]
+
+    if getattr(args, "json", False):
+        print(json.dumps(rows, indent=2))
+        return 0
+
+    ui.banner(__version__)
+    if not rows:
+        ui.warn_line("no agent history found on this machine")
+        return 0
+    ui.sources_table(rows)
+    return 0
+
+
 def _suggest_paths(missing: Path) -> list[str]:
     """Typo forgiveness: close-matching sibling directory names."""
     parent = missing.parent

--- a/src/agentsweep/ui/__init__.py
+++ b/src/agentsweep/ui/__init__.py
@@ -31,6 +31,7 @@ from .widgets import (  # noqa: F401
     redact_row,
     rel,
     rotation_panel,
+    sources_table,
     stage,
     warn_line,
 )

--- a/src/agentsweep/ui/widgets.py
+++ b/src/agentsweep/ui/widgets.py
@@ -89,6 +89,46 @@ def findings_table(rows: list[tuple[str, str, Path, int]], root: Path) -> None:
     console.print(Padding(table, (0, 0, 0, 8)))
 
 
+def sources_table(rows: list[dict]) -> None:
+    """Table of every supported source: key, name, on-disk root, detection.
+
+    Each row is a dict with keys ``source``, ``display``, ``experimental``,
+    ``root`` and ``detected`` (matching pipeline.list_sources' payload). A
+    green ``● found`` marks a root that exists on this machine; a dim ``–``
+    marks one that doesn't. Cells are wrapped in Text so bracketed path
+    segments are never parsed as rich markup.
+    """
+    ic = _icons(console)
+    found = ic.get("ok", "●")
+    table = Table(
+        box=_box(console, box.HEAVY_HEAD),
+        border_style="cyan",
+        header_style="bold cyan",
+    )
+    table.add_column("SOURCE", style="bold")
+    table.add_column("AGENT")
+    table.add_column("HISTORY ROOT")
+    table.add_column("ON DISK", justify="center")
+    for r in rows:
+        name = r["display"]
+        if r.get("experimental"):
+            name += " (experimental)"
+        if r.get("detected"):
+            mark = Text(f"{found} found", style="green")
+        else:
+            mark = Text("–", style="dim")
+        table.add_row(
+            Text(_safe(console, r["source"])),
+            Text(_safe(console, name)),
+            Text(_safe(console, r["root"]), style="dim"),
+            mark,
+        )
+    console.print(Padding(table, (0, 0, 0, 2)))
+    detected = sum(1 for r in rows if r.get("detected"))
+    warn_line(f"{detected} of {len(rows)} source(s) have history on this "
+              f"machine — scan one with:  agentsweep scan --source <SOURCE>")
+
+
 def rel(path: Path, root: Path) -> str:
     try:
         return str(path.relative_to(root))

--- a/tests/test_list_sources.py
+++ b/tests/test_list_sources.py
@@ -1,0 +1,130 @@
+"""Tests for the `agentsweep list-sources` verb (cli.py / pipeline.py).
+
+Covers:
+  (a) list-sources --json → parseable list, one entry per registered source,
+      required keys present and correctly typed, exit 0
+  (b) every SOURCES key appears exactly once in the JSON payload
+  (c) --detected filters to only sources whose root exists (subset of full)
+  (d) detection tracks the on-disk root: claude-code flips False→True once its
+      default root is created under an isolated HOME
+  (e) human (non-JSON) output renders without crashing and exits 0
+  (f) list-sources exits before any scan — no findings/pipeline output leaks
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.cli import main  # noqa: E402
+from agentsweep.sources import SOURCES  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Isolate HOME / USERPROFILE so HOME-rooted sources (claude-code, codex, …)
+# don't report detection based on the real machine.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    yield fake_home
+
+
+# ===========================================================================
+# (a) / (b) JSON output shape
+# ===========================================================================
+
+def test_list_sources_json_lists_every_source(capsys):
+    code = main(["list-sources", "--json"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    keys = [row["source"] for row in payload]
+    # Exactly one entry per registered source, no dupes, no omissions.
+    assert keys == list(SOURCES)
+    assert len(keys) == len(set(keys))
+
+
+def test_list_sources_json_entry_schema(capsys):
+    main(["list-sources", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    for row in payload:
+        assert set(row) == {"source", "display", "experimental", "root", "detected"}
+        assert isinstance(row["source"], str) and row["source"]
+        assert isinstance(row["display"], str) and row["display"]
+        assert isinstance(row["experimental"], bool)
+        assert isinstance(row["root"], str)
+        assert isinstance(row["detected"], bool)
+
+
+# ===========================================================================
+# (c) --detected filters to a subset
+# ===========================================================================
+
+def test_detected_flag_is_subset_of_all(capsys):
+    main(["list-sources", "--json"])
+    full = json.loads(capsys.readouterr().out)
+    main(["list-sources", "--json", "--detected"])
+    detected = json.loads(capsys.readouterr().out)
+
+    assert all(row["detected"] for row in detected)
+    full_keys = {row["source"] for row in full}
+    detected_keys = {row["source"] for row in detected}
+    assert detected_keys <= full_keys
+    # The detected set is exactly the detected rows of the full set.
+    assert detected_keys == {row["source"] for row in full if row["detected"]}
+
+
+# ===========================================================================
+# (d) detection tracks the on-disk root
+# ===========================================================================
+
+def test_detection_reflects_root_existence(_isolate_home, capsys):
+    def _claude_row():
+        main(["list-sources", "--json"])
+        payload = json.loads(capsys.readouterr().out)
+        return next(r for r in payload if r["source"] == "claude-code")
+
+    # Root absent under the isolated HOME → not detected.
+    assert _claude_row()["detected"] is False
+
+    # Create the default root; detection should flip to True.
+    (_isolate_home / ".claude" / "projects").mkdir(parents=True)
+    assert _claude_row()["detected"] is True
+
+
+# ===========================================================================
+# (e) human output renders and exits 0
+# ===========================================================================
+
+def test_list_sources_human_output_exits_0(capsys):
+    code = main(["list-sources"])
+    out = capsys.readouterr().out
+    assert code == 0
+    # Banner + at least one source key should appear in the rendered table.
+    assert "claude-code" in out
+
+
+def test_list_sources_human_detected_only_exits_0(_isolate_home, capsys):
+    (_isolate_home / ".claude" / "projects").mkdir(parents=True)
+    code = main(["list-sources", "--detected"])
+    assert code == 0
+    assert "claude-code" in capsys.readouterr().out
+
+
+# ===========================================================================
+# (f) list-sources never scans
+# ===========================================================================
+
+def test_list_sources_does_not_scan(capsys):
+    """No 'FINDINGS' / 'SCAN' pipeline stages should appear — it lists only."""
+    main(["list-sources"])
+    out = capsys.readouterr().out
+    assert "FINDINGS" not in out
+    assert "SECRET (masked)" not in out


### PR DESCRIPTION
## What

Adds a read-only `agentsweep list-sources` verb that lists every supported agent source, its default history root, and whether that root exists on the current machine.

```
agentsweep list-sources             # all 29 sources + which are on disk
agentsweep list-sources --detected  # only the ones found on this machine
agentsweep list-sources --json      # machine-readable (scripts/CI)
```

## Why

agentsweep supports **29 agents**, but a given developer only has a handful installed. Today the only way to find out which `--source` values are worth scanning is to read the README's list and try them one by one. `list-sources` turns that into a single glance: it shows exactly which agents have history on this machine, and where.

It pairs naturally with the existing multi-source design and the tool's scripting/`--json` focus — e.g. CI can enumerate detected sources and scan each.

## Safety

Strictly read-only and side-effect free. It instantiates each `Source` only to compute `default_root()` and calls `root.exists()` — **no history is read and nothing is written**. It touches none of the redaction/write path, so the corruption-prevention invariants are unaffected.

## Implementation

- `pipeline.list_sources()` + `_source_rows()` build the payload (dispatched from `cli.py` exactly like the existing `undo`/`purge` verbs)
- `ui.sources_table()` renders the human table (green `● found` / dim `–`); `--json` bypasses `ui` entirely, keeping machine output clean, consistent with the rest of the tool
- `cli` gains the `list-sources` route and its own arg parser

## Tests

7 new tests in `tests/test_list_sources.py`, fully hermetic (isolated `HOME`, everything under `tmp_path`):

- `--json` lists every registered source exactly once, with the correct schema/types
- `--detected` is exactly the detected subset of the full list
- detection tracks the on-disk root (claude-code flips `False`→`True` once its default root is created)
- human output renders and exits 0
- `list-sources` never triggers a scan

Full suite: **414 passed, 11 skipped** (was 407) — no regressions. `ruff check` passes on all changed files.

## Note on scope

I read the v1 scope boundary in `CONTRIBUTING.md`. This isn't a detection rule, feature-flag/config system, daemon/watch mode, or CI/CD integration — it's a small, read-only discovery aid for the sources that already exist, in the spirit of "more sources, more tests." Happy to adjust or close if you'd rather hold it for v1.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)