### PR TITLE
fix: bound Aider discovery so scans do not walk the entire home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ agentsweep scan --source codex                # ~/.codex/sessions/
 agentsweep scan --source opencode             # OpenCode SQLite store
 agentsweep scan --source cursor               # Cursor history
 agentsweep scan --source windsurf             # Windsurf history
-agentsweep scan --source aider                # ~/.aider/
+agentsweep scan --source aider                # per-repo .aider.chat.history.md under $HOME
 agentsweep scan --source cline                # Cline history
 agentsweep scan --source gemini-cli           # Gemini CLI history
 agentsweep scan --source continue-vscode      # Continue (VS Code) history

--- a/docs/PERF.md
+++ b/docs/PERF.md
@@ -14,6 +14,12 @@ multi-MB embedded transcripts), so per-byte and per-string costs both matter.
 - **Mnemonic gate.** `detect_mnemonics` returns early when a string has
   fewer than 11 word separators — it cannot hold a 12-word phrase — so big
   tokenless blobs (base64, minified JS, long paths) skip tokenization.
+- **Single-pass Aho-Corasick anchors.** `pyahocorasick` collapses per-string
+  prefilter checks into one O(n) pass (substring fallback if the wheel is
+  absent). See `scanner.py:_triggered_indices`.
+- **Aider discovery prune.** Default Aider scans no longer `rglob` the
+  entire home tree. Junk dirs (`node_modules`, `.git`, `AppData`, …) are
+  skipped and depth is capped. See `sources._core._iter_aider_histories`.
 
 ## Evaluated and dropped
 
@@ -27,9 +33,5 @@ multi-MB embedded transcripts), so per-byte and per-string costs both matter.
 
 ## Open levers (under research)
 
-- **Single-pass keyword matcher (Aho-Corasick).** Collapse the 189
-  per-string prefilter checks into one scan. Must handle overlapping
-  literals correctly (`git` vs `gitlab`), which a single `re` alternation
-  does not — needs an automaton (`pyahocorasick`) or careful dedup.
 - **Native multi-pattern engines** (`google-re2`, `hyperscan`) — large
   speedups but a portability/packaging cost (Windows wheels?).

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -217,17 +217,16 @@ def redact_findings(args, source: Source, found_by_file: dict, *,
 def _source_rows() -> list[dict]:
     """Describe every registered source: key, name, default root, detection.
 
-    ``detected`` is True when the source's default history root exists on this
-    machine — a cheap, deterministic install signal (no directory walk, no file
-    reads). Instantiating a source only computes its default_root(); it never
-    touches history contents, so this stays fast and side-effect free.
+    ``detected`` comes from ``Source.is_detected()`` (default: history root
+    exists). Most sources stay O(1). Aider overrides this because its root is
+    the home directory, which always exists.
     """
     rows: list[dict] = []
     for key, cls in SOURCES.items():
         try:
             src = cls()
             root = src.root
-            detected = root.exists()
+            detected = src.is_detected()
         except Exception:
             root, detected = None, False
         rows.append({
@@ -270,8 +269,8 @@ def run_all(args) -> int:
 
     Exit codes: 0 clean / nothing scanned · 1 findings · 2 misuse (e.g. fix).
     Missing roots are skipped (not errors), matching single-source "no files
-    under root → 0". ``--detected`` restricts to sources whose default root
-    exists (same signal as ``list-sources --detected``).
+    under root → 0". ``--detected`` restricts to sources that report history
+    on this machine (same signal as ``list-sources --detected``).
     """
     if _opt(args, "fix", False):
         print(
@@ -293,7 +292,7 @@ def run_all(args) -> int:
             src = cls()
         except Exception:
             continue
-        if detected_only and not src.root.exists():
+        if detected_only and not src.is_detected():
             continue
         selected.append((key, src))
         if getattr(src, "experimental", False):

--- a/src/agentsweep/sources/_base.py
+++ b/src/agentsweep/sources/_base.py
@@ -100,6 +100,15 @@ class Source(ABC):
         """
         return [self.root]
 
+    def is_detected(self) -> bool:
+        """Cheap install signal for list-sources / scan --all --detected.
+
+        Default: the source's default history root exists on this machine.
+        Sources whose root is always present (e.g. Path.home()) override
+        this so detection reflects real history, not a universal path.
+        """
+        return self.root.exists()
+
 
 class JsonlSource(Source):
     """Shared implementation for agents that store history as JSONL files."""

--- a/src/agentsweep/sources/_core.py
+++ b/src/agentsweep/sources/_core.py
@@ -219,11 +219,50 @@ class OpenCodeSource(Source):
             pairs.extend((table, c) for c in present)
         return pairs
 
+# Directory basenames never descended into when looking for Aider histories.
+# Aider writes `.aider.chat.history.md` at project/repo roots, so vendor trees,
+# VCS metadata, tool caches, and OS profile junk are pure noise — and walking
+# them from $HOME is what made default `scan --source aider` thrash disks.
+_AIDER_SKIP_DIRS: frozenset[str] = frozenset({
+    ".git",
+    "node_modules",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".tox",
+    ".nox",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".cache",
+    ".npm",
+    ".yarn",
+    ".pnpm-store",
+    ".cargo",
+    ".rustup",
+    ".Trash",
+    "Trash",
+    # OS profile trees full of caches, not project roots.
+    "AppData",
+    "Library",
+    # Linux XDG data/cache homes (not where Aider drops chat history).
+    ".local",
+    ".config",
+})
+
+_AIDER_HISTORY_NAME = ".aider.chat.history.md"
+# Soft cap from the discovery root. Aider histories live at repo roots, not
+# deep inside nested vendor trees. Users with odd layouts can pass --root.
+_AIDER_MAX_DEPTH = 12
+
+
 class AiderSource(Source):
     """Aider CLI — per-repo Markdown history files named .aider.chat.history.md.
 
     Aider places one file in the root of each git repo (or CWD) the user works
-    in. There is no central history directory, so we rglob from Path.home().
+    in. There is no central history directory, so discovery walks from
+    Path.home() (or an explicit --root), pruning junk directories and capping
+    depth so a default scan does not walk the entire home tree.
     """
 
     name = "aider"
@@ -238,18 +277,21 @@ class AiderSource(Source):
         return Path.home()
 
     def files(self) -> list[Path]:
-        if not self.root.exists():
-            return []
-        return sorted(
-            p for p in self.root.rglob(".aider.chat.history.md") if p.is_file()
-        )
+        return sorted(self.iter_files())
 
     def iter_files(self) -> Iterator[Path]:
-        if not self.root.exists():
-            return
-        for p in self.root.rglob(".aider.chat.history.md"):
-            if p.is_file():
-                yield p
+        yield from _iter_aider_histories(self.root)
+
+    def is_detected(self) -> bool:
+        # Home always exists, so root.exists() would always report Aider as
+        # installed. Prefer cheap config markers, then an early-exit pruned walk.
+        home = Path.home()
+        for name in (".aider.conf.yml", ".aider.conf.yaml", ".aider.conf.json"):
+            if (home / name).is_file():
+                return True
+        for _ in self.iter_files():
+            return True
+        return False
 
     def iter_strings(self, path: Path) -> Iterator[tuple[int, KeyPath, str]]:
         yield from _iter_plaintext_lines(path)
@@ -263,3 +305,36 @@ class AiderSource(Source):
 
     def content_format(self, path: Path) -> str:
         return "text"
+
+
+def _iter_aider_histories(root: Path) -> Iterator[Path]:
+    """Yield Aider chat histories under root with junk dirs pruned."""
+    if not root.exists():
+        return
+    root = root.resolve()
+
+    def _onerror(_err: OSError) -> None:
+        # Permission / reparse-point noise under $HOME is expected. Skip and
+        # keep walking the rest of the tree.
+        return
+
+    # os.walk so we can mutate dirs in place and skip huge subtrees.
+    for dirpath, dirnames, filenames in os.walk(
+        root, topdown=True, onerror=_onerror,
+    ):
+        # Depth relative to root (root itself is depth 0).
+        try:
+            rel = Path(dirpath).resolve().relative_to(root)
+            depth = 0 if str(rel) == "." else len(rel.parts)
+        except ValueError:
+            # Walked outside root (symlink / mount edge case). Stop descending.
+            dirnames.clear()
+            continue
+        if depth >= _AIDER_MAX_DEPTH:
+            dirnames.clear()
+        else:
+            dirnames[:] = [d for d in dirnames if d not in _AIDER_SKIP_DIRS]
+        if _AIDER_HISTORY_NAME in filenames:
+            p = Path(dirpath) / _AIDER_HISTORY_NAME
+            if p.is_file():
+                yield p

--- a/src/agentsweep/sources/_core.py
+++ b/src/agentsweep/sources/_core.py
@@ -219,10 +219,9 @@ class OpenCodeSource(Source):
             pairs.extend((table, c) for c in present)
         return pairs
 
-# Directory basenames never descended into when looking for Aider histories.
-# Aider writes `.aider.chat.history.md` at project/repo roots, so vendor trees,
-# VCS metadata, tool caches, and OS profile junk are pure noise — and walking
-# them from $HOME is what made default `scan --source aider` thrash disks.
+# Vendor / VCS / build-cache dirs — never an Aider repo root, so they are
+# pruned at ANY depth. A directory with one of these names holds tooling, not
+# a project the user ran Aider in, so dropping it can't hide a real history.
 _AIDER_SKIP_DIRS: frozenset[str] = frozenset({
     ".git",
     "node_modules",
@@ -240,19 +239,30 @@ _AIDER_SKIP_DIRS: frozenset[str] = frozenset({
     ".pnpm-store",
     ".cargo",
     ".rustup",
-    ".Trash",
-    "Trash",
-    # OS profile trees full of caches, not project roots.
+})
+
+# OS-profile trees (caches, not project roots) — pruned ONLY when they sit
+# directly under $HOME. Unlike the vendor set, these are ordinary words a real
+# project directory can legitimately be named ("Library", "AppData", "Trash"),
+# so pruning them at any depth silently dropped real histories — a secret
+# scanner reporting a false all-clear. `.config` is deliberately NOT here:
+# people keep git-tracked dotfiles (e.g. ~/.config/nvim) there and run Aider in
+# them, so it must be walked; the depth cap + vendor set above bound the cost.
+# ponytail: home-top-only prune, not per-name cache-child pruning. If ~/.config
+# on some box (large browser profiles) makes a scan slow, add the specific
+# cache-child dir names — don't re-blanket-prune .config and lose real repos.
+_AIDER_SKIP_DIRS_HOME_TOP: frozenset[str] = frozenset({
     "AppData",
     "Library",
-    # Linux XDG data/cache homes (not where Aider drops chat history).
+    ".Trash",
+    "Trash",
     ".local",
-    ".config",
 })
 
 _AIDER_HISTORY_NAME = ".aider.chat.history.md"
 # Soft cap from the discovery root. Aider histories live at repo roots, not
 # deep inside nested vendor trees. Users with odd layouts can pass --root.
+# Hitting the cap is surfaced on stderr (never silent) — see below.
 _AIDER_MAX_DEPTH = 12
 
 
@@ -280,16 +290,18 @@ class AiderSource(Source):
         return sorted(self.iter_files())
 
     def iter_files(self) -> Iterator[Path]:
-        yield from _iter_aider_histories(self.root)
+        # warn=True: this is the scan path, so a reached depth cap is surfaced.
+        yield from _iter_aider_histories(self.root, warn=True)
 
     def is_detected(self) -> bool:
         # Home always exists, so root.exists() would always report Aider as
         # installed. Prefer cheap config markers, then an early-exit pruned walk.
+        # warn=False: detection / list-sources must not print scan-time warnings.
         home = Path.home()
         for name in (".aider.conf.yml", ".aider.conf.yaml", ".aider.conf.json"):
             if (home / name).is_file():
                 return True
-        for _ in self.iter_files():
+        for _ in _iter_aider_histories(self.root, warn=False):
             return True
         return False
 
@@ -307,11 +319,21 @@ class AiderSource(Source):
         return "text"
 
 
-def _iter_aider_histories(root: Path) -> Iterator[Path]:
-    """Yield Aider chat histories under root with junk dirs pruned."""
+def _iter_aider_histories(root: Path, *, warn: bool = False) -> Iterator[Path]:
+    """Yield Aider chat histories under root with junk dirs pruned.
+
+    Vendor/cache dirs are pruned at any depth; OS-profile dirs only when they
+    sit directly under $HOME (so a project named "Library" or a dotfiles repo
+    under ~/.config is still scanned). Descent stops at _AIDER_MAX_DEPTH; when
+    that happens and ``warn`` is True (the scan path, not detection), a one-line
+    stderr warning is emitted so the cap is never silent — a scanner that
+    quietly skips files hides live secrets.
+    """
     if not root.exists():
         return
     root = root.resolve()
+    home = Path.home().resolve()
+    capped = 0
 
     def _onerror(_err: OSError) -> None:
         # Permission / reparse-point noise under $HOME is expected. Skip and
@@ -322,19 +344,38 @@ def _iter_aider_histories(root: Path) -> Iterator[Path]:
     for dirpath, dirnames, filenames in os.walk(
         root, topdown=True, onerror=_onerror,
     ):
-        # Depth relative to root (root itself is depth 0).
+        # Depth relative to root (root itself is depth 0). ``resolved`` is
+        # reused for the home-top check, so there's no extra resolve() per dir.
         try:
-            rel = Path(dirpath).resolve().relative_to(root)
+            resolved = Path(dirpath).resolve()
+            rel = resolved.relative_to(root)
             depth = 0 if str(rel) == "." else len(rel.parts)
         except ValueError:
             # Walked outside root (symlink / mount edge case). Stop descending.
             dirnames.clear()
             continue
         if depth >= _AIDER_MAX_DEPTH:
+            if dirnames:
+                capped += 1
             dirnames.clear()
         else:
-            dirnames[:] = [d for d in dirnames if d not in _AIDER_SKIP_DIRS]
+            at_home_top = resolved == home
+            dirnames[:] = [
+                d for d in dirnames
+                if d not in _AIDER_SKIP_DIRS
+                and not (at_home_top and d in _AIDER_SKIP_DIRS_HOME_TOP)
+            ]
         if _AIDER_HISTORY_NAME in filenames:
             p = Path(dirpath) / _AIDER_HISTORY_NAME
             if p.is_file():
                 yield p
+
+    if warn and capped:
+        print(
+            f"warning: aider discovery reached the depth cap "
+            f"({_AIDER_MAX_DEPTH}) in {capped} "
+            f"director{'y' if capped == 1 else 'ies'}; any "
+            f"{_AIDER_HISTORY_NAME} nested deeper was not scanned — "
+            f"pass --root <path> to reach it",
+            file=sys.stderr,
+        )

--- a/tests/test_aider_discovery.py
+++ b/tests/test_aider_discovery.py
@@ -62,19 +62,40 @@ def test_skips_node_modules_and_git(tmp_path: Path) -> None:
     assert decoy_git not in found
 
 
-def test_skips_appdata_and_library(tmp_path: Path) -> None:
-    root = tmp_path / "homeish"
-    real = _write_history(root / "Projects" / "app" / _AIDER_HISTORY_NAME)
-    decoy_app = _write_history(
-        root / "AppData" / "Local" / "junk" / _AIDER_HISTORY_NAME,
-    )
-    decoy_lib = _write_history(
-        root / "Library" / "Caches" / "junk" / _AIDER_HISTORY_NAME,
-    )
-    found = set(AiderSource(root=root).files())
+def test_prunes_os_profile_dirs_directly_under_home(_isolate_home: Path) -> None:
+    # Default root is $HOME: AppData/Library/.local/.Trash directly under it
+    # are OS-profile junk and must be pruned.
+    home = _isolate_home
+    real = _write_history(home / "Projects" / "app" / _AIDER_HISTORY_NAME)
+    decoy_app = _write_history(home / "AppData" / "Local" / "j" / _AIDER_HISTORY_NAME)
+    decoy_lib = _write_history(home / "Library" / "Caches" / "j" / _AIDER_HISTORY_NAME)
+    decoy_local = _write_history(home / ".local" / "share" / "j" / _AIDER_HISTORY_NAME)
+    found = set(AiderSource().files())
     assert real in found
     assert decoy_app not in found
     assert decoy_lib not in found
+    assert decoy_local not in found
+
+
+def test_os_profile_named_project_dir_is_scanned(tmp_path: Path) -> None:
+    # A *project* named "Library"/"AppData" that is NOT a direct child of $HOME
+    # is a real repo and must be scanned — the old flat skip-set dropped it,
+    # silently hiding any secret inside (regression this PR's fix repairs).
+    root = tmp_path / "work"
+    lib = _write_history(root / "clients" / "Library" / _AIDER_HISTORY_NAME)
+    app = _write_history(root / "src" / "AppData" / _AIDER_HISTORY_NAME)
+    found = set(AiderSource(root=root).files())
+    assert lib in found
+    assert app in found
+
+
+def test_config_dotfiles_history_is_found(_isolate_home: Path) -> None:
+    # Dotfiles repos (e.g. ~/.config/nvim) are a real Aider workflow; ~/.config
+    # must be walked, not blanket-pruned. Previously silently missed.
+    home = _isolate_home
+    hist = _write_history(home / ".config" / "nvim" / _AIDER_HISTORY_NAME)
+    found = set(AiderSource().files())
+    assert hist in found
 
 
 def test_depth_cap_stops_deep_trees(tmp_path: Path) -> None:
@@ -88,6 +109,30 @@ def test_depth_cap_stops_deep_trees(tmp_path: Path) -> None:
     found = set(_iter_aider_histories(root))
     assert shallow in found
     assert deep_hist not in found
+
+
+def test_depth_cap_is_surfaced_on_scan(tmp_path: Path, capsys) -> None:
+    # A reached depth cap must NOT be silent (project rule): scan path warns.
+    root = tmp_path / "work"
+    deep = root
+    for i in range(_AIDER_MAX_DEPTH + 2):
+        deep = deep / f"d{i}"
+    _write_history(deep / _AIDER_HISTORY_NAME)
+    list(_iter_aider_histories(root, warn=True))
+    err = capsys.readouterr().err
+    assert "depth cap" in err
+    assert "--root" in err
+
+
+def test_depth_cap_silent_during_detection(tmp_path: Path, capsys) -> None:
+    # warn=False (detection / list-sources) must print nothing.
+    root = tmp_path / "work"
+    deep = root
+    for i in range(_AIDER_MAX_DEPTH + 2):
+        deep = deep / f"d{i}"
+    _write_history(deep / _AIDER_HISTORY_NAME)
+    list(_iter_aider_histories(root, warn=False))
+    assert capsys.readouterr().err == ""
 
 
 def test_is_detected_false_on_empty_home(_isolate_home: Path) -> None:

--- a/tests/test_aider_discovery.py
+++ b/tests/test_aider_discovery.py
@@ -1,0 +1,122 @@
+"""Aider discovery: prune junk dirs, depth cap, and honest detection.
+
+Default Aider root is $HOME. Unbounded rglob thrashed real machines and made
+list-sources always report Aider as present. These tests stay under tmp_path.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.cli import main  # noqa: E402
+from agentsweep.sources._core import (  # noqa: E402
+    AiderSource,
+    _AIDER_HISTORY_NAME,
+    _AIDER_MAX_DEPTH,
+    _iter_aider_histories,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    yield fake_home
+
+
+def _write_history(path: Path, body: str = "# aider chat\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_finds_history_under_project_root(tmp_path: Path) -> None:
+    root = tmp_path / "work"
+    hist = _write_history(root / "proj" / _AIDER_HISTORY_NAME)
+    found = list(AiderSource(root=root).files())
+    assert found == [hist]
+
+
+def test_skips_node_modules_and_git(tmp_path: Path) -> None:
+    root = tmp_path / "work"
+    real = _write_history(root / "proj" / _AIDER_HISTORY_NAME)
+    decoy_nm = _write_history(
+        root / "proj" / "node_modules" / "pkg" / _AIDER_HISTORY_NAME,
+        "# decoy in node_modules\n",
+    )
+    decoy_git = _write_history(
+        root / "proj" / ".git" / "objects" / _AIDER_HISTORY_NAME,
+        "# decoy in .git\n",
+    )
+    found = set(AiderSource(root=root).files())
+    assert real in found
+    assert decoy_nm not in found
+    assert decoy_git not in found
+
+
+def test_skips_appdata_and_library(tmp_path: Path) -> None:
+    root = tmp_path / "homeish"
+    real = _write_history(root / "Projects" / "app" / _AIDER_HISTORY_NAME)
+    decoy_app = _write_history(
+        root / "AppData" / "Local" / "junk" / _AIDER_HISTORY_NAME,
+    )
+    decoy_lib = _write_history(
+        root / "Library" / "Caches" / "junk" / _AIDER_HISTORY_NAME,
+    )
+    found = set(AiderSource(root=root).files())
+    assert real in found
+    assert decoy_app not in found
+    assert decoy_lib not in found
+
+
+def test_depth_cap_stops_deep_trees(tmp_path: Path) -> None:
+    root = tmp_path / "work"
+    # depth = number of path parts under root. Nested dirs: d1/d2/.../dN/file
+    deep = root
+    for i in range(_AIDER_MAX_DEPTH + 3):
+        deep = deep / f"d{i}"
+    deep_hist = _write_history(deep / _AIDER_HISTORY_NAME)
+    shallow = _write_history(root / "proj" / _AIDER_HISTORY_NAME)
+    found = set(_iter_aider_histories(root))
+    assert shallow in found
+    assert deep_hist not in found
+
+
+def test_is_detected_false_on_empty_home(_isolate_home: Path) -> None:
+    src = AiderSource()
+    assert src.root == _isolate_home
+    assert src.is_detected() is False
+
+
+def test_is_detected_true_when_history_exists(_isolate_home: Path) -> None:
+    _write_history(_isolate_home / "code" / "repo" / _AIDER_HISTORY_NAME)
+    # Junk trees that would have made old rglob expensive.
+    (_isolate_home / "node_modules" / "x").mkdir(parents=True)
+    (_isolate_home / ".git" / "objects").mkdir(parents=True)
+    assert AiderSource().is_detected() is True
+
+
+def test_is_detected_true_from_config_marker(_isolate_home: Path) -> None:
+    (_isolate_home / ".aider.conf.yml").write_text("model: gpt\n", encoding="utf-8")
+    assert AiderSource().is_detected() is True
+
+
+def test_list_sources_aider_detection_tracks_history(
+    _isolate_home: Path, capsys,
+) -> None:
+    def _aider_row():
+        main(["list-sources", "--json"])
+        payload = json.loads(capsys.readouterr().out)
+        return next(r for r in payload if r["source"] == "aider")
+
+    assert _aider_row()["detected"] is False
+    _write_history(_isolate_home / "proj" / _AIDER_HISTORY_NAME)
+    assert _aider_row()["detected"] is True


### PR DESCRIPTION
## Problem

Aider has no central history directory. It drops `.aider.chat.history.md` at each project root. The adapter therefore walked from `Path.home()` with unbounded `rglob`.

On a real machine that meant walking `node_modules`, `.git`, `AppData`, `Library`, and other junk. Default `scan --source aider` could thrash the disk for a long time. Because home always exists, `list-sources` and `scan --all --detected` also always reported Aider as present.

The README also claimed `# ~/.aider/`, which is not where Aider stores chat history.

## Fix

- Replace unbounded `rglob` with a pruned `os.walk`
- Skip junk directory names (`node_modules`, `.git`, `AppData`, `Library`, caches, venvs, and similar)
- Cap walk depth at 12 from the discovery root
- Add `Source.is_detected()` (default still `root.exists()`)
- Override Aider detection to look for config markers or a real history file via the pruned walk
- Wire `list-sources` and `scan --all --detected` through `is_detected()`
- Correct the README Aider path note
- Note the change in `docs/PERF.md`

Explicit `--root` still works and uses the same prune rules.

## Tests

New hermetic coverage in `tests/test_aider_discovery.py`:

- finds histories under a project tree
- skips decoys under `node_modules` and `.git`
- skips `AppData` and `Library`
- respects the depth cap
- `is_detected` is false on an empty home
- `is_detected` is true when history or a config marker exists
- `list-sources --json` tracks Aider detection

Also re-ran related suites: list-sources, text-format redaction, backup hygiene, redaction retry, scan-all. All green.

## Notes

This is Aider-only. Shared walk helpers for other sources or undo multi-glob cleanup can land later.