### PR TITLE
fix: align shell completion behavior with CLI contract

### DIFF
--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -141,7 +141,7 @@ def main(argv: list[str] | None = None) -> int:
         import argcomplete
         completion_parser = _get_completion_parser()
         argcomplete.autocomplete(completion_parser)
-    except Exception:
+    except ImportError:
         pass
 
     if argv and argv[0] in ("-V", "--version"):
@@ -353,8 +353,6 @@ def _get_completion_parser() -> argparse.ArgumentParser:
                                      help="Which agent's history (default: claude-code).")
     fix_source.completer = source_completer
     fix_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
-    fix_p.add_argument("--all", action="store_true", help="Scan every registered agent source.")
-    fix_p.add_argument("--detected", action="store_true", help="Only scan sources whose history root exists.")
     fix_p.add_argument("-o", "--output", type=Path, help="Write findings as JSON to this file.")
     fix_p.add_argument("--json", action="store_true", help="Emit findings as JSON to stdout.")
     fix_p.add_argument("--no-ignore", action="store_true", help="Ignore any .agentsweepignore files.")
@@ -406,7 +404,7 @@ def _run_completion(rest: list[str]) -> int:
     except ImportError:
         print("  error: argcomplete is not installed.", file=sys.stderr)
         print("  Install it using: pip install argcomplete", file=sys.stderr)
-        return 1
+        return 2
 
     print(shellcode(["agentsweep", "asweep"], shell=args.shell))
     return 0

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -13,9 +13,11 @@ Covers:
 """
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 import time
+import types
 from pathlib import Path
 
 import pytest
@@ -481,10 +483,56 @@ def test_completion_fish(capsys):
     assert "agentsweep" in captured.out
 
 
+def test_completion_missing_argcomplete_exits_2(monkeypatch, capsys):
+    fake_argcomplete = types.ModuleType("argcomplete")
+    setattr(fake_argcomplete, "autocomplete", lambda parser: None)
+    monkeypatch.setitem(sys.modules, "argcomplete", fake_argcomplete)
+
+    code = main(["completion", "bash"])
+
+    assert code == 2
+    assert "argcomplete is not installed" in capsys.readouterr().err
+
+
+def test_completion_setup_does_not_swallow_parser_errors(monkeypatch):
+    import agentsweep.cli as cli
+
+    fake_argcomplete = types.ModuleType("argcomplete")
+    setattr(fake_argcomplete, "autocomplete", lambda parser: None)
+    monkeypatch.setitem(sys.modules, "argcomplete", fake_argcomplete)
+
+    def _fail_parser():
+        raise RuntimeError("broken completion parser")
+
+    monkeypatch.setattr(cli, "_get_completion_parser", _fail_parser)
+
+    with pytest.raises(RuntimeError, match="broken completion parser"):
+        main(["--version"])
+
+
+def test_fix_completion_does_not_advertise_unsupported_flags():
+    from agentsweep.cli import _get_completion_parser
+
+    parser = _get_completion_parser()
+    subparsers_action = next(
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+    fix_parser = subparsers_action.choices["fix"]
+    fix_options = {
+        option
+        for action in fix_parser._actions
+        for option in action.option_strings
+    }
+
+    assert "--all" not in fix_options
+    assert "--detected" not in fix_options
+
+
 def test_source_completer_matches():
     from agentsweep.cli import source_completer
     res = source_completer("clau")
     assert "claude-code" in res
     res_all = source_completer("")
     assert len(res_all) > 10
-


### PR DESCRIPTION
## Summary

- return exit code 2 when `argcomplete` is unavailable
- only suppress `ImportError` during completion setup so parser bugs fail visibly
- stop advertising unsupported `fix --all` and `fix --detected` flags
- add regression coverage for all three behaviors

## Testing

- `uv run pytest tests/test_verbs.py -q` (29 passed)
- `uv run pytest tests/ -q` (488 passed)
- `uv run ruff check src/`
- `git diff --check`

Closes #42