### PR TITLE
feat: scan --all aggregates findings across every agent source

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ agentsweep list-sources --detected  # only the ones found on this machine
 agentsweep list-sources --json      # machine-readable (for scripts/CI)
 ```
 
+Scan **every** registered agent in one pass (aggregated findings; redaction stays per-source):
+
+```bash
+agentsweep scan --all                 # all registered sources
+agentsweep scan --all --detected      # only sources with a history root on disk
+agentsweep scan --all --json          # aggregated JSON (each finding has "source")
+agentsweep scan --all --json -o out.json
+```
+
 Override the default root directory to scan any arbitrary folder:
 
 ```bash

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -4,6 +4,9 @@ Usage shapes, all supported:
 
     agentsweep                 bare → interactive menu (on a real terminal)
     agentsweep scan [opts]     scan only
+    agentsweep scan --all      scan every registered agent (aggregate report)
+    agentsweep scan --all --detected
+                               scan only agents whose history root exists
     agentsweep fix  [opts]     redact (guided + confirmed on a terminal)
     agentsweep undo [opts]     restore .bak backups
     agentsweep purge [opts]    delete .bak backups (after rotating the keys)
@@ -165,8 +168,13 @@ def main(argv: list[str] | None = None) -> int:
 
         args = _parse_run(verb, rest)
         _background_update_notice(args)
-        from .pipeline import run
+        from .pipeline import run, run_all
         from .menu import offer_redaction
+
+        # Multi-source scan is read-only and has no interactive redact offer
+        # (fix stays per-source). Dispatch before the single-source path.
+        if getattr(args, "all", False):
+            return run_all(args)
 
         if verb == "fix" and not _interactive():
             args.fix = True  # script path: explicit gate flags required
@@ -210,7 +218,19 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
         prog=f"agentsweep {verb}",
         description="Find and redact secrets in AI coding agent histories.",
     )
-    _add_common(ap)
+    # default=None so we can tell "user passed --source" from the implicit
+    # default when validating mutual exclusion with --all.
+    ap.add_argument("--source", choices=list(SOURCES), default=None,
+                    help="Which agent's history (default: claude-code).")
+    ap.add_argument("--root", type=Path,
+                    help="Override the source's default root directory.")
+    ap.add_argument("--all", action="store_true",
+                    help="Scan every registered agent source and aggregate "
+                         "findings (scan only; not valid with fix).")
+    ap.add_argument("--detected", action="store_true",
+                    help="With --all, only scan sources whose history root "
+                         "exists on this machine (same signal as "
+                         "list-sources --detected).")
     ap.add_argument("-o", "--output", type=Path,
                     help="Write findings as JSON to this file instead of "
                          "flooding the terminal.")
@@ -227,6 +247,25 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
                     help="Allow --fix against the default production root.")
     args = ap.parse_args(rest)
     args.fix = (verb == "fix")
+
+    if args.all:
+        if args.source is not None:
+            ap.error("cannot use --source with --all")
+        if args.root is not None:
+            ap.error("cannot use --root with --all")
+        if args.fix:
+            ap.error(
+                "fix --all is not supported; "
+                "run: agentsweep fix --source <name>"
+            )
+        # Placeholder so any code that still reads args.source is safe.
+        args.source = "claude-code"
+    else:
+        if args.detected:
+            ap.error("--detected requires --all "
+                     "(or use: agentsweep list-sources --detected)")
+        if args.source is None:
+            args.source = "claude-code"
     return args
 
 

--- a/src/agentsweep/menu.py
+++ b/src/agentsweep/menu.py
@@ -213,24 +213,10 @@ def _run_numbered_menu(main) -> int:
 # ── Shared helpers ────────────────────────────────────────────────────────────
 
 def _scan_all_sources() -> None:
-    """Scan all registered sources; delegates to pipeline.run_all (CLI path)."""
-    import argparse
+    """Scan all registered sources via cli.main — no duplicated pipeline logic."""
+    from .cli import main
 
-    from .pipeline import run_all
-
-    run_all(argparse.Namespace(
-        all=True,
-        detected=False,
-        json=False,
-        fix=False,
-        no_ignore=False,
-        output=None,
-        source="claude-code",
-        root=None,
-        no_backup=False,
-        force=False,
-        allow_production=False,
-    ))
+    main(["scan", "--all"])
 
 
 def _ask_folder() -> Path | None:

--- a/src/agentsweep/menu.py
+++ b/src/agentsweep/menu.py
@@ -213,102 +213,24 @@ def _run_numbered_menu(main) -> int:
 # ── Shared helpers ────────────────────────────────────────────────────────────
 
 def _scan_all_sources() -> None:
-    """Scan all registered sources in parallel and display combined results."""
-    import sys
-    import time
-    from concurrent.futures import ThreadPoolExecutor, as_completed
+    """Scan all registered sources; delegates to pipeline.run_all (CLI path)."""
+    import argparse
 
-    from .sources import SOURCES
-    from .pipeline import _scan_file
-    from .scanner import ROTATION_GUIDANCE
+    from .pipeline import run_all
 
-    # Step 1: discover all source files in parallel
-    source_data: list = []
-
-    def _try_discover(item):
-        name, cls = item
-        try:
-            src = cls()
-            files = list(src.iter_files())
-            return name, src, files
-        except Exception:
-            return name, None, []
-
-    with ui.console.status("[dim]Discovering history files across all sources…[/]"):
-        with ThreadPoolExecutor(max_workers=min(10, len(SOURCES))) as pool:
-            for name, src, files in pool.map(_try_discover, list(SOURCES.items())):
-                if src and files:
-                    source_data.append((name, src, files))
-
-    total_files = sum(len(f) for _, _, f in source_data)
-    if total_files == 0:
-        print("No history files found for any source.", file=sys.stderr)
-        return
-
-    source_count = len(source_data)
-    ui.stage(1, "ok", "DISCOVER", f"{source_count} source(s)", f"{total_files} file(s)")
-
-    # Step 2: scan all files in parallel
-    findings_by_source: dict = {}
-    total_strings = 0
-    all_tasks = [(name, src, f) for name, src, files in source_data for f in files]
-
-    t0 = time.perf_counter()
-    with ThreadPoolExecutor(max_workers=8) as pool:
-        future_meta = {
-            pool.submit(_scan_file, src, f, None): (name, src)
-            for name, src, f in all_tasks
-        }
-        with ui.scan_progress(total_files) as progress:
-            for fut in as_completed(future_meta):
-                name, src = future_meta[fut]
-                try:
-                    path, items, sc, _, _trunc = fut.result()
-                except Exception:
-                    continue
-                total_strings += sc
-                progress.advance(ui.rel(path, src.root))
-                if items:
-                    findings_by_source.setdefault(name, {})[path] = items
-
-    elapsed = time.perf_counter() - t0
-    ui.stage(2, "ok", "SCAN", f"{total_files} file(s)", f"{total_strings} string(s)", f"{elapsed:.1f}s")
-
-    if not findings_by_source:
-        ui.stage(3, "ok", "FINDINGS", "no secrets found")
-        return
-
-    grand_total = sum(
-        len(items)
-        for fd in findings_by_source.values()
-        for items in fd.values()
-    )
-    ui.stage(3, "fail", "FINDINGS", f"{grand_total} secret(s) across {len(findings_by_source)} source(s)")
-
-    for src_name, found_by_file in findings_by_source.items():
-        src = next(s for n, s, _ in source_data if n == src_name)
-        src_total = sum(len(v) for v in found_by_file.values())
-        ui.warn_line(f"{src_name}: {src_total} secret(s)")
-        rows = [
-            (f.display, f.masked, path, ln)
-            for path, items in found_by_file.items()
-            for ln, _, _, f in items
-        ]
-        ui.findings_table(rows, src.root)
-
-    rules = sorted({
-        f.rule
-        for fd in findings_by_source.values()
-        for items in fd.values()
-        for _, _, _, f in items
-    })
-    rotation_items = [
-        (rule, ROTATION_GUIDANCE.get(rule, "rotate via the issuing provider"))
-        for rule in rules
-    ]
-    ui.rotation_panel(rotation_items)
-    ui.stage(4, "skip", "REDACT", "run: agentsweep fix --source <name>  to redact")
-    ui.stage(5, "warn", "ROTATE", "these keys are still live")
+    run_all(argparse.Namespace(
+        all=True,
+        detected=False,
+        json=False,
+        fix=False,
+        no_ignore=False,
+        output=None,
+        source="claude-code",
+        root=None,
+        no_backup=False,
+        force=False,
+        allow_production=False,
+    ))
 
 
 def _ask_folder() -> Path | None:

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -263,6 +263,169 @@ def list_sources(args) -> int:
     return 0
 
 
+def run_all(args) -> int:
+    """Scan every registered (or detected) source and aggregate findings.
+
+    Scan-only — redaction stays per-source via ``fix --source <name>``.
+
+    Exit codes: 0 clean / nothing scanned · 1 findings · 2 misuse (e.g. fix).
+    Missing roots are skipped (not errors), matching single-source "no files
+    under root → 0". ``--detected`` restricts to sources whose default root
+    exists (same signal as ``list-sources --detected``).
+    """
+    if getattr(args, "fix", False):
+        print(
+            "fix --all is not supported; "
+            "run: agentsweep fix --source <name>",
+            file=sys.stderr,
+        )
+        return 2
+
+    output: Path | None = _opt(args, "output")
+    detected_only = bool(getattr(args, "detected", False))
+    no_ignore = bool(_opt(args, "no_ignore"))
+
+    selected: list[tuple[str, Source]] = []
+    experimental: list[str] = []
+    for key, cls in SOURCES.items():
+        try:
+            src = cls()
+        except Exception:
+            continue
+        if detected_only and not src.root.exists():
+            continue
+        selected.append((key, src))
+        if getattr(src, "experimental", False):
+            experimental.append(getattr(src, "display_name", key))
+
+    if not selected:
+        msg = ("no agent history roots found on this machine"
+               if detected_only else "no sources available to scan")
+        print(msg, file=sys.stderr)
+        if args.json:
+            print("[]")
+        elif not args.json:
+            ui.banner(__version__)
+            ui.warn_line(msg)
+        return 0
+
+    if not args.json:
+        ui.banner(__version__)
+        if experimental:
+            ui.warn_line(
+                f"includes experimental source(s): {', '.join(experimental)} "
+                f"— history path/format not yet verified against a real install"
+            )
+
+    # Phase 1: discover files per source (no scan yet).
+    discovered: list[tuple[str, Source, list[Path]]] = []
+    for key, source in selected:
+        try:
+            files = list(source.iter_files())
+        except Exception:
+            files = []
+        if files:
+            discovered.append((key, source, files))
+
+    total_files = sum(len(f) for _, _, f in discovered)
+
+    if total_files == 0:
+        print("No history files found under any selected source", file=sys.stderr)
+        if args.json:
+            print("[]")
+        else:
+            ui.stage(1, "warn", "DISCOVER", f"{len(selected)} source(s)",
+                     "no history files", err=True)
+            ui.stage(2, "skip", "SCAN", "nothing to scan")
+            ui.stage(3, "ok", "FINDINGS", "no secrets found")
+            ui.stage(4, "skip", "REDACT", "nothing to redact")
+            ui.stage(5, "skip", "ROTATE", "nothing to rotate")
+            ui.contribute_line()
+        return 0
+
+    if not args.json:
+        ui.stage(1, "ok", "DISCOVER", f"{len(discovered)} source(s)",
+                 f"{total_files} file(s)")
+
+    # Phase 2: scan each source sequentially (inner pool still parallelizes files).
+    per_source: list[tuple[str, Source, list[Path], dict, int, int, list[Path]]] = []
+    total_strings = 0
+    total_suppressed = 0
+    total_truncated: list[Path] = []
+
+    t0 = time.perf_counter()
+    for key, source, files in discovered:
+        ignores = (ignore_mod.IgnoreSet() if no_ignore
+                   else ignore_mod.load([source.root, Path.cwd()]))
+        if args.json:
+            found_by_file, strings_scanned, suppressed, truncated = _scan(
+                source, files, ignores)
+        else:
+            with ui.scan_progress(len(files)) as progress:
+                found_by_file, strings_scanned, suppressed, truncated = _scan(
+                    source, files, ignores, progress)
+        per_source.append(
+            (key, source, files, found_by_file, strings_scanned, suppressed, truncated)
+        )
+        total_strings += strings_scanned
+        total_suppressed += suppressed
+        total_truncated.extend(truncated)
+    elapsed = time.perf_counter() - t0
+
+    if args.json:
+        payload: list[dict] = []
+        for _key, source, _files, found_by_file, _sc, _sup, _tr in per_source:
+            payload.extend(_json_payload(found_by_file, source))
+        return _emit_json_payload(payload, output, total_suppressed)
+
+    ui.stage(2, "ok", "SCAN", f"{total_files} file(s)",
+             f"{total_strings} string(s)", f"{elapsed:.1f}s")
+    if total_truncated:
+        ui.warn_line(
+            f"{len(total_truncated)} file(s) exceeded the "
+            f"{_MAX_FILE_SCAN_CHARS // 1_000_000}MB scan budget and were truncated"
+        )
+    if total_suppressed:
+        ui.warn_line(
+            f"{total_suppressed} finding(s) suppressed by .agentsweepignore"
+        )
+
+    dirty = [(k, s, fbf) for k, s, _files, fbf, _sc, _sup, _tr in per_source if fbf]
+    if not dirty:
+        ui.stage(3, "ok", "FINDINGS", "no secrets found")
+        ui.stage(4, "skip", "REDACT", "nothing to redact")
+        ui.stage(5, "skip", "ROTATE", "nothing to rotate")
+        ui.contribute_line()
+        return 0
+
+    grand = sum(len(items) for _k, _s, fbf in dirty for items in fbf.values())
+    ui.stage(3, "fail", "FINDINGS",
+             f"{grand} secret(s) across {len(dirty)} source(s)")
+
+    # Aggregate for rotation + optional -o file; show per-source tables.
+    combined: dict = {}
+    combined_payload: list[dict] = []
+    for key, source, fbf in dirty:
+        src_total = sum(len(v) for v in fbf.values())
+        ui.warn_line(f"{key}: {src_total} secret(s) under {source.root}")
+        _show_findings(fbf, source, output=None)
+        combined.update(fbf)
+        combined_payload.extend(_json_payload(fbf, source))
+
+    if output is not None:
+        _write_text(output, json.dumps(combined_payload, indent=2) + "\n")
+        ui.warn_line(f"{len(combined_payload)} finding(s) also written to {output}")
+
+    dirty_names = ", ".join(k for k, _s, _f in dirty)
+    ui.stage(4, "skip", "REDACT",
+             f"skipped — run: agentsweep fix --source <name>  "
+             f"(dirty: {dirty_names})")
+    ui.stage(5, "warn", "ROTATE", "these keys are still live")
+    ui.rotation_panel(_rotation_items(combined))
+    ui.contribute_line()
+    return 1
+
+
 def _suggest_paths(missing: Path) -> list[str]:
     """Typo forgiveness: close-matching sibling directory names."""
     parent = missing.parent
@@ -424,6 +587,7 @@ def _json_payload(found_by_file: dict, source: Source) -> list[dict]:
         relpath = ui.rel(path, source.root)
         for line_num, keypath, _val, finding in items:
             payload.append({
+                "source": source.name,
                 "fingerprint": ignore_mod.fingerprint(relpath, line_num, finding.rule),
                 "file": str(path),
                 "line": line_num,
@@ -435,11 +599,9 @@ def _json_payload(found_by_file: dict, source: Source) -> list[dict]:
     return payload
 
 
-def _output_json(found_by_file: dict, source: Source, output: Path | None,
-                 suppressed: int) -> int:
-    """Emit JSON. With -o (or a flood-risk tty) write to a file and keep
-    stdout/scrollback clean; otherwise print to stdout for piping."""
-    payload = _json_payload(found_by_file, source)
+def _emit_json_payload(payload: list[dict], output: Path | None,
+                       suppressed: int) -> int:
+    """Shared JSON emission for single- and multi-source scans."""
     code = 0 if not payload else 1
 
     if output is not None:
@@ -461,6 +623,14 @@ def _output_json(found_by_file: dict, source: Source, output: Path | None,
     if suppressed:
         print(f"({suppressed} suppressed by .agentsweepignore)", file=sys.stderr)
     return code
+
+
+def _output_json(found_by_file: dict, source: Source, output: Path | None,
+                 suppressed: int) -> int:
+    """Emit JSON. With -o (or a flood-risk tty) write to a file and keep
+    stdout/scrollback clean; otherwise print to stdout for piping."""
+    return _emit_json_payload(_json_payload(found_by_file, source),
+                              output, suppressed)
 
 
 def _show_findings(found_by_file: dict, source: Source,

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -273,7 +273,7 @@ def run_all(args) -> int:
     under root → 0". ``--detected`` restricts to sources whose default root
     exists (same signal as ``list-sources --detected``).
     """
-    if getattr(args, "fix", False):
+    if _opt(args, "fix", False):
         print(
             "fix --all is not supported; "
             "run: agentsweep fix --source <name>",
@@ -282,8 +282,9 @@ def run_all(args) -> int:
         return 2
 
     output: Path | None = _opt(args, "output")
-    detected_only = bool(getattr(args, "detected", False))
-    no_ignore = bool(_opt(args, "no_ignore"))
+    as_json = bool(_opt(args, "json", False))
+    detected_only = bool(_opt(args, "detected", False))
+    no_ignore = bool(_opt(args, "no_ignore", False))
 
     selected: list[tuple[str, Source]] = []
     experimental: list[str] = []
@@ -302,14 +303,14 @@ def run_all(args) -> int:
         msg = ("no agent history roots found on this machine"
                if detected_only else "no sources available to scan")
         print(msg, file=sys.stderr)
-        if args.json:
+        if as_json:
             print("[]")
-        elif not args.json:
+        else:
             ui.banner(__version__)
             ui.warn_line(msg)
         return 0
 
-    if not args.json:
+    if not as_json:
         ui.banner(__version__)
         if experimental:
             ui.warn_line(
@@ -317,21 +318,38 @@ def run_all(args) -> int:
                 f"— history path/format not yet verified against a real install"
             )
 
-    # Phase 1: discover files per source (no scan yet).
+    # Phase 1: discover files per source (stream status so large roots
+    # don't look hung — same contract as single-source run()).
     discovered: list[tuple[str, Source, list[Path]]] = []
-    for key, source in selected:
-        try:
-            files = list(source.iter_files())
-        except Exception:
-            files = []
-        if files:
-            discovered.append((key, source, files))
+    if as_json:
+        for key, source in selected:
+            try:
+                files = list(source.iter_files())
+            except Exception:
+                files = []
+            if files:
+                discovered.append((key, source, files))
+    else:
+        with ui.console.status("") as status:
+            for key, source in selected:
+                try:
+                    files: list[Path] = []
+                    for f in source.iter_files():
+                        files.append(f)
+                        status.update(
+                            f"[dim]Discovering[/] [bold]{key}[/bold]"
+                            f" … [yellow]{len(files):,}[/] file(s)"
+                        )
+                except Exception:
+                    files = []
+                if files:
+                    discovered.append((key, source, files))
 
     total_files = sum(len(f) for _, _, f in discovered)
 
     if total_files == 0:
         print("No history files found under any selected source", file=sys.stderr)
-        if args.json:
+        if as_json:
             print("[]")
         else:
             ui.stage(1, "warn", "DISCOVER", f"{len(selected)} source(s)",
@@ -343,39 +361,58 @@ def run_all(args) -> int:
             ui.contribute_line()
         return 0
 
-    if not args.json:
+    if not as_json:
         ui.stage(1, "ok", "DISCOVER", f"{len(discovered)} source(s)",
                  f"{total_files} file(s)")
 
-    # Phase 2: scan each source sequentially (inner pool still parallelizes files).
+    # Phase 2: scan sources sequentially; one shared progress bar over all
+    # files (inner _scan still parallelizes within a source).
     per_source: list[tuple[str, Source, list[Path], dict, int, int, list[Path]]] = []
     total_strings = 0
     total_suppressed = 0
     total_truncated: list[Path] = []
 
     t0 = time.perf_counter()
-    for key, source, files in discovered:
-        ignores = (ignore_mod.IgnoreSet() if no_ignore
-                   else ignore_mod.load([source.root, Path.cwd()]))
-        if args.json:
+    if as_json:
+        for key, source, files in discovered:
+            ignores = (ignore_mod.IgnoreSet() if no_ignore
+                       else ignore_mod.load([source.root, Path.cwd()]))
             found_by_file, strings_scanned, suppressed, truncated = _scan(
                 source, files, ignores)
-        else:
-            with ui.scan_progress(len(files)) as progress:
+            per_source.append(
+                (key, source, files, found_by_file, strings_scanned,
+                 suppressed, truncated)
+            )
+            total_strings += strings_scanned
+            total_suppressed += suppressed
+            total_truncated.extend(truncated)
+    else:
+        with ui.scan_progress(total_files) as progress:
+            for key, source, files in discovered:
+                ignores = (ignore_mod.IgnoreSet() if no_ignore
+                           else ignore_mod.load([source.root, Path.cwd()]))
                 found_by_file, strings_scanned, suppressed, truncated = _scan(
                     source, files, ignores, progress)
-        per_source.append(
-            (key, source, files, found_by_file, strings_scanned, suppressed, truncated)
-        )
-        total_strings += strings_scanned
-        total_suppressed += suppressed
-        total_truncated.extend(truncated)
+                per_source.append(
+                    (key, source, files, found_by_file, strings_scanned,
+                     suppressed, truncated)
+                )
+                total_strings += strings_scanned
+                total_suppressed += suppressed
+                total_truncated.extend(truncated)
     elapsed = time.perf_counter() - t0
 
-    if args.json:
+    if as_json:
         payload: list[dict] = []
         for _key, source, _files, found_by_file, _sc, _sup, _tr in per_source:
             payload.extend(_json_payload(found_by_file, source))
+        # Match single-source run(): scan-budget cap is reported, never silent.
+        if total_truncated:
+            print(
+                f"warning: {len(total_truncated)} file(s) exceeded the scan budget "
+                f"and were truncated",
+                file=sys.stderr,
+            )
         return _emit_json_payload(payload, output, total_suppressed)
 
     ui.stage(2, "ok", "SCAN", f"{total_files} file(s)",
@@ -402,26 +439,56 @@ def run_all(args) -> int:
     ui.stage(3, "fail", "FINDINGS",
              f"{grand} secret(s) across {len(dirty)} source(s)")
 
-    # Aggregate for rotation + optional -o file; show per-source tables.
-    combined: dict = {}
+    # Display tables per source without writing the fixed overflow report
+    # path (that would clobber across sources). One aggregated report after.
     combined_payload: list[dict] = []
+    any_source_capped = False
+    rows_shown = 0
+    on_tty = ui.console.is_terminal
     for key, source, fbf in dirty:
         src_total = sum(len(v) for v in fbf.values())
         ui.warn_line(f"{key}: {src_total} secret(s) under {source.root}")
-        _show_findings(fbf, source, output=None)
-        combined.update(fbf)
+        rows = _table_rows(fbf)
+        remaining_budget = max(0, MAX_TABLE_ROWS - rows_shown) if on_tty else len(rows)
+        if on_tty and (len(rows) > remaining_budget or remaining_budget == 0):
+            any_source_capped = True
+            if remaining_budget > 0:
+                ui.findings_table(rows[:remaining_budget], source.root)
+                rows_shown += remaining_budget
+                ui.warn_line(
+                    f"{key}: …and {len(rows) - remaining_budget} more "
+                    f"(full multi-source list written after all sources)"
+                )
+            else:
+                ui.warn_line(
+                    f"{key}: {src_total} secret(s) omitted from table "
+                    f"(global cap {MAX_TABLE_ROWS}; see full report)"
+                )
+        else:
+            ui.findings_table(rows, source.root)
+            rows_shown += len(rows)
         combined_payload.extend(_json_payload(fbf, source))
 
+    # Single overflow destination: -o JSON if given, else one text report
+    # that includes every source (never per-source clobber of DEFAULT_REPORT).
+    needs_overflow = on_tty and (any_source_capped or grand > MAX_TABLE_ROWS)
     if output is not None:
         _write_text(output, json.dumps(combined_payload, indent=2) + "\n")
         ui.warn_line(f"{len(combined_payload)} finding(s) also written to {output}")
+    elif needs_overflow:
+        report = Path.cwd() / DEFAULT_REPORT_NAME
+        _write_text(report, _text_report_multi(combined_payload))
+        ui.warn_line(
+            f"full multi-source findings ({grand}) written to {report}"
+        )
 
     dirty_names = ", ".join(k for k, _s, _f in dirty)
     ui.stage(4, "skip", "REDACT",
              f"skipped — run: agentsweep fix --source <name>  "
              f"(dirty: {dirty_names})")
     ui.stage(5, "warn", "ROTATE", "these keys are still live")
-    ui.rotation_panel(_rotation_items(combined))
+    # Flatten across sources — do not merge by Path (collisions across roots).
+    ui.rotation_panel(_rotation_items_multi(dirty))
     ui.contribute_line()
     return 1
 
@@ -581,6 +648,22 @@ def _rotation_items(found_by_file: dict) -> list[tuple[str, str]]:
     ]
 
 
+def _rotation_items_multi(
+    dirty: list[tuple[str, Source, dict]],
+) -> list[tuple[str, str]]:
+    """Union of rotation guidance across sources (Path-merge-safe)."""
+    rules = sorted({
+        finding.rule
+        for _key, _source, fbf in dirty
+        for items in fbf.values()
+        for _, _, _, finding in items
+    })
+    return [
+        (rule, ROTATION_GUIDANCE.get(rule, "rotate via the issuing provider"))
+        for rule in rules
+    ]
+
+
 def _json_payload(found_by_file: dict, source: Source) -> list[dict]:
     payload = []
     for path, items in found_by_file.items():
@@ -666,6 +749,19 @@ def _text_report(found_by_file: dict, source: Source) -> str:
         lines.append(f"    {item['display']}  {item['masked']}")
     lines.append("")
     lines.append("Rotate these — see the provider URLs printed by the scan.")
+    return "\n".join(lines) + "\n"
+
+
+def _text_report_multi(payload: list[dict]) -> str:
+    """Aggregated human report for scan --all (includes source on every row)."""
+    lines = ["agentsweep findings report (all sources)", ""]
+    for item in payload:
+        src = item.get("source", "?")
+        lines.append(f"[{src}] {item['fingerprint']}")
+        lines.append(f"    {item['display']}  {item['masked']}")
+    lines.append("")
+    lines.append("Rotate these — see the provider URLs printed by the scan.")
+    lines.append("Redact per source: agentsweep fix --source <name>")
     return "\n".join(lines) + "\n"
 
 

--- a/src/agentsweep/tips.py
+++ b/src/agentsweep/tips.py
@@ -11,6 +11,7 @@ TIPS: list[str] = [
     "agentsweep --json pipes clean JSON into jq or any downstream tool",
     "Type REDACT to confirm in-place redaction — backups are always kept",
     "agentsweep scan --source codex scans your OpenAI Codex history too",
+    "agentsweep scan --all aggregates every agent; --detected limits to installed ones",
     "Seed phrases are validated by BIP-39 checksum, so prose never false-positives",
     "Set AGENTSWEEP_NO_ANIM=1 to disable animations and the live progress bar",
     "Use --root /path/to/copy to scan an offline archive without touching production",

--- a/tests/test_scan_all.py
+++ b/tests/test_scan_all.py
@@ -12,19 +12,27 @@ Covers:
   (i) ignore file suppresses only the source it sits under
   (j) single-source scan still works and includes "source" field
   (k) legacy form: agentsweep --all --json
+  (l) multi-source overflow report is aggregated (not clobbered per source)
+  (m) scan --all --json emits truncation warning on stderr
+  (n) menu._scan_all_sources shells out via cli.main(["scan", "--all"])
+  (o) -o with multi-source overflow does not write agentsweep-report.txt
 """
 from __future__ import annotations
 
 import json
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
+from agentsweep import pipeline  # noqa: E402
+from agentsweep import menu as menu_mod  # noqa: E402
 from agentsweep.cli import main  # noqa: E402
 from agentsweep.sources import SOURCES  # noqa: E402
+from rich.console import Console  # noqa: E402
 
 AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
 GH_TOKEN = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
@@ -308,3 +316,110 @@ def test_scan_all_sources_order_stable(_isolate_env, capsys):
             seen.append(item["source"])
     registered = [k for k in SOURCES if k in seen]
     assert seen == registered
+
+
+# ---------------------------------------------------------------------------
+# (l) multi-source overflow report is not clobbered
+# ---------------------------------------------------------------------------
+
+def _seed_many_claude(home: Path, n: int) -> None:
+    root = home / ".claude" / "projects"
+    root.mkdir(parents=True, exist_ok=True)
+    for i in range(n):
+        (root / f"session_{i}.jsonl").write_text(CLAUDE_LINE, encoding="utf-8")
+
+
+def _seed_many_codex(home: Path, n: int) -> None:
+    root = home / ".codex" / "sessions" / "2026" / "01" / "01"
+    root.mkdir(parents=True, exist_ok=True)
+    for i in range(n):
+        (root / f"rollout-{i}.jsonl").write_text(CODEX_LINE, encoding="utf-8")
+
+
+def test_scan_all_overflow_report_includes_all_sources(
+    _isolate_env, tmp_path, monkeypatch, capsys,
+):
+    """Two large sources must not clobber agentsweep-report.txt to last-only."""
+    _seed_many_claude(_isolate_env, 45)
+    _seed_many_codex(_isolate_env, 45)
+    monkeypatch.chdir(tmp_path)
+
+    with patch.object(
+        Console, "is_terminal", new_callable=lambda: property(lambda self: True)
+    ):
+        code = main(["scan", "--all"])
+        captured = capsys.readouterr()
+
+    assert code == 1
+    report = tmp_path / pipeline.DEFAULT_REPORT_NAME
+    assert report.exists(), "aggregated overflow report must be written once"
+    text = report.read_text(encoding="utf-8")
+    assert "[claude-code]" in text
+    assert "[codex]" in text
+    assert "all sources" in text.lower()
+    # Raw secrets never land in the report
+    assert AWS_KEY not in text
+    assert GH_TOKEN not in text
+    combined = captured.out + captured.err
+    assert report.name in combined or "full multi-source" in combined.lower()
+
+
+def test_scan_all_overflow_with_dash_o_skips_default_report(
+    _isolate_env, tmp_path, monkeypatch, capsys,
+):
+    """When -o is set, full JSON goes there — no agentsweep-report.txt clobber path."""
+    _seed_many_claude(_isolate_env, 45)
+    _seed_many_codex(_isolate_env, 45)
+    monkeypatch.chdir(tmp_path)
+    out_file = tmp_path / "multi.json"
+
+    with patch.object(
+        Console, "is_terminal", new_callable=lambda: property(lambda self: True)
+    ):
+        code = main(["scan", "--all", "-o", str(out_file)])
+
+    assert code == 1
+    assert out_file.exists()
+    payload = json.loads(out_file.read_text(encoding="utf-8"))
+    sources = {item["source"] for item in payload}
+    assert "claude-code" in sources and "codex" in sources
+    assert not (tmp_path / pipeline.DEFAULT_REPORT_NAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# (m) JSON truncation warning
+# ---------------------------------------------------------------------------
+
+def test_scan_all_json_emits_truncation_warning(_isolate_env, monkeypatch, capsys):
+    """scan --all --json must stderr-warn when the scan budget truncates files."""
+    _seed_claude(_isolate_env)
+    # Tiny budget forces every non-empty string walk to truncate.
+    monkeypatch.setattr(pipeline, "_MAX_FILE_SCAN_CHARS", 1)
+
+    code = main(["scan", "--all", "--json"])
+    captured = capsys.readouterr()
+
+    # May be 0 or 1 depending on whether any secret fit before the cap;
+    # the contract under test is the warning, not the findings.
+    assert code in (0, 1)
+    assert "truncated" in captured.err.lower()
+    assert "scan budget" in captured.err.lower()
+    # stdout still parseable JSON
+    json.loads(captured.out)
+
+
+# ---------------------------------------------------------------------------
+# (n) menu uses cli.main
+# ---------------------------------------------------------------------------
+
+def test_menu_scan_all_shells_out_to_cli_main(monkeypatch):
+    """_scan_all_sources must call cli.main(['scan', '--all']), not hand-roll args."""
+    seen: list[list[str]] = []
+
+    def fake_main(argv=None):
+        seen.append(list(argv or []))
+        return 0
+
+    monkeypatch.setattr("agentsweep.cli.main", fake_main)
+    menu_mod._scan_all_sources()
+    assert seen == [["scan", "--all"]]

--- a/tests/test_scan_all.py
+++ b/tests/test_scan_all.py
@@ -1,0 +1,310 @@
+"""Tests for `agentsweep scan --all` multi-source aggregated scanning.
+
+Covers:
+  (a) empty HOME → exit 0, JSON []
+  (b) one seeded source → exit 1, findings tagged with that source
+  (c) two seeded sources → findings from both, distinguished by "source"
+  (d) --all --detected only visits roots that exist
+  (e) --all + --source / --root / fix --all rejected
+  (f) --detected without --all rejected
+  (g) human mode stages + no raw secrets
+  (h) --json -o writes aggregated file, clean stdout
+  (i) ignore file suppresses only the source it sits under
+  (j) single-source scan still works and includes "source" field
+  (k) legacy form: agentsweep --all --json
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.cli import main  # noqa: E402
+from agentsweep.sources import SOURCES  # noqa: E402
+
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+GH_TOKEN = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+
+CLAUDE_LINE = (
+    '{"type":"user","message":{"content":[{"type":"text",'
+    f'"text":"aws key={AWS_KEY}"}}]}}}}\n'
+)
+CODEX_LINE = (
+    '{"type":"message","role":"user","content":'
+    f'"token {GH_TOKEN}"}}\n'
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(tmp_path, monkeypatch):
+    """Isolate HOME and Windows/XDG dirs so multi-source discovery is hermetic."""
+    home = tmp_path / "home"
+    home.mkdir()
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    appdata = tmp_path / "appdata"
+    appdata.mkdir()
+    local = tmp_path / "localappdata"
+    local.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg / "share"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg / "config"))
+    monkeypatch.setenv("APPDATA", str(appdata))
+    monkeypatch.setenv("LOCALAPPDATA", str(local))
+    monkeypatch.setenv("AGENTSWEEP_NO_UPDATE", "1")
+    return home
+
+
+def _seed_claude(home: Path, content: str = CLAUDE_LINE) -> Path:
+    root = home / ".claude" / "projects"
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / "session.jsonl"
+    path.write_text(content, encoding="utf-8")
+    return root
+
+
+def _seed_codex(home: Path, content: str = CODEX_LINE) -> Path:
+    # CodexSource walks ~/.codex (sessions + root jsonl files).
+    root = home / ".codex"
+    sess = root / "sessions" / "2026" / "01" / "01"
+    sess.mkdir(parents=True, exist_ok=True)
+    (sess / "rollout-test.jsonl").write_text(content, encoding="utf-8")
+    return root
+
+
+def _scan_all_json(extra=None, capsys=None):
+    argv = ["scan", "--all", "--json"] + (extra or [])
+    code = main(argv)
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out) if captured.out.strip() else []
+    return code, payload, captured.err
+
+
+# ---------------------------------------------------------------------------
+# (a) empty
+# ---------------------------------------------------------------------------
+
+def test_scan_all_empty_home_is_clean(capsys):
+    code, payload, _err = _scan_all_json(capsys=capsys)
+    assert code == 0
+    assert payload == []
+
+
+def test_scan_all_detected_empty_is_clean(capsys):
+    code = main(["scan", "--all", "--detected", "--json"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert json.loads(out) == []
+
+
+# ---------------------------------------------------------------------------
+# (b) single seeded source
+# ---------------------------------------------------------------------------
+
+def test_scan_all_one_source_tags_findings(_isolate_env, capsys):
+    _seed_claude(_isolate_env)
+    code, payload, _err = _scan_all_json(capsys=capsys)
+    assert code == 1
+    assert payload
+    assert all(item["source"] == "claude-code" for item in payload)
+    assert any(item["rule"] for item in payload)
+    raw = json.dumps(payload)
+    assert AWS_KEY not in raw
+
+
+# ---------------------------------------------------------------------------
+# (c) two sources
+# ---------------------------------------------------------------------------
+
+def test_scan_all_two_sources_aggregate(_isolate_env, capsys):
+    _seed_claude(_isolate_env)
+    _seed_codex(_isolate_env)
+    code, payload, _err = _scan_all_json(capsys=capsys)
+    assert code == 1
+    sources = {item["source"] for item in payload}
+    assert "claude-code" in sources
+    assert "codex" in sources
+    # Each finding has the additive schema fields.
+    for item in payload:
+        assert "source" in item
+        assert "fingerprint" in item
+        assert "rule" in item
+        assert "masked" in item
+        assert "file" in item
+        assert "line" in item
+        assert "keypath" in item
+        assert "display" in item
+
+
+# ---------------------------------------------------------------------------
+# (d) --detected
+# ---------------------------------------------------------------------------
+
+def test_scan_all_detected_skips_absent_roots(_isolate_env, capsys):
+    # Only claude-code root exists; codex is absent.
+    _seed_claude(_isolate_env)
+    code, payload, _err = _scan_all_json(extra=["--detected"], capsys=capsys)
+    assert code == 1
+    assert payload
+    assert all(item["source"] == "claude-code" for item in payload)
+    assert not any(item["source"] == "codex" for item in payload)
+
+
+def test_scan_all_detected_includes_both_when_present(_isolate_env, capsys):
+    _seed_claude(_isolate_env)
+    _seed_codex(_isolate_env)
+    code, payload, _err = _scan_all_json(extra=["--detected"], capsys=capsys)
+    assert code == 1
+    sources = {item["source"] for item in payload}
+    assert sources >= {"claude-code", "codex"}
+
+
+# ---------------------------------------------------------------------------
+# (e) / (f) flag rejection
+# ---------------------------------------------------------------------------
+
+def test_scan_all_rejects_source_flag():
+    with pytest.raises(SystemExit) as ei:
+        main(["scan", "--all", "--source", "codex"])
+    assert ei.value.code == 2
+
+
+def test_scan_all_rejects_root_flag(tmp_path):
+    with pytest.raises(SystemExit) as ei:
+        main(["scan", "--all", "--root", str(tmp_path)])
+    assert ei.value.code == 2
+
+
+def test_fix_all_rejected():
+    with pytest.raises(SystemExit) as ei:
+        main(["fix", "--all"])
+    assert ei.value.code == 2
+
+
+def test_detected_without_all_rejected():
+    with pytest.raises(SystemExit) as ei:
+        main(["scan", "--detected"])
+    assert ei.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# (g) human mode
+# ---------------------------------------------------------------------------
+
+def test_scan_all_human_mode_stages(_isolate_env, capsys):
+    _seed_claude(_isolate_env)
+    _seed_codex(_isolate_env)
+    code = main(["scan", "--all"])
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "DISCOVER" in out
+    assert "SCAN" in out
+    assert "FINDINGS" in out
+    assert "claude-code" in out
+    assert "codex" in out
+    assert AWS_KEY not in out
+    assert GH_TOKEN not in out
+    # Points at per-source fix, not fix --all
+    assert "fix --source" in out
+
+
+def test_scan_all_human_clean(_isolate_env, capsys):
+    # Empty roots that exist but have no history files still clean.
+    (_isolate_env / ".claude" / "projects").mkdir(parents=True)
+    code = main(["scan", "--all", "--detected"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "no secrets" in out.lower() or "FINDINGS" in out
+
+
+# ---------------------------------------------------------------------------
+# (h) -o file
+# ---------------------------------------------------------------------------
+
+def test_scan_all_json_output_file(_isolate_env, tmp_path, capsys):
+    _seed_claude(_isolate_env)
+    out_file = tmp_path / "all-findings.json"
+    code = main(["scan", "--all", "--json", "-o", str(out_file)])
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out.strip() == ""
+    assert out_file.exists()
+    payload = json.loads(out_file.read_text(encoding="utf-8"))
+    assert payload
+    assert all(item["source"] == "claude-code" for item in payload)
+    assert AWS_KEY not in out_file.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# (i) ignore per source
+# ---------------------------------------------------------------------------
+
+def test_scan_all_respects_per_source_ignore(_isolate_env, capsys):
+    claude_root = _seed_claude(_isolate_env)
+    _seed_codex(_isolate_env)
+    # Suppress everything under claude-code via fingerprint-style ignore of rule.
+    # .agentsweepignore supports rule names — suppress aws-access-key only there.
+    (claude_root / ".agentsweepignore").write_text(
+        "rule:aws-access-key\n", encoding="utf-8"
+    )
+    code, payload, _err = _scan_all_json(capsys=capsys)
+    # Codex finding should remain; claude aws may be suppressed.
+    sources = {item["source"] for item in payload}
+    assert "codex" in sources
+    assert "claude-code" not in sources or not any(
+        i["source"] == "claude-code" and "aws" in i["rule"] for i in payload
+    )
+
+
+# ---------------------------------------------------------------------------
+# (j) single-source regression — source field present
+# ---------------------------------------------------------------------------
+
+def test_single_source_json_includes_source_field(tmp_path, capsys):
+    root = tmp_path / "history"
+    root.mkdir()
+    (root / "session.jsonl").write_text(CLAUDE_LINE, encoding="utf-8")
+    code = main(["scan", "--root", str(root), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert payload
+    assert all(item.get("source") == "claude-code" for item in payload)
+
+
+def test_single_source_default_still_works(_isolate_env, capsys):
+    _seed_claude(_isolate_env)
+    code = main(["scan", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert all(item["source"] == "claude-code" for item in payload)
+
+
+# ---------------------------------------------------------------------------
+# (k) legacy flag form
+# ---------------------------------------------------------------------------
+
+def test_legacy_all_json_form(_isolate_env, capsys):
+    _seed_claude(_isolate_env)
+    code = main(["--all", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert payload
+    assert all(item["source"] == "claude-code" for item in payload)
+
+
+def test_scan_all_sources_order_stable(_isolate_env, capsys):
+    """Findings sources appear in SOURCES registration order, not random."""
+    _seed_claude(_isolate_env)
+    _seed_codex(_isolate_env)
+    _code, payload, _err = _scan_all_json(capsys=capsys)
+    seen = []
+    for item in payload:
+        if item["source"] not in seen:
+            seen.append(item["source"])
+    registered = [k for k in SOURCES if k in seen]
+    assert seen == registered


### PR DESCRIPTION
## What

Adds **`agentsweep scan --all`** — multi-source aggregated scanning with a stable JSON contract.

```bash
agentsweep scan --all
agentsweep scan --all --detected
agentsweep scan --all --json
agentsweep scan --all --json -o findings.json
```

## Why

29 agents, one `--source` at a time is friction. Menu already had a multi-scan path; CLI did not. This makes multi-source scan scriptable and pairs with `list-sources --detected`.

## Behavior

| Flag combo | Result |
|---|---|
| `scan --all` | Every registered source (missing roots skipped) |
| `scan --all --detected` | Only sources whose default root exists |
| `scan --all --json` | Array of findings; each has `"source"` |
| `fix --all` | **Rejected** — redaction stays per-source |
| `--all` + `--source` / `--root` | argparse error |

- Exit codes unchanged: **0** clean · **1** findings · **2** misuse
- Single-source JSON gains additive `"source"` field (backward compatible for consumers that only read known keys)
- Per-source `.agentsweepignore` loading preserved
- Interactive menu "scan all" now calls `pipeline.run_all` (one path)

## Out of scope

`fix --all` deferred (production/process gates, multi-root blast radius). Dirty sources print `agentsweep fix --source <name>`.

## Testing

- New `tests/test_scan_all.py` — 18 cases (empty, one/two sources, detected filter, flag rejection, human stages, `-o`, ignore, single-source regression, legacy `--all`)
- Full suite: **447 passed, 10 skipped**
- `ruff check` clean on touched files

## Type of change

- [x] Feature / enhancement
- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule

## Checklist

- [x] `pytest` passes locally
- [x] No real secrets in commits (synthetic AWS/GitHub fixtures only)
- [x] Write path / redactor untouched
- [x] README + tip updated
