### PR TITLE
fix(sources): preserve CRLF line endings through redaction rewrites

### DIFF
--- a/src/agentsweep/sources/_base.py
+++ b/src/agentsweep/sources/_base.py
@@ -152,7 +152,7 @@ class JsonlSource(Source):
         path: Path,
         redactions: list[tuple[int, KeyPath, str]],
     ) -> str:
-        text = path.read_text(encoding="utf-8")
+        text = path.read_bytes().decode("utf-8")
         lines = text.splitlines(keepends=True)
 
         by_line: dict[int, list[tuple[KeyPath, str]]] = {}

--- a/src/agentsweep/sources/_helpers.py
+++ b/src/agentsweep/sources/_helpers.py
@@ -172,7 +172,7 @@ def _apply_jsonl_redactions(
     redactions: list[tuple[int, KeyPath, str]],
 ) -> str:
     """Apply redactions to a JSONL file, preserving line count and endings."""
-    text = path.read_text(encoding="utf-8")
+    text = path.read_bytes().decode("utf-8")
     lines = text.splitlines(keepends=True)
     by_line: dict[int, list[tuple[KeyPath, str]]] = {}
     for line_num, kp, new_val in redactions:
@@ -269,7 +269,7 @@ def _apply_plaintext_redactions(
     writing empty content.
     """
     try:
-        text = path.read_text(encoding="utf-8")
+        text = path.read_bytes().decode("utf-8")
     except (OSError, UnicodeDecodeError) as e:
         raise SafetyError(
             f"Cannot re-read {path.name} for redaction: {e}") from e

--- a/tests/test_line_endings.py
+++ b/tests/test_line_endings.py
@@ -1,0 +1,92 @@
+"""CRLF / Windows line-ending round-trip coverage for the redaction write path.
+
+The write path promises byte-level structure preservation: line count, JSON
+validity, and the exact line-ending byte sequence of every line. Agent history
+files written on Windows can carry \r\n (and a final line with no trailing
+newline), so each fixture variant must survive scan -> redact -> undo
+byte-identically outside the redacted spans.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep import pipeline  # noqa: E402
+from agentsweep.cli import main  # noqa: E402
+
+AWS_KEY = b"AKIAIOSFODNN7EXAMPLE"
+MARKER = b"[REDACTED:aws-access-key]"
+
+_LINE_WITH_SECRET = b'{"type":"user","text":"key=AKIAIOSFODNN7EXAMPLE"}'
+_LINE_PLAIN = b'{"type":"assistant","text":"hello"}'
+
+VARIANTS = {
+    "lf": _LINE_WITH_SECRET + b"\n" + _LINE_PLAIN + b"\n",
+    "crlf": _LINE_WITH_SECRET + b"\r\n" + _LINE_PLAIN + b"\r\n",
+    "mixed_no_final_newline": (
+        _LINE_PLAIN + b"\r\n" + _LINE_PLAIN + b"\n" + _LINE_WITH_SECRET
+    ),
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Keep the audit log (~/.agentsweep/audit.jsonl) inside tmp_path."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _no_running_agent(monkeypatch):
+    monkeypatch.setattr(pipeline, "is_agent_running",
+                        lambda markers: (False, ""))
+
+
+def _endings(data: bytes) -> list[bytes]:
+    """The file's line-ending byte sequences, in order (\r\n before \n)."""
+    return re.findall(rb"\r\n|\r|\n", data)
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_redact_preserves_line_ending_bytes(tmp_path, variant):
+    root = tmp_path / "projects"
+    root.mkdir()
+    session = root / "session.jsonl"
+    original = VARIANTS[variant]
+    session.write_bytes(original)
+
+    code = main(["--source", "claude-code", "--root", str(root),
+                 "--fix", "--force"])
+    assert code == 0
+
+    redacted = session.read_bytes()
+    assert AWS_KEY not in redacted
+    assert MARKER in redacted
+    assert len(redacted.splitlines()) == len(original.splitlines())
+    assert _endings(redacted) == _endings(original)
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_undo_restores_original_bytes(tmp_path, variant):
+    root = tmp_path / "projects"
+    root.mkdir()
+    session = root / "session.jsonl"
+    original = VARIANTS[variant]
+    session.write_bytes(original)
+
+    assert main(["--source", "claude-code", "--root", str(root),
+                 "--fix", "--force"]) == 0
+    backup = session.with_name(session.name + ".bak")
+    assert backup.read_bytes() == original
+
+    assert main(["undo", "--source", "claude-code", "--root", str(root)]) == 0
+    assert session.read_bytes() == original
+    assert not backup.exists()


### PR DESCRIPTION
## What & why

#47 asked for byte-level CRLF round-trip coverage of the redaction write path. Writing it surfaced a real bug, so — per the issue's "if any variant fails, that's a real bug — file it / fix it in the same PR rather than skipping the case" — the fix ships here too.

The three text apply paths (`JsonlSource.apply_redactions`, `_apply_jsonl_redactions`, `_apply_plaintext_redactions`) re-read the history file with `Path.read_text()`, whose universal-newline mode translates `\r\n` to `\n` before any line ending is inspected. `safe_write()` then writes the result back in binary, so **redacting a CRLF history file silently rewrote every line ending in it** — outside the redacted spans, and against the preservation guarantee that both `safe_write()` and `apply_redactions()` document. The post-write line-count validation cannot catch this, because `splitlines()` is ending-agnostic.

The fix reads raw bytes and decodes, so `splitlines(keepends=True)` sees the real per-line endings and the existing `_line_ending()` helper puts them back unchanged. Three one-line changes; no new code paths and no change to the write path's invariants.

Closes #47

## Type of change

- [x] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [ ] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing

`tests/test_line_endings.py` builds JSONL fixtures in three variants — `\n`, `\r\n`, and mixed endings with no trailing newline on the final (secret-bearing) line — each carrying `AKIAIOSFODNN7EXAMPLE`, the same AWS example key the existing fixtures use, so the `aws-access-key` rule fires. For each variant it drives the real CLI (`--fix --force`, then `undo`) and asserts on `read_bytes()`:

- the secret is gone and `[REDACTED:aws-access-key]` is present,
- the line count is unchanged,
- every line-ending byte sequence is preserved in order,
- `.bak` holds the original bytes, and `undo` restores the file byte-for-byte.

Verified test-first: the `crlf` and `mixed_no_final_newline` variants **fail on current `main`** and pass with the fix. Hermetic — `tmp_path` only, with `HOME`/`USERPROFILE` redirected so the audit log never escapes the sandbox.

```
$ pytest tests/test_line_endings.py -q
......                                                    [100%]
6 passed in 0.47s

$ pytest -q
481 passed, 10 skipped in 93.56s
```

Local run is Windows / Python 3.11.9, in a clean `venv` with `pip install -e ".[dev]"`. Full suite green; leaving the rest of the matrix to CI.

## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13) — local Windows/3.11 pass as above; deferring to CI for the rest of the matrix
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [x] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail) — this PR touches only the three `apply_redactions` producers; `redactor.py` and every validation are unchanged, and the new tests assert the `.bak` and undo guarantees still hold
- [ ] **New detection rule?** — n/a
- [ ] **New source?** — n/a
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths) — no output paths touched
- [x] Did not re-introduce `force-include` in `pyproject.toml` — `pyproject.toml` is not modified by this PR

