### PR TITLE
docs: refresh CONTRIBUTING.md to match current sources/ layout and sc…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,23 @@
 
 ## PRs we want right now
 
-**New `Source` adapters.** Every AI coding agent stores history somewhere. Today agentsweep only understands Claude Code. If you write code against Codex, Aider, Cursor, Continue, Cline, Amp, Windsurf, Zed AI, or anything else — a ~30-line adapter makes agentsweep work for your tool.
+**New `Source` adapters.** Every AI coding agent stores history somewhere. agentsweep currently understands ~30 agents (run `agentsweep list-sources` for the full, current list) — if you write code against something not on that list, a small adapter makes agentsweep work for your tool too.
+
+**New detection rules, with rotation guidance and a fixture.** We're actively taking new secret patterns — see [#23](https://github.com/Ishannaik/agent-sweep/issues/23) (missing LLM-provider API keys: xAI, Groq, Mistral, Cohere, DeepSeek, OpenRouter, Together, Fireworks) and [#30](https://github.com/Ishannaik/agent-sweep/issues/30) (Google service-account keys and OAuth client secrets) for examples of the kind of rule PRs we want.
+
+**Tests, packaging, and safety hardening** around the scan/redact pipeline are always welcome.
 
 ## The `Source` interface
 
-Every adapter implements three methods (see `src/agentsweep/sources.py`):
+Sources live in the `src/agentsweep/sources/` package (`_base.py`, `_core.py`, `_extended.py`, `_vscode.py`, `_more.py`, `_community.py`) and are re-exported from `sources/__init__.py`. Every adapter subclasses `Source` (see `_base.py`):
 
 ```python
 class Source(ABC):
     name: str
+    display_name: str
     root: Path
+    process_markers: tuple[str, ...] = ()
+    experimental: bool = False
 
     def files(self) -> list[Path]:
         """Every history file to scan under this source's root."""
@@ -27,51 +34,33 @@ class Source(ABC):
         self,
         path: Path,
         redactions: list[tuple[int, KeyPath, str]],
-    ) -> str:
+    ) -> str | bytes:
         """Return the full new file content with strings replaced.
 
-        MUST preserve structure — line count, JSON validity (for JSON-based
-        formats), line endings — or the redactor's post-write validation
-        will reject the write.
+        str for text-based formats, bytes for binary formats like SQLite.
+        MUST preserve structure per content_format() (JSONL, whole-file JSON,
+        or line-count-preserving text) — the redactor's post-write validation
+        will reject a write that doesn't.
         """
 ```
 
+`process_markers` feeds `preflight.is_agent_running()`, a best-effort check that warns if the source's agent is currently running (to avoid redacting a file mid-write). Set `experimental = True` if the storage path/format was derived from research but not yet confirmed against a real install of the tool.
+
 ## Adding a new source — checklist
 
-1. Subclass `Source` in a new file (or in `sources.py` for v1; we'll split later).
-2. Add it to the `SOURCES` dict in `sources.py`.
-3. Add an anonymized fixture under `tests/fixtures/<your-source>/sample.<ext>`.
-4. Add one integration test: `test_<your_source>_iter_strings_finds_secret` and `test_<your_source>_redactions_preserve_structure`.
-5. Document the history location in README.md.
-6. Open the PR. Mention which version of the agent you tested against.
+1. Subclass `Source` in the right file under `src/agentsweep/sources/` (or add a new module for a new family of agents).
+2. Register it in the `SOURCES` dict in `sources/__init__.py`, and re-export it from that file's `__all__`.
+3. If the agent has a detectable running process, add its `*_MARKERS` tuple to `preflight.py` and set `process_markers` on the class.
+4. Update the hardcoded agent count in `ui/widgets.py`'s `menu_options()` (`"all N agents in parallel"`) and in README.md's supported-agents line/table.
+5. Add an anonymized fixture under `tests/fixtures/<your-source>/sample.<ext>` and a round-trip test covering `iter_strings` (finds a planted secret) and `apply_redactions` (preserves structure).
+6. Document the history location in README.md.
+7. Open the PR, referencing which version of the agent you tested against.
 
-## Scope boundary for v1
+## Adding a new detection rule — checklist
 
-Until v1.0 we will NOT merge:
-
-- New detection rules (keep regex in one place, don't fragment)
-- Feature flags / configuration systems
-- Dashboard / daemon / watch modes
-- CI/CD integrations
-
-These may land in v1.x. For now, the focus is: more sources, more tests, tighter safety.
+1. Add a `(rule_id, display_name, compiled_regex)` tuple to `RULES` in `scanner.py`.
+2. Add matching guidance to `ROTATION_GUIDANCE` in `scanner.py` (how to rotate/revoke that credential type).
+3. Add a synthetic (non-live-looking) fixture value to `FIXTURES` in `tests/test_ported_rules.py` — split across adjacent string literals so the file itself never contains a contiguous secret-shaped token (GitHub push protection will flag it otherwise).
+4. Run the suite; `test_ported_rules.py` enforces that every rule has both a fixture and rotation guidance.
 
 ## Running tests
-
-```
-pip install -e ".[dev]"
-pytest -v
-```
-
-The test suite is fully hermetic — it never touches `~/.claude/` or any real history directory. Every test uses `tmp_path`. If you add a test that reaches outside `tmp_path`, the PR will be rejected.
-
-## Safety-first review
-
-Any PR that touches `redactor.py` or the write path must:
-
-- Preserve all post-write validations (JSON re-parse, line count match).
-- Preserve atomic write semantics (tempfile → fsync → replace).
-- Preserve `.bak` creation.
-- Not add any code path that writes without going through `safe_write()`.
-
-If you're unsure, open a draft PR and ask.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,21 @@ class Source(ABC):
 4. Run the suite; `test_ported_rules.py` enforces that every rule has both a fixture and rotation guidance.
 
 ## Running tests
+
+```
+pip install -e ".[dev]"
+pytest -v
+```
+
+The test suite is fully hermetic — it never touches `~/.claude/` or any real history directory. Every test uses `tmp_path`. If you add a test that reaches outside `tmp_path`, the PR will be rejected.
+
+## Safety-first review
+
+Any PR that touches `redactor.py` or the write path must:
+
+- Preserve all post-write validations (JSON re-parse, line count match).
+- Preserve atomic write semantics (tempfile → fsync → replace).
+- Preserve `.bak` creation.
+- Not add any code path that writes without going through `safe_write()`.
+
+If you're unsure, open a draft PR and ask.


### PR DESCRIPTION
## What & why
Refreshes CONTRIBUTING.md to match the current codebase. The doc had drifted:
it said agentsweep only supports Claude Code (there are ~30 registered
sources now), it banned new detection rules until v1.0 (there are open
issues asking for exactly that), it pointed at a sources.py file that no
longer exists (sources now live in the sources/ package), and the
"adding a new source" checklist was missing steps that the real code
requires (process_markers in preflight.py, the hardcoded count in
ui/widgets.py). Docs-only, no code changed.

Fixes #41

## Type of change
- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [ ] Feature / enhancement
- [x] Refactor / docs / chore

## Testing
N/A — docs-only change, no code touched, nothing to run pytest against.

## Checklist
- [ ] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13)
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [ ] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail)
- [ ] **New detection rule?** N/A — no rule changes in this PR
- [ ] **New source?** N/A — no source changes in this PR
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths) — unaffected, docs-only
- [x] Did not re-introduce `force-include` in `pyproject.toml`