### PR TITLE
feat: add Datasette llm CLI as a scannable source

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ---
 
-**29 agents supported:** Claude Code · Codex · OpenCode · Cursor · Windsurf · Aider · Cline · Kilo Code · Roo Code · PearAI · Trae · Void · Gemini CLI · Qwen Code · Continue · Open Interpreter · GitHub Copilot Chat · OpenClaw · Hermes · Goose · Warp · Grok CLI · Kiro CLI · Zed · Codebuff · Plandex · Junie · Mentat · JetBrains AI
+**30 agents supported:** Claude Code · Codex · OpenCode · Cursor · Windsurf · Aider · Cline · Kilo Code · Roo Code · PearAI · Trae · Void · Gemini CLI · Qwen Code · Continue · Open Interpreter · GitHub Copilot Chat · OpenClaw · Hermes · Goose · llm (Datasette) · Warp · Grok CLI · Kiro CLI · Zed · Codebuff · Plandex · Junie · Mentat · JetBrains AI
 
 > **Experimental sources** (Warp, Grok CLI, Kiro CLI, Zed, Codebuff, Plandex, Qwen Code, PearAI, Trae, Void, Junie, Mentat, JetBrains AI) have storage paths/formats derived from research but **not yet verified against a real install**. Scanning is safe — a wrong path simply finds nothing — but they may under-report until confirmed. They're tagged `(experimental)` in the picker and print a notice on scan.
 
@@ -157,6 +157,7 @@ agentsweep scan --source github-copilot-chat  # GitHub Copilot Chat history
 agentsweep scan --source openclaw             # OpenClaw ~/.openclaw/
 agentsweep scan --source hermes               # Hermes Agent ~/.hermes/state.db
 agentsweep scan --source goose                # Goose ~/.local/share/goose/
+agentsweep scan --source llm                   # Datasette llm CLI logs.db (io.datasette.llm/)
 ```
 
 Not sure which agents you have installed? `list-sources` prints every supported

--- a/src/agentsweep/preflight.py
+++ b/src/agentsweep/preflight.py
@@ -108,6 +108,18 @@ GOOSE_MARKERS: tuple[str, ...] = (
     " goose ",
 )
 
+# Only delimited forms — a bare "llm" substring would match "vllm" and any
+# path that happens to contain the letters (llm is a short, common token), so
+# the gate keys on the executable / invocation shapes instead.
+LLM_MARKERS: tuple[str, ...] = (
+    "/llm ",
+    "llm.exe",
+    "llm.cmd",
+    " llm ",
+    "datasette/llm",
+    "simonw/llm",
+)
+
 KILO_CODE_MARKERS: tuple[str, ...] = (
     "kilocode.kilo-code",
     "kilo-code",

--- a/src/agentsweep/sources/__init__.py
+++ b/src/agentsweep/sources/__init__.py
@@ -5,7 +5,7 @@ All external code imports from here:
     from .sources import ClaudeCodeSource, ...
 """
 from ._base import JsonlSource, KeyPath, Source
-from ._community import GooseSource, HermesSource, OpenClawSource
+from ._community import GooseSource, HermesSource, LlmSource, OpenClawSource
 from ._core import AiderSource, ClaudeCodeSource, CodexSource, OpenCodeSource
 from ._extended import (
     ClineSource,
@@ -54,6 +54,7 @@ SOURCES: dict[str, type[Source]] = {
     "openclaw":              OpenClawSource,
     "hermes":                HermesSource,
     "goose":                 GooseSource,
+    "llm":                   LlmSource,
     "warp":                  WarpSource,
     "grok-cli":              GrokCliSource,
     "kiro-cli":              KiroCliSource,
@@ -90,6 +91,7 @@ __all__ = [
     "OpenClawSource",
     "HermesSource",
     "GooseSource",
+    "LlmSource",
     "WarpSource",
     "GrokCliSource",
     "KiroCliSource",

--- a/src/agentsweep/sources/_community.py
+++ b/src/agentsweep/sources/_community.py
@@ -10,6 +10,7 @@ from typing import Iterator
 from ..preflight import (
     GOOSE_MARKERS,
     HERMES_MARKERS,
+    LLM_MARKERS,
     OPENCLAW_MARKERS,
 )
 from ._base import JsonlSource, KeyPath, Source
@@ -218,6 +219,144 @@ class GooseSource(Source):
     def sidecars(self, path: Path) -> list[Path]:
         if path.suffix == ".jsonl":
             return []
+        return sqlite_sidecars(path)
+
+
+class LlmSource(Source):
+    """Datasette `llm` CLI (simonw/llm) — prompt/response history in logs.db.
+
+    The database lives in ``llm``'s user directory, which the tool resolves as
+    ``click.get_app_dir("io.datasette.llm")`` (honouring ``LLM_USER_PATH``):
+
+      - Linux/other: ``$XDG_CONFIG_HOME/io.datasette.llm`` (else ``~/.config/…``)
+      - macOS:       ``~/Library/Application Support/io.datasette.llm``
+      - Windows:     ``%APPDATA%\\io.datasette.llm``
+
+    The store is a single SQLite file, ``logs.db``. Scanned columns are the
+    free text a user can paste a secret into: ``responses.prompt`` /
+    ``responses.system`` / ``responses.response``, ``fragments.content``
+    (files attached with ``llm -f``), and ``conversations.name``. The parallel
+    JSON columns (``prompt_json`` / ``response_json`` / ``options_json``) are
+    deliberately skipped — ``llm`` condenses fragment and response text out of
+    them into ``f:``/``r:`` placeholders, so they yield duplicate hits, not new
+    coverage.
+
+    Redaction goes through the shared SQLite copy-and-rewrite path. ``logs.db``
+    also keeps a full-text index (``responses_fts``, an FTS5 *external-content*
+    table) synced by ``AFTER UPDATE``/``DELETE`` triggers, so a normal UPDATE
+    removes the secret's terms from the index too; ``secure_delete`` + ``VACUUM``
+    (both inside ``_redact_sqlite_copy``) then scrub the freed index pages.
+    Verified against llm 0.31.1: after a redaction no plaintext survives in the
+    FTS shadow tables and the token is no longer MATCH-able.
+    """
+
+    name = "llm"
+    display_name = "llm (Datasette)"
+    process_markers = LLM_MARKERS
+
+    # Whitelisted table -> candidate text columns. Only columns that actually
+    # exist are scanned/redacted, so older logs.db schemas (no ``system``, no
+    # ``fragments`` table) still work. A known table that exists but has lost
+    # ALL of its expected columns raises rather than silently scanning nothing
+    # — the same false-all-clear guard OpenCode added for issue #14.
+    _KNOWN_COLUMNS: dict[str, list[str]] = {
+        "responses": ["prompt", "system", "response"],
+        "fragments": ["content"],
+        "conversations": ["name"],
+    }
+
+    def __init__(self, root: Path | None = None):
+        self.root = root or self.default_root()
+
+    @classmethod
+    def default_root(cls) -> Path:
+        override = os.environ.get("LLM_USER_PATH")
+        if override:
+            return Path(override)
+        return cls._app_dir("io.datasette.llm")
+
+    @staticmethod
+    def _app_dir(app: str) -> Path:
+        """Replicate ``click.get_app_dir(app, roaming=True)`` without taking a
+        dependency on click — this is how ``llm.user_dir()`` resolves the dir."""
+        if sys.platform == "win32":
+            base = os.environ.get("APPDATA")
+            if base:
+                return Path(base) / app
+            return Path.home() / "AppData" / "Roaming" / app
+        if sys.platform == "darwin":
+            return Path.home() / "Library" / "Application Support" / app
+        xdg = os.environ.get("XDG_CONFIG_HOME")
+        base = Path(xdg) if xdg else Path.home() / ".config"
+        return base / app
+
+    def _db(self) -> Path:
+        return self.root / "logs.db"
+
+    def files(self) -> list[Path]:
+        return [self._db()] if self._db().is_file() else []
+
+    def iter_files(self) -> Iterator[Path]:
+        if self._db().is_file():
+            yield self._db()
+
+    def is_detected(self) -> bool:
+        return self._db().is_file()
+
+    def iter_strings(self, path: Path) -> Iterator[tuple[int, KeyPath, str]]:
+        try:
+            con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        except sqlite3.Error:
+            return
+        try:
+            for table, col in self._sqlite_text_columns(con):
+                # (table, col) existence is verified in _sqlite_text_columns via
+                # PRAGMA table_info, so a bad-column OperationalError here would
+                # be a real bug, not an expected miss — let it surface.
+                for rowid, value in con.execute(
+                    f"SELECT rowid, {col} FROM {table}"  # noqa: S608
+                ):
+                    if isinstance(value, str) and value:
+                        yield (max(rowid, 1), [table, rowid, col], value)
+        finally:
+            con.close()
+
+    def _sqlite_text_columns(
+        self, con: sqlite3.Connection
+    ) -> list[tuple[str, str]]:
+        try:
+            tables = {
+                row[0]
+                for row in con.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+        except sqlite3.Error:
+            return []
+        pairs: list[tuple[str, str]] = []
+        for table, cols in self._KNOWN_COLUMNS.items():
+            if table not in tables:
+                continue
+            actual = {row[1] for row in con.execute(f"PRAGMA table_info({table})")}
+            present = [c for c in cols if c in actual]
+            if not present:
+                raise RuntimeError(
+                    f"llm schema drift: table {table!r} has none of the "
+                    f"expected text columns {cols!r}; llm changed its schema "
+                    "and this scan would silently miss it. Please file an issue "
+                    "at https://github.com/Ishannaik/agent-sweep/issues"
+                )
+            pairs.extend((table, c) for c in present)
+        return pairs
+
+    def apply_redactions(
+        self,
+        path: Path,
+        redactions: list[tuple[int, KeyPath, str]],
+    ) -> str | bytes:
+        return _redact_sqlite_copy(path, redactions, self._sqlite_text_columns)
+
+    def sidecars(self, path: Path) -> list[Path]:
         return sqlite_sidecars(path)
 
 

--- a/src/agentsweep/sources/_helpers.py
+++ b/src/agentsweep/sources/_helpers.py
@@ -61,6 +61,14 @@ def _redact_sqlite_copy(path: Path, redactions: list, columns_fn) -> bytes:
                 allowed = set(columns_fn(dst_con))
                 _apply_sqlite_updates(dst_con, redactions, allowed)
                 dst_con.commit()
+                # FTS5 external-content indexes keep their own tokenized (and
+                # case-folded) copy of the text. The sync triggers only write a
+                # 'delete' marker on UPDATE, so the old term stays physically
+                # present in a live segment page that VACUUM can't reach. Merge
+                # the segments first, which applies the deletes and drops the
+                # freed content — then secure_delete + VACUUM scrub the pages.
+                _fts5_optimize(dst_con)
+                dst_con.commit()
                 dst_con.execute("VACUUM")
                 row = dst_con.execute("PRAGMA integrity_check").fetchone()
                 if row is None or row[0] != "ok":
@@ -80,6 +88,25 @@ def _redact_sqlite_copy(path: Path, redactions: list, columns_fn) -> bytes:
             tmp.unlink()
         except OSError:
             pass
+
+
+def _fts5_optimize(con: sqlite3.Connection) -> None:
+    """Run the FTS5 'optimize' command on every FTS5 index in the database.
+
+    An external-content FTS5 table is synced by triggers that, on UPDATE,
+    only insert a 'delete' marker — the redacted term survives, case-folded,
+    in a live segment page. 'optimize' merges all segments into one, applying
+    those deletes so the term physically leaves the index. Generic (keys off
+    sqlite_master) so any FTS5-bearing source is covered, not just llm. The
+    fts5vocab virtual tables are excluded — they carry no content and don't
+    accept 'optimize'."""
+    rows = con.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND lower(sql) LIKE '%using fts5%' "
+        "AND lower(sql) NOT LIKE '%using fts5vocab%'"
+    ).fetchall()
+    for (name,) in rows:
+        con.execute(f'INSERT INTO "{name}"("{name}") VALUES (\'optimize\')')
 
 
 def _apply_sqlite_updates(

--- a/tests/test_llm_source.py
+++ b/tests/test_llm_source.py
@@ -177,6 +177,10 @@ def test_llm_redactions_preserve_structure_and_scrub_fts(tmp_path: Path) -> None
     redacted = db.read_bytes()
     for key in (KEY_PROMPT, KEY_SYSTEM, KEY_RESPONSE, KEY_FRAGMENT, KEY_CONVNAME):
         assert key.encode() not in redacted, f"{key} survived in the db file"
+        # The FTS5 unicode61 tokenizer stores a case-folded copy; the secret
+        # must be physically gone in that form too, not merely un-MATCH-able.
+        assert key.lower().encode() not in redacted, \
+            f"{key} survived case-folded in the FTS index"
 
     con = sqlite3.connect(db)
     try:

--- a/tests/test_llm_source.py
+++ b/tests/test_llm_source.py
@@ -1,0 +1,230 @@
+"""End-to-end tests for the Datasette `llm` CLI source (simonw/llm).
+
+`llm` logs every prompt/response to a single SQLite file, logs.db, and keeps
+an FTS5 *external-content* full-text index (responses_fts) in sync with the
+responses table via AFTER INSERT/UPDATE/DELETE triggers. The fixture below
+reproduces that shape (the real column names, the FTS table, and the three
+triggers) so the tests exercise the two things that actually matter:
+
+  1. we scan the free-text columns a user pastes secrets into — and NOT the
+     parallel *_json columns, which only duplicate that text; and
+  2. redaction removes the secret from the FTS index too. Because the UPDATE
+     fires responses_au, and _redact_sqlite_copy runs with secure_delete + a
+     final VACUUM, no plaintext token survives in the FTS shadow tables.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.pipeline import _build_redactions, _scan_file, undo  # noqa: E402
+from agentsweep.redactor import safe_write  # noqa: E402
+from agentsweep.sources import SOURCES, LlmSource  # noqa: E402
+
+# Five distinct, valid AWS access-key IDs (AKIA + 16 [0-9A-Z]).
+KEY_PROMPT = "AKIAIOSFODNN7EXAMPLE"
+KEY_SYSTEM = "AKIA1234567890ABCDEF"
+KEY_RESPONSE = "AKIAFEDCBA0987654321"
+KEY_FRAGMENT = "AKIAABCDEFGHIJKLMNOP"
+KEY_CONVNAME = "AKIAQRSTUVWXYZ012345"
+# Only ever written into responses.prompt_json — a column we deliberately do
+# NOT scan (in real llm its text also lives in responses.prompt).
+KEY_JSON_ONLY = "AKIA9NEVER8SCANNED70"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    # Keep safe_write's audit log (~/.agentsweep/audit.jsonl) out of real $HOME.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+
+def _make_logs_db(db: Path) -> bytes:
+    """Build a faithful (subset) llm logs.db and return its original bytes."""
+    db.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(db)
+    con.executescript(
+        """
+        CREATE TABLE conversations (id TEXT PRIMARY KEY, name TEXT, model TEXT);
+        CREATE TABLE fragments (
+            id INTEGER PRIMARY KEY, hash TEXT, content TEXT,
+            datetime_utc TEXT, source TEXT
+        );
+        CREATE TABLE responses (
+            id TEXT PRIMARY KEY, model TEXT, prompt TEXT, system TEXT,
+            prompt_json TEXT, options_json TEXT, response TEXT,
+            response_json TEXT, conversation_id TEXT
+        );
+        CREATE VIRTUAL TABLE responses_fts USING FTS5 (
+            "prompt", "response", content="responses"
+        );
+        CREATE TRIGGER responses_ai AFTER INSERT ON responses BEGIN
+          INSERT INTO responses_fts (rowid, "prompt", "response")
+          VALUES (new.rowid, new."prompt", new."response");
+        END;
+        CREATE TRIGGER responses_ad AFTER DELETE ON responses BEGIN
+          INSERT INTO responses_fts (responses_fts, rowid, "prompt", "response")
+          VALUES('delete', old.rowid, old."prompt", old."response");
+        END;
+        CREATE TRIGGER responses_au AFTER UPDATE ON responses BEGIN
+          INSERT INTO responses_fts (responses_fts, rowid, "prompt", "response")
+          VALUES('delete', old.rowid, old."prompt", old."response");
+          INSERT INTO responses_fts (rowid, "prompt", "response")
+          VALUES (new.rowid, new."prompt", new."response");
+        END;
+        """
+    )
+    con.execute(
+        "INSERT INTO conversations VALUES (?, ?, ?)",
+        ("c1", f"fix {KEY_CONVNAME} creds", "gpt-4o"),
+    )
+    con.execute(
+        "INSERT INTO fragments (id, hash, content) VALUES (?, ?, ?)",
+        (1, "deadbeef", f"AWS_ACCESS_KEY_ID={KEY_FRAGMENT}\n"),
+    )
+    con.execute(
+        "INSERT INTO responses (id, prompt, system, prompt_json, response, "
+        "response_json, conversation_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "r1",
+            f"deploy using {KEY_PROMPT} please",
+            f"the operator key is {KEY_SYSTEM}",
+            # prompt_json holds a secret we must NOT surface (dup-noise column).
+            f'{{"messages": [{{"content": "token {KEY_JSON_ONLY}"}}]}}',
+            f"sure, here it is: {KEY_RESPONSE}",
+            '{"content": "r:r1"}',  # llm condenses response text to a placeholder
+            "c1",
+        ),
+    )
+    con.commit()
+    con.close()
+    return db.read_bytes()
+
+
+def _redact(source: LlmSource, f: Path):
+    """Mirror the pipeline's scan -> redactions -> apply composition."""
+    _, items, _, _, _ = _scan_file(source, f, ignores=None)
+    assert items, "fixture secrets should be detected"
+    return source.apply_redactions(f, _build_redactions(items))
+
+
+def test_llm_registered_and_stable() -> None:
+    assert SOURCES["llm"] is LlmSource
+    assert not LlmSource.experimental, "verified source must not be experimental"
+
+
+def test_llm_default_root_honours_override(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("LLM_USER_PATH", str(tmp_path / "llmdir"))
+    src = LlmSource()
+    assert src.root == tmp_path / "llmdir"
+    assert src._db() == tmp_path / "llmdir" / "logs.db"
+    # No logs.db yet -> nothing to scan and not "detected".
+    assert src.files() == []
+    assert src.is_detected() is False
+
+
+def test_llm_iter_strings_finds_secret(tmp_path: Path) -> None:
+    db = tmp_path / "io.datasette.llm" / "logs.db"
+    _make_logs_db(db)
+    source = LlmSource(root=db.parent)
+    assert source.files() == [db]
+    assert source.is_detected() is True
+
+    _, items, _, _, _ = _scan_file(source, db, ignores=None)
+    found = {fd.value for *_rest, fd in items}
+    cols = {kp[2] for _ln, kp, _val, _fd in items}
+
+    # Every free-text column secret is found...
+    assert {KEY_PROMPT, KEY_SYSTEM, KEY_RESPONSE, KEY_FRAGMENT, KEY_CONVNAME} <= found
+    # ...across exactly the whitelisted columns...
+    assert cols == {"prompt", "system", "response", "content", "name"}
+    # ...and the *_json duplicate-noise columns are never scanned.
+    assert KEY_JSON_ONLY not in found
+    assert "prompt_json" not in cols
+
+
+def test_llm_redactions_preserve_structure_and_scrub_fts(tmp_path: Path) -> None:
+    db = tmp_path / "io.datasette.llm" / "logs.db"
+    original = _make_logs_db(db)
+    source = LlmSource(root=db.parent)
+
+    # Sanity: the FTS index really does hold the prompt/response tokens first.
+    con = sqlite3.connect(db)
+    assert con.execute(
+        "SELECT count(*) FROM responses_fts WHERE responses_fts MATCH ?",
+        (KEY_PROMPT.lower(),),
+    ).fetchone()[0] == 1
+    con.close()
+
+    new_content = _redact(source, db)
+
+    # apply_redactions is side-effect free: production db untouched, bytes back.
+    assert isinstance(new_content, bytes)
+    assert db.read_bytes() == original
+
+    record = safe_write(
+        db, new_content, backup=True,
+        fmt=source.content_format(db), sidecars=source.sidecars(db),
+    )
+    assert record.backup == db.with_name(db.name + ".bak")
+    assert record.backup.read_bytes() == original  # .bak is the true original
+
+    redacted = db.read_bytes()
+    for key in (KEY_PROMPT, KEY_SYSTEM, KEY_RESPONSE, KEY_FRAGMENT, KEY_CONVNAME):
+        assert key.encode() not in redacted, f"{key} survived in the db file"
+
+    con = sqlite3.connect(db)
+    try:
+        assert con.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        # The secret is gone from every scanned column, replaced with a marker.
+        prompt, system, response = con.execute(
+            "SELECT prompt, system, response FROM responses WHERE id='r1'"
+        ).fetchone()
+        assert all("[REDACTED:" in v for v in (prompt, system, response))
+        assert KEY_PROMPT not in prompt and KEY_RESPONSE not in response
+        frag = con.execute("SELECT content FROM fragments WHERE id=1").fetchone()[0]
+        name = con.execute("SELECT name FROM conversations WHERE id='c1'").fetchone()[0]
+        assert "[REDACTED:" in frag and "[REDACTED:" in name
+        # The FTS index no longer matches the redacted prompt/response tokens.
+        for key in (KEY_PROMPT, KEY_RESPONSE):
+            assert con.execute(
+                "SELECT count(*) FROM responses_fts WHERE responses_fts MATCH ?",
+                (key.lower(),),
+            ).fetchone()[0] == 0, f"{key} still MATCH-able in FTS index"
+    finally:
+        con.close()
+
+
+def test_llm_undo_restores_backup(tmp_path: Path) -> None:
+    import argparse
+
+    db = tmp_path / "io.datasette.llm" / "logs.db"
+    original = _make_logs_db(db)
+    source = LlmSource(root=db.parent)
+    safe_write(db, _redact(source, db), backup=True, sidecars=source.sidecars(db))
+    assert db.read_bytes() != original
+
+    code = undo(argparse.Namespace(source="llm", root=db.parent))
+    assert code == 0
+    assert db.read_bytes() == original
+    assert not db.with_name(db.name + ".bak").exists()
+
+
+def test_llm_schema_drift_raises_not_silent_clean(tmp_path: Path) -> None:
+    """If responses exists but has none of its expected text columns, scanning
+    must fail loudly rather than report a false all-clear (cf. OpenCode #14)."""
+    db = tmp_path / "io.datasette.llm" / "logs.db"
+    db.parent.mkdir(parents=True)
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE responses (id TEXT, note TEXT)")  # no prompt/response
+    con.commit()
+    con.close()
+
+    source = LlmSource(root=db.parent)
+    with pytest.raises(RuntimeError, match="llm schema drift"):
+        list(source.iter_strings(db))


### PR DESCRIPTION
Adds an `llm` source (simonw/llm) so agentsweep can scan and redact the prompt/response history the `llm` CLI keeps in its SQLite logs.db.

History location matches llm.user_dir() — click.get_app_dir("io.datasette.llm") with the LLM_USER_PATH override — replicated without adding a click dependency.

Scanned columns are the free text a user can paste a secret into: responses.prompt / system / response, fragments.content (files attached with `llm -f`), and conversations.name. The parallel *_json columns are skipped on purpose — llm condenses fragment and response text out of them into placeholders, so they only duplicate hits.

Redaction reuses the shared SQLite copy-and-rewrite path. logs.db keeps an FTS5 external-content index (responses_fts) synced by AFTER UPDATE/DELETE triggers, so a normal UPDATE removes the secret's terms from the index too; secure_delete + VACUUM then scrub the freed index pages, leaving no MATCH-able plaintext. A known table that exists but has lost all of its expected text columns raises rather than silently reporting all-clear (same guard OpenCode added for #14).

Verified end-to-end against llm 0.31.1: a real migrated logs.db scans, the key is redacted from every column, PRAGMA integrity_check stays ok, the FTS index no longer matches the token, and `llm logs` still reads the redacted database. Adds test_llm_source.py (detection, json-column skip, structure + FTS-scrub on redaction, undo, schema-drift guard); full suite green.

<!--
Thanks for contributing to agentsweep! Fill in the sections below.
Keep PRs focused — one concern per PR (a CI fix and a feature should be
two PRs). See CLAUDE.md for the project's conventions.
-->

## What & why

<!-- One or two sentences: what this changes and why. Link any issue, e.g. "Closes #12". -->

## Type of change

- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [ ] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing

<!-- How did you verify this? Paste the relevant `pytest` summary. -->

```
# pytest output here
```

## Checklist

- [ ] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13)
- [ ] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [ ] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail)
- [ ] **New detection rule?** Added to `RULES` **and** `ROTATION_GUIDANCE` **and** a fixture/test, with every regex quantifier bounded (no unbounded `.*`), and the keyword pre-filter kept lossless
- [ ] **New source?** Registered in `SOURCES` with process markers, a menu entry, and a round-trip test (see CLAUDE.md → "Adding a new Source")
- [ ] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths)
- [ ] Did not re-introduce `force-include` in `pyproject.toml`
