### PR TITLE
docs: switch to readme-contribs widgets + add stargazers

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,11 @@ No. It is fully offline — zero network calls during scanning or redacting. The
 
 Thanks to everyone who has contributed code, bug reports, and ideas.
 
-[![Contributors](https://contrib.rocks/image?repo=Ishannaik/agent-sweep&max=100)](https://github.com/Ishannaik/agent-sweep/graphs/contributors)
+[![Contributors](https://readme-contribs.as93.net/contributors/Ishannaik/agent-sweep?shape=circle)](https://github.com/Ishannaik/agent-sweep/graphs/contributors)
+
+## Star Gazers
+
+[![Star Gazers](https://readme-contribs.as93.net/stargazers/Ishannaik/agent-sweep?shape=circle)](https://github.com/Ishannaik/agent-sweep/stargazers)
 
 ## License
 


### PR DESCRIPTION
Replaces the contrib.rocks contributors image with readme-contribs (readme-contribs.as93.net) + adds a Star Gazers widget.