### PR TITLE
feat(cli): add PowerShell completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,20 @@ agentsweep completion fish > ~/.config/fish/completions/agentsweep.fish
 register-python-argcomplete --shell fish agentsweep > ~/.config/fish/completions/agentsweep.fish
 ```
 
+#### PowerShell
+
+Works in both Windows PowerShell 5.1 and PowerShell 7+. To activate completions for the current session:
+```powershell
+agentsweep completion powershell | Out-String | Invoke-Expression
+```
+To make it permanent, append the completion script to your profile:
+```powershell
+if (-not (Test-Path $PROFILE)) { New-Item -ItemType File -Path $PROFILE -Force }
+agentsweep completion powershell | Out-String | Add-Content $PROFILE
+```
+If your profile blocks script execution, allow local scripts first with
+`Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`.
+
 ## Usage
 
 ### Interactive mode

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -384,7 +384,8 @@ def _get_completion_parser() -> argparse.ArgumentParser:
 
     # completion
     comp_p = subparsers.add_parser("completion", description="Generate shell completion scripts.")
-    comp_p.add_argument("shell", choices=["bash", "zsh", "fish"], help="The shell to generate completions for.")
+    comp_p.add_argument("shell", choices=["bash", "zsh", "fish", "powershell"],
+                        help="The shell to generate completions for.")
 
     return ap
 
@@ -394,7 +395,7 @@ def _parse_completion(rest: list[str]) -> argparse.Namespace:
         prog="agentsweep completion",
         description="Generate shell completion scripts for agentsweep.",
     )
-    ap.add_argument("shell", choices=["bash", "zsh", "fish"],
+    ap.add_argument("shell", choices=["bash", "zsh", "fish", "powershell"],
                     help="The shell to generate completions for.")
     return ap.parse_args(rest)
 

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -481,6 +481,19 @@ def test_completion_fish(capsys):
     assert "agentsweep" in captured.out
 
 
+def test_completion_powershell(capsys):
+    code = main(["completion", "powershell"])
+    assert code == 0
+    captured = capsys.readouterr()
+    assert "Register-ArgumentCompleter" in captured.out
+    assert "agentsweep" in captured.out
+
+
+def test_completion_rejects_unknown_shell():
+    with pytest.raises(SystemExit):
+        main(["completion", "tcsh"])
+
+
 def test_source_completer_matches():
     from agentsweep.cli import source_completer
     res = source_completer("clau")


### PR DESCRIPTION
## What & why

#31 shipped completions for bash, zsh and fish, but `agentsweep completion powershell` hard-rejected the shell — even though a large share of the histories agentsweep scans (Claude Code, Cursor, Windsurf) live on Windows machines.

argcomplete already emits real PowerShell shellcode (`Register-ArgumentCompleter -Native`), so the fix is just adding `"powershell"` to the `shell` choices in `_parse_completion()` and the completion subparser in `_get_completion_parser()`.

**On the version pin —** the issue asked to verify `argcomplete>=3.0.0` exposes this and bump if needed. **No bump is needed.** I tested `shellcode(..., shell="powershell")` across 3.0.0, 3.1.0, 3.2.0, 3.5.0 and 3.7.0; every one emits genuine `Register-ArgumentCompleter` output (not a silent bash fallback), and 3.0.0 is the oldest 3.x on PyPI. The existing pin is already correct.

Closes #43

## Type of change

- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [x] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing

Verified on a real Windows machine against **both** supported hosts, driving the actual completer (`TabExpansion2`) rather than just checking that the script generates:

```
Windows PowerShell 5.1.26100.8772  →  agentsweep scan --source <TAB>  →  30 completions
PowerShell 7.6.0                   →  agentsweep scan --source <TAB>  →  30 completions
```

Both return the full `SOURCES` registry via `source_completer` — `claude-code, codex, opencode, cursor, windsurf, aider, ...` — so the dynamic `--source` path works, not just static subcommands.

Added `test_completion_powershell` (exits 0, emits `Register-ArgumentCompleter`) alongside the existing bash/zsh/fish smoke tests, and `test_completion_rejects_unknown_shell` so the choices list can't silently start accepting anything.

```
$ pytest tests/test_verbs.py -q
28 passed in 1.45s

$ pytest -q
477 passed, 10 skipped in 78.90s
```

Local run: Windows / Python 3.11.9, clean `venv` with `pip install -e ".[dev]"`.

**Heads-up on overlap:** #53 also touches `src/agentsweep/cli.py` and `tests/test_verbs.py` (completion exit code / flag advertising). This branch is based on current `main` and doesn't depend on it; whichever lands second will want a trivial rebase around the `choices=[...]` lines. Happy to rebase on request.

## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13) — local Windows/3.11 green as above; deferring the rest of the matrix to CI
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [x] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail) — n/a, this PR does not touch the write path
- [ ] **New detection rule?** — n/a
- [ ] **New source?** — n/a
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths) — `completion` prints only shellcode to stdout; no `ui` import added
- [x] Did not re-introduce `force-include` in `pyproject.toml` — `pyproject.toml` is not modified by this PR
