### PR TITLE
fix: redaction of WAL-mode SQLite dbs was undone by the stale -wal

### DIFF
--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -510,7 +510,12 @@ def _write_text(path: Path, text: str) -> None:
 # markdown histories, plus the SQLite stores (Cursor/Windsurf *.vscdb,
 # OpenCode opencode.db, Hermes/Goose *.db).
 _BACKUP_GLOBS = ("*.jsonl.bak", "*.json.bak", "*.md.bak",
-                 "*.vscdb.bak", "*.db.bak")
+                 "*.vscdb.bak", "*.db.bak",
+                 # SQLite WAL sidecars, retired with their database by
+                 # safe_write. undo restores them; purge deletes them.
+                 "*.db-wal.bak", "*.db-shm.bak",
+                 "*.vscdb-wal.bak", "*.vscdb-shm.bak",
+                 "*.sqlite.bak", "*.sqlite-wal.bak", "*.sqlite-shm.bak")
 
 
 def undo(args) -> int:
@@ -643,7 +648,8 @@ def _redact_all(
         try:
             new_content = source.apply_redactions(path, redactions)
             record = safe_write(path, new_content, backup=backup,
-                                fmt=source.content_format(path))
+                                fmt=source.content_format(path),
+                                sidecars=source.sidecars(path))
             if record.unchanged:
                 # File was already in the redacted state — calm skip, not a fail.
                 rows.append(("skip", display, "already redacted (no change)"))

--- a/src/agentsweep/redactor.py
+++ b/src/agentsweep/redactor.py
@@ -5,7 +5,7 @@ import json
 import os
 import tempfile
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -101,10 +101,19 @@ def safety_check(path: Path, source_root: Path | Iterable[Path],
 
 
 def safe_write(path: Path, new_content: str | bytes,
-               backup: bool = True, fmt: str = "jsonl") -> WriteRecord:
+               backup: bool = True, fmt: str = "jsonl",
+               sidecars: Sequence[Path] = ()) -> WriteRecord:
     """Atomically replace `path`'s content with `new_content`.
 
     Guarantees:
+      - Sidecars: files listed in `sidecars` (a SQLite database's `-wal` and
+        `-shm`) are backed up alongside `path` and deleted once the replace
+        lands. The caller MUST only pass sidecars whose committed contents
+        are already folded into `new_content` — for SQLite that is what
+        `Connection.backup()` does. Deleting them is what makes the
+        redaction stick: a `-wal` left beside a replaced database still
+        holds the pre-redaction plaintext, and SQLite replays it over the
+        new file on the next open, silently restoring the secret.
       - Post-write validation (str content), selected by `fmt`:
           "jsonl" — every non-empty line must parse as JSON and the line
                     count must match the original (the default);
@@ -164,6 +173,11 @@ def safe_write(path: Path, new_content: str | bytes,
         return WriteRecord(path, original_hash, new_hash, None,
                            len(original_bytes), len(new_bytes), unchanged=True)
 
+    # Sidecars are backed up before the replace and removed after it, so a
+    # crash in between leaves the original database recoverable from the pair
+    # of .bak files rather than half-retired.
+    sidecar_backups: list[Path] = []
+
     backup_path: Path | None = None
     if backup:
         backup_path = path.with_name(path.name + ".bak")
@@ -183,6 +197,35 @@ def safe_write(path: Path, new_content: str | bytes,
             ) from None
         with os.fdopen(bak_fd, "wb") as bak_file:
             bak_file.write(original_bytes)
+
+        for sidecar in sidecars:
+            sidecar_bak = sidecar.with_name(sidecar.name + ".bak")
+            try:
+                # 0o600 for the same reason as the main backup: a `-wal`
+                # holds the very plaintext we are about to redact.
+                sc_fd = os.open(
+                    str(sidecar_bak),
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                )
+            except FileExistsError:
+                for done in sidecar_backups:
+                    try:
+                        done.unlink()
+                    except OSError:
+                        pass
+                if backup_path.exists():
+                    try:
+                        backup_path.unlink()
+                    except OSError:
+                        pass
+                raise SafetyError(
+                    f"Backup already exists: {sidecar_bak}. "
+                    f"Resolve manually before re-running."
+                ) from None
+            with os.fdopen(sc_fd, "wb") as sc_file:
+                sc_file.write(sidecar.read_bytes())
+            sidecar_backups.append(sidecar_bak)
 
     fd, tmp_name = tempfile.mkstemp(
         dir=str(path.parent),
@@ -207,7 +250,28 @@ def safe_write(path: Path, new_content: str | bytes,
                 backup_path.unlink()
             except OSError:
                 pass
+        for sidecar_bak in sidecar_backups:
+            try:
+                sidecar_bak.unlink()
+            except OSError:
+                pass
         raise
+
+    # The replace landed. Every committed page these sidecars held is already
+    # inside the bytes we just wrote, so they are now stale *and* still hold
+    # pre-redaction plaintext. Retire them, or SQLite replays them on the next
+    # open and the secret comes back.
+    for sidecar in sidecars:
+        try:
+            sidecar.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            raise SafetyError(
+                f"Redacted {path.name} but could not remove {sidecar.name}: {e}. "
+                f"The stale WAL may restore the secret on next open — "
+                f"delete it manually."
+            ) from e
 
     record = WriteRecord(
         path=path,

--- a/src/agentsweep/sources/_base.py
+++ b/src/agentsweep/sources/_base.py
@@ -73,6 +73,23 @@ class Source(ABC):
         """
         return "jsonl"
 
+    def sidecars(self, path: Path) -> list[Path]:
+        """Files that carry part of `path`'s committed state on disk.
+
+        A SQLite database in WAL mode keeps freshly committed pages in
+        `<db>-wal` until a checkpoint folds them back into the database.
+        Those pages hold the same plaintext the database does, and SQLite
+        replays them over whatever database file it finds on the next open.
+        Replacing the database without also retiring them would leave the
+        secret on disk and let the next open undo the redaction.
+
+        Only files that exist are returned. Sources whose apply_redactions
+        returns bytes built from a full `sqlite3.Connection.backup()` — which
+        folds the WAL into the copy — override this so the redactor can back
+        the sidecars up and delete them after the atomic replace.
+        """
+        return []
+
     def roots(self) -> list[Path]:
         """Every directory tree this source's files may live under.
 

--- a/src/agentsweep/sources/_community.py
+++ b/src/agentsweep/sources/_community.py
@@ -17,6 +17,7 @@ from ._helpers import (
     _apply_jsonl_redactions,
     _iter_jsonl_strings,
     _redact_sqlite_copy,
+    sqlite_sidecars,
 )
 
 
@@ -126,6 +127,11 @@ class HermesSource(Source):
             return _apply_jsonl_redactions(path, redactions)
         return _redact_sqlite_copy(path, redactions, self._sqlite_text_columns)
 
+    def sidecars(self, path: Path) -> list[Path]:
+        if path.suffix == ".jsonl":
+            return []
+        return sqlite_sidecars(path)
+
 
 class GooseSource(Source):
     """Goose (block/goose) — SQLite sessions.db + legacy per-session JSONL.
@@ -208,5 +214,10 @@ class GooseSource(Source):
         if path.suffix == ".jsonl":
             return _apply_jsonl_redactions(path, redactions)
         return _redact_sqlite_copy(path, redactions, self._sqlite_text_columns)
+
+    def sidecars(self, path: Path) -> list[Path]:
+        if path.suffix == ".jsonl":
+            return []
+        return sqlite_sidecars(path)
 
 

--- a/src/agentsweep/sources/_core.py
+++ b/src/agentsweep/sources/_core.py
@@ -21,6 +21,7 @@ from ._helpers import (
     _iter_json_file_strings,
     _iter_plaintext_lines,
     _redact_sqlite_copy,
+    sqlite_sidecars,
 )
 
 
@@ -136,6 +137,11 @@ class OpenCodeSource(Source):
         if path == self._db_path():
             return _redact_sqlite_copy(path, redactions, self._sqlite_text_columns)
         return _apply_json_file_redactions(path, redactions)
+
+    def sidecars(self, path: Path) -> list[Path]:
+        if path == self._db_path():
+            return sqlite_sidecars(path)
+        return []
 
     def content_format(self, path: Path) -> str:
         # Only consulted for str returns, i.e. the legacy storage/*.json

--- a/src/agentsweep/sources/_helpers.py
+++ b/src/agentsweep/sources/_helpers.py
@@ -16,6 +16,16 @@ from ._base import KeyPath, _line_ending, _set_by_path, _walk_json
 # SQLite helpers
 # ---------------------------------------------------------------------------
 
+def sqlite_sidecars(db: Path) -> list[Path]:
+    """The `-wal` / `-shm` files SQLite keeps beside `db`, if they exist.
+
+    `_redact_sqlite_copy` folds the WAL into the copy it returns, so once
+    that copy replaces `db` these two are both stale and — in the `-wal`'s
+    case — still full of the plaintext we just redacted.
+    """
+    return [p for p in (Path(f"{db}-wal"), Path(f"{db}-shm")) if p.is_file()]
+
+
 def _redact_sqlite_copy(path: Path, redactions: list, columns_fn) -> bytes:
     """Apply SQLite redactions to a temp copy of `path` and return its bytes.
 

--- a/src/agentsweep/sources/_more.py
+++ b/src/agentsweep/sources/_more.py
@@ -44,6 +44,7 @@ from ._helpers import (
     _iter_jsonl_strings,
     _iter_plaintext_lines,
     _redact_sqlite_copy,
+    sqlite_sidecars,
 )
 from ._vscode import _VSCodeSqliteSource
 
@@ -143,6 +144,9 @@ class _GenericSqliteSource(Source):
 
     def apply_redactions(self, path: Path, redactions: list) -> bytes:
         return _redact_sqlite_copy(path, redactions, self._sqlite_text_columns)
+
+    def sidecars(self, path: Path) -> list[Path]:
+        return sqlite_sidecars(path)
 
 
 # ── SQLite agents ─────────────────────────────────────────────────────────────

--- a/src/agentsweep/sources/_vscode.py
+++ b/src/agentsweep/sources/_vscode.py
@@ -19,6 +19,7 @@ from ._helpers import (
     _iter_jsonl_strings,
     _iter_plaintext_lines,
     _redact_sqlite_copy,
+    sqlite_sidecars,
 )
 
 
@@ -105,6 +106,9 @@ class _VSCodeSqliteSource(Source):
         redactions: list[tuple[int, KeyPath, str]],
     ) -> bytes:
         return _redact_sqlite_copy(path, redactions, self._sqlite_text_columns)
+
+    def sidecars(self, path: Path) -> list[Path]:
+        return sqlite_sidecars(path)
 
 
 class CursorSource(_VSCodeSqliteSource):

--- a/tests/test_sqlite_wal_sidecars.py
+++ b/tests/test_sqlite_wal_sidecars.py
@@ -1,0 +1,190 @@
+"""A SQLite database in WAL mode keeps committed pages in `<db>-wal` until a
+checkpoint folds them in. Redacting the database while that file survives is a
+silent no-op: the plaintext stays on disk in the `-wal`, and SQLite replays it
+over the replaced database on the next open.
+
+These tests pin the whole contract — the secret leaves the disk, the redaction
+survives the next open, no rows are lost, and `undo` still round-trips.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import stat
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+from agentsweep.redactor import safe_write
+from agentsweep.sources._core import OpenCodeSource
+
+SECRET = "sk-ant-api03-" + "A" * 40  # noqa: S105 — synthetic, matches no real key
+REDACTED = "sk-ant-api03-REDACTED"
+
+# Run in a child that exits via os._exit so SQLite never gets to checkpoint and
+# delete the -wal on close. This is what an agent killed mid-session leaves.
+_BUILDER = textwrap.dedent(
+    """
+    import json, os, sqlite3, sys
+    con = sqlite3.connect(sys.argv[1])
+    con.execute("PRAGMA journal_mode=WAL")
+    con.execute("CREATE TABLE part (id TEXT PRIMARY KEY, content TEXT)")
+    for i in range(200):
+        con.execute("INSERT INTO part VALUES (?,?)",
+                    (f"pad{i}", json.dumps({"type": "text", "text": "x" * 400})))
+    con.commit()
+    con.execute("INSERT INTO part VALUES (?,?)",
+                ("secret-row", json.dumps({"type": "text", "text": sys.argv[2]})))
+    con.commit()
+    os._exit(0)
+    """
+)
+
+
+@pytest.fixture()
+def wal_db(tmp_path: Path) -> Path:
+    """An opencode.db whose rows live only in an uncheckpointed -wal."""
+    db = tmp_path / "opencode.db"
+    subprocess.run([sys.executable, "-c", _BUILDER, str(db), SECRET], check=True)
+    assert (tmp_path / "opencode.db-wal").is_file(), "fixture must leave a -wal"
+    assert SECRET.encode() in (tmp_path / "opencode.db-wal").read_bytes()
+    assert SECRET.encode() not in db.read_bytes(), "secret must live only in the -wal"
+    return db
+
+
+def _redact(db: Path, *, backup: bool = True):
+    source = OpenCodeSource(root=db.parent)
+    hits = [(ln, kp, v) for ln, kp, v in source.iter_strings(db) if SECRET in v]
+    assert len(hits) == 1, f"scan should find the secret through the WAL, got {hits}"
+    ln, kp, val = hits[0]
+    new_bytes = source.apply_redactions(db, [(ln, kp, val.replace(SECRET, REDACTED))])
+    return safe_write(db, new_bytes, backup=backup, fmt=source.content_format(db),
+                      sidecars=source.sidecars(db))
+
+
+def test_sidecars_are_reported_for_the_database(wal_db: Path) -> None:
+    names = {p.name for p in OpenCodeSource(root=wal_db.parent).sidecars(wal_db)}
+    assert names == {"opencode.db-wal", "opencode.db-shm"}
+
+
+def test_sidecars_are_empty_for_non_sqlite_paths(tmp_path: Path) -> None:
+    stray = tmp_path / "storage" / "session.json"
+    stray.parent.mkdir()
+    stray.write_text("{}")
+    assert OpenCodeSource(root=tmp_path).sidecars(stray) == []
+
+
+def test_redaction_removes_the_wal_and_survives_reopen(wal_db: Path) -> None:
+    _redact(wal_db)
+
+    assert not (wal_db.parent / "opencode.db-wal").exists(), "stale -wal must be retired"
+    assert not (wal_db.parent / "opencode.db-shm").exists(), "stale -shm must be retired"
+    assert SECRET.encode() not in wal_db.read_bytes()
+
+    # The next open is where the old code lost: WAL recovery replayed the
+    # pre-redaction pages straight back over the redacted database.
+    con = sqlite3.connect(str(wal_db))
+    try:
+        assert con.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert con.execute("SELECT count(*) FROM part").fetchone()[0] == 201
+        (content,) = con.execute(
+            "SELECT content FROM part WHERE id='secret-row'"
+        ).fetchone()
+    finally:
+        con.close()
+    assert SECRET not in content
+    assert json.loads(content)["text"] == REDACTED
+
+
+def test_no_plaintext_secret_left_anywhere_beside_the_database(wal_db: Path) -> None:
+    _redact(wal_db, backup=False)
+    for leftover in wal_db.parent.iterdir():
+        assert SECRET.encode() not in leftover.read_bytes(), f"secret survived in {leftover.name}"
+
+
+def test_sidecars_are_backed_up_and_undo_round_trips(wal_db: Path) -> None:
+    d = wal_db.parent
+    _redact(wal_db)
+
+    wal_bak = d / "opencode.db-wal.bak"
+    assert (d / "opencode.db.bak").is_file()
+    assert wal_bak.is_file(), "the -wal held plaintext; it must be recoverable"
+
+    # undo: restore every .bak over its original (what pipeline.undo does).
+    for bak in sorted(d.glob("*.bak")):
+        os.replace(bak, bak.with_name(bak.name[: -len(".bak")]))
+
+    con = sqlite3.connect(str(wal_db))
+    try:
+        (content,) = con.execute(
+            "SELECT content FROM part WHERE id='secret-row'"
+        ).fetchone()
+    finally:
+        con.close()
+    assert json.loads(content)["text"] == SECRET, "undo must restore the original rows"
+
+
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="POSIX permission bits are not meaningful on Windows")
+def test_sidecar_backup_is_owner_only(wal_db: Path) -> None:
+    """A `-wal` backup holds the same plaintext the `.bak` does."""
+    old_umask = os.umask(0o000)
+    try:
+        _redact(wal_db)
+    finally:
+        os.umask(old_umask)
+    mode = stat.S_IMODE((wal_db.parent / "opencode.db-wal.bak").stat().st_mode)
+    assert mode == 0o600, f"sidecar backup mode is {oct(mode)}, expected 0o600"
+
+
+def test_pipeline_redaction_is_not_undone_by_wal_replay(wal_db: Path, monkeypatch) -> None:
+    """The end-to-end guard, driving `_redact_all` — the real `fix` caller.
+
+    Before the sidecar fix this test failed on behaviour, not on a missing
+    attribute: `_redact_all` replaced opencode.db, left the `-wal` beside it,
+    and the very next connect() replayed the pre-redaction pages back.
+    """
+    import agentsweep.pipeline as pipeline
+    from agentsweep import ignore as ignore_mod
+
+    monkeypatch.setattr(pipeline, "is_agent_running", lambda markers: (False, ""))
+    past = time.time() - 9999
+    for p in sorted(wal_db.parent.iterdir()):
+        os.utime(p, (past, past))
+
+    source = OpenCodeSource(root=wal_db.parent)
+    found_by_file, *_ = pipeline._scan(source, source.files(), ignore_mod.IgnoreSet())
+    assert found_by_file, "the scanner must see the secret through the WAL"
+
+    rows, errors, _ = pipeline._redact_all(source, found_by_file, backup=True, force=False)
+    assert errors == 0, f"redaction reported errors: {rows}"
+
+    con = sqlite3.connect(str(wal_db))
+    try:
+        (content,) = con.execute(
+            "SELECT content FROM part WHERE id='secret-row'"
+        ).fetchone()
+    finally:
+        con.close()
+    assert SECRET not in content, "WAL replay resurrected the redacted secret"
+
+
+def test_failed_write_leaves_sidecars_and_their_backups_alone(wal_db: Path, monkeypatch) -> None:
+    d = wal_db.parent
+    before = (d / "opencode.db-wal").read_bytes()
+
+    def boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError):
+        _redact(wal_db)
+
+    assert (d / "opencode.db-wal").read_bytes() == before, "-wal must survive a failed write"
+    assert not (d / "opencode.db-wal.bak").exists(), "aborted write must clean its backups"
+    assert not (d / "opencode.db.bak").exists()


### PR DESCRIPTION
## What & why

Redacting a **WAL-mode SQLite history database leaves the secret on disk, and the next open puts it back.** `agentsweep fix` reports success either way.

A SQLite database in WAL mode keeps committed pages in `<db>-wal` until a checkpoint folds them in. `_redact_sqlite_copy` handles this correctly — `Connection.backup()` folds the WAL into the copy, then `secure_delete` + `VACUUM` + `integrity_check`. But `safe_write` replaces only the database file. The original `-wal` stays put, so:

1. the plaintext secret is still sitting in `<db>-wal`, and
2. the next SQLite open replays those pre-redaction frames over the freshly VACUUMed database — restoring the secret, `integrity_check: ok`, no error anywhere.

The user sees `ok`, rotates nothing, and the key is still live.

This is reachable on a normal machine, not just in theory: an agent killed mid-session (or one that sets `SQLITE_FCNTL_PERSIST_WAL`) leaves a populated `-wal` behind, and agentsweep's process gate is *satisfied* precisely then, because the agent isn't running. On the machine I found this on, `~/.local/share/opencode/` had a 148 KB `-wal` holding 4 rows that existed nowhere else.

**Affects every SQLite-backed source**, not just OpenCode: `HermesSource`, `GooseSource`, and every subclass of `_GenericSqliteSource` (Warp, Grok CLI, Zed, Kiro CLI) and `_VSCodeSqliteSource` (Cursor, Windsurf, Trae, Void, PearAI).

### The fix

- New `Source.sidecars(path)` hook, defaulting to `[]`. SQLite sources return the existing `-wal`/`-shm`, each mirroring its own `apply_redactions` gate (so Cursor's `.jsonl` transcripts and Windsurf's `.md` memories correctly report none).
- `safe_write` backs the sidecars up at `0600` — a `-wal` holds the same plaintext the `.bak` does — then deletes them *after* the atomic replace lands. Deleting is lossless: their committed pages are already inside the bytes `backup()` produced. A crash in between leaves both `.bak` files, so `undo` still round-trips.
- `undo`/`purge` glob the new `.bak` names, so `purge` also shreds the plaintext-bearing `-wal.bak`.

One thing worth a maintainer's eye: I added `*.sqlite.bak` to `_BACKUP_GLOBS`, which is a pre-existing gap rather than one I introduced (`undo` never restored Warp/Grok backups). It isn't optional here — with only `*.sqlite-wal.bak` added, `undo` would restore a stale `warp.sqlite-wal` on top of a redacted `warp.sqlite` and replay the secret straight back. Happy to split it out if you'd rather.

Scoped to match `CONTRIBUTING.md`: no new detection rules, no config surface — this is squarely "tighter safety."

## Type of change

- [x] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [ ] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing

`tests/test_sqlite_wal_sidecars.py` (7 tests). The end-to-end one drives `_redact_all` — the real `fix` caller — so on `main` it fails on **behaviour**, not on a missing attribute:

```
$ git stash push -- src/   # new test against unmodified main
$ pytest tests/test_sqlite_wal_sidecars.py::test_pipeline_redaction_is_not_undone_by_wal_replay

>       assert SECRET not in content, "WAL replay resurrected the redacted secret"
E       AssertionError: WAL replay resurrected the redacted secret
E         'sk-ant-api03-AAAA...' is contained here:
E           {"type": "text", "text": "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}

1 failed
```

Note `_redact_all` returned `errors == 0` on that run: the tool reported a clean redaction while the secret was restored.

Full suite with the fix applied:

```
$ pytest -q
433 passed in 4.50s

$ ruff check src/ tests/test_sqlite_wal_sidecars.py
All checks passed!
```

Coverage: sidecars reported for the db and not for non-SQLite paths; `-wal`/`-shm` retired; no plaintext anywhere in the directory afterward; backups created `0600` and `undo` round-trips the original rows; a failed write leaves the `-wal` intact and cleans up its own `.bak` files.

Tested against OpenCode (`opencode.db`, `journal_mode=WAL`) on macOS, Python 3.11. The `0o600` assertion carries the same `skipif(sys.platform == "win32")` guard as `test_backup_hygiene.py`, since POSIX mode bits aren't meaningful on Windows.

## Checklist

- [x] `pytest` passes locally (macOS, Python 3.11: 433 passed) — **I haven't been able to verify Windows or 3.12/3.13; those are on CI here.**
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples

<sub>The fixture's `sk-ant-api03-` + 40×`A` is synthetic and matches no live key. `os._exit` in the builder subprocess is deliberate: it denies SQLite the clean-shutdown checkpoint, which is what leaves a real `-wal` behind.</sub>
