### PR TITLE
feat(sources): add Crush (Charm) as a scannable source

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 
 ---
 
-**30 agents supported:** Claude Code · Codex · OpenCode · Cursor · Windsurf · Aider · Cline · Kilo Code · Roo Code · PearAI · Trae · Void · Gemini CLI · Qwen Code · Continue · Open Interpreter · GitHub Copilot Chat · OpenClaw · Hermes · Goose · llm (Datasette) · Warp · Grok CLI · Kiro CLI · Zed · Codebuff · Plandex · Junie · Mentat · JetBrains AI
+**31 agents supported:** Claude Code · Codex · OpenCode · Cursor · Windsurf · Aider · Cline · Kilo Code · Roo Code · PearAI · Trae · Void · Gemini CLI · Qwen Code · Continue · Open Interpreter · GitHub Copilot Chat · OpenClaw · Hermes · Goose · llm (Datasette) · Warp · Crush · Grok CLI · Kiro CLI · Zed · Codebuff · Plandex · Junie · Mentat · JetBrains AI
 
-> **Experimental sources** (Warp, Grok CLI, Kiro CLI, Zed, Codebuff, Plandex, Qwen Code, PearAI, Trae, Void, Junie, Mentat, JetBrains AI) have storage paths/formats derived from research but **not yet verified against a real install**. Scanning is safe — a wrong path simply finds nothing — but they may under-report until confirmed. They're tagged `(experimental)` in the picker and print a notice on scan.
+> **Experimental sources** (Warp, Crush, Grok CLI, Kiro CLI, Zed, Codebuff, Plandex, Qwen Code, PearAI, Trae, Void, Junie, Mentat, JetBrains AI) have storage paths/formats derived from research but **not yet verified against a real install**. Scanning is safe — a wrong path simply finds nothing — but they may under-report until confirmed. They're tagged `(experimental)` in the picker and print a notice on scan.
 
 **191 detection rules** — AWS, GitHub, Stripe, OpenAI, Anthropic, Google, Slack, Discord, HuggingFace, JWT, PEM keys, DB URLs, BIP-39 seed phrases, and [many more](#whats-detected)
 
@@ -204,6 +204,7 @@ agentsweep scan --source opencode             # OpenCode SQLite store
 agentsweep scan --source cursor               # Cursor history
 agentsweep scan --source windsurf             # Windsurf history
 agentsweep scan --source aider                # per-repo .aider.chat.history.md under $HOME
+agentsweep scan --source crush                # per-project .crush/crush.db under $HOME
 agentsweep scan --source cline                # Cline history
 agentsweep scan --source gemini-cli           # Gemini CLI history
 agentsweep scan --source continue-vscode      # Continue (VS Code) history

--- a/src/agentsweep/preflight.py
+++ b/src/agentsweep/preflight.py
@@ -161,6 +161,14 @@ KIRO_CLI_MARKERS: tuple[str, ...] = (
     "kiro.exe",
 )
 
+# No bare "crush": it is an ordinary word that matches unrelated processes
+# (crushftp, image-crush), and a false "agent is running" gate blocks redaction.
+CRUSH_MARKERS: tuple[str, ...] = (
+    "charmbracelet/crush",
+    "/crush ",
+    "crush.exe",
+)
+
 KIRO_MARKERS: tuple[str, ...] = (
     "kiro.kiroagent",
     "kirodotdev",

--- a/src/agentsweep/sources/__init__.py
+++ b/src/agentsweep/sources/__init__.py
@@ -18,6 +18,7 @@ from ._extended import (
 )
 from ._more import (
     CodebuffSource,
+    CrushSource,
     GrokCliSource,
     JetBrainsAiSource,
     JunieSource,
@@ -56,6 +57,7 @@ SOURCES: dict[str, type[Source]] = {
     "goose":                 GooseSource,
     "llm":                   LlmSource,
     "warp":                  WarpSource,
+    "crush":                 CrushSource,
     "grok-cli":              GrokCliSource,
     "kiro-cli":              KiroCliSource,
     "zed":                   ZedSource,
@@ -93,6 +95,7 @@ __all__ = [
     "GooseSource",
     "LlmSource",
     "WarpSource",
+    "CrushSource",
     "GrokCliSource",
     "KiroCliSource",
     "ZedSource",

--- a/src/agentsweep/sources/_core.py
+++ b/src/agentsweep/sources/_core.py
@@ -20,6 +20,7 @@ from ._helpers import (
     _apply_plaintext_redactions,
     _iter_json_file_strings,
     _iter_plaintext_lines,
+    _iter_project_histories,
     _redact_sqlite_copy,
     sqlite_sidecars,
 )
@@ -219,46 +220,6 @@ class OpenCodeSource(Source):
             pairs.extend((table, c) for c in present)
         return pairs
 
-# Vendor / VCS / build-cache dirs — never an Aider repo root, so they are
-# pruned at ANY depth. A directory with one of these names holds tooling, not
-# a project the user ran Aider in, so dropping it can't hide a real history.
-_AIDER_SKIP_DIRS: frozenset[str] = frozenset({
-    ".git",
-    "node_modules",
-    ".venv",
-    "venv",
-    "__pycache__",
-    ".tox",
-    ".nox",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    ".cache",
-    ".npm",
-    ".yarn",
-    ".pnpm-store",
-    ".cargo",
-    ".rustup",
-})
-
-# OS-profile trees (caches, not project roots) — pruned ONLY when they sit
-# directly under $HOME. Unlike the vendor set, these are ordinary words a real
-# project directory can legitimately be named ("Library", "AppData", "Trash"),
-# so pruning them at any depth silently dropped real histories — a secret
-# scanner reporting a false all-clear. `.config` is deliberately NOT here:
-# people keep git-tracked dotfiles (e.g. ~/.config/nvim) there and run Aider in
-# them, so it must be walked; the depth cap + vendor set above bound the cost.
-# ponytail: home-top-only prune, not per-name cache-child pruning. If ~/.config
-# on some box (large browser profiles) makes a scan slow, add the specific
-# cache-child dir names — don't re-blanket-prune .config and lose real repos.
-_AIDER_SKIP_DIRS_HOME_TOP: frozenset[str] = frozenset({
-    "AppData",
-    "Library",
-    ".Trash",
-    "Trash",
-    ".local",
-})
-
 _AIDER_HISTORY_NAME = ".aider.chat.history.md"
 # Soft cap from the discovery root. Aider histories live at repo roots, not
 # deep inside nested vendor trees. Users with odd layouts can pass --root.
@@ -319,63 +280,26 @@ class AiderSource(Source):
         return "text"
 
 
+def _find_aider_history(
+    dirpath: Path, _dirnames: list[str], filenames: list[str],
+) -> Iterator[Path]:
+    if _AIDER_HISTORY_NAME in filenames:
+        p = dirpath / _AIDER_HISTORY_NAME
+        if p.is_file():
+            yield p
+
+
 def _iter_aider_histories(root: Path, *, warn: bool = False) -> Iterator[Path]:
     """Yield Aider chat histories under root with junk dirs pruned.
 
-    Vendor/cache dirs are pruned at any depth; OS-profile dirs only when they
-    sit directly under $HOME (so a project named "Library" or a dotfiles repo
-    under ~/.config is still scanned). Descent stops at _AIDER_MAX_DEPTH; when
-    that happens and ``warn`` is True (the scan path, not detection), a one-line
-    stderr warning is emitted so the cap is never silent — a scanner that
-    quietly skips files hides live secrets.
+    Discovery (pruning, depth cap, cap warning) is shared with the other
+    per-project sources — see _iter_project_histories in _helpers.py.
     """
-    if not root.exists():
-        return
-    root = root.resolve()
-    home = Path.home().resolve()
-    capped = 0
-
-    def _onerror(_err: OSError) -> None:
-        # Permission / reparse-point noise under $HOME is expected. Skip and
-        # keep walking the rest of the tree.
-        return
-
-    # os.walk so we can mutate dirs in place and skip huge subtrees.
-    for dirpath, dirnames, filenames in os.walk(
-        root, topdown=True, onerror=_onerror,
-    ):
-        # Depth relative to root (root itself is depth 0). ``resolved`` is
-        # reused for the home-top check, so there's no extra resolve() per dir.
-        try:
-            resolved = Path(dirpath).resolve()
-            rel = resolved.relative_to(root)
-            depth = 0 if str(rel) == "." else len(rel.parts)
-        except ValueError:
-            # Walked outside root (symlink / mount edge case). Stop descending.
-            dirnames.clear()
-            continue
-        if depth >= _AIDER_MAX_DEPTH:
-            if dirnames:
-                capped += 1
-            dirnames.clear()
-        else:
-            at_home_top = resolved == home
-            dirnames[:] = [
-                d for d in dirnames
-                if d not in _AIDER_SKIP_DIRS
-                and not (at_home_top and d in _AIDER_SKIP_DIRS_HOME_TOP)
-            ]
-        if _AIDER_HISTORY_NAME in filenames:
-            p = Path(dirpath) / _AIDER_HISTORY_NAME
-            if p.is_file():
-                yield p
-
-    if warn and capped:
-        print(
-            f"warning: aider discovery reached the depth cap "
-            f"({_AIDER_MAX_DEPTH}) in {capped} "
-            f"director{'y' if capped == 1 else 'ies'}; any "
-            f"{_AIDER_HISTORY_NAME} nested deeper was not scanned — "
-            f"pass --root <path> to reach it",
-            file=sys.stderr,
-        )
+    yield from _iter_project_histories(
+        root,
+        find=_find_aider_history,
+        max_depth=_AIDER_MAX_DEPTH,
+        source_label="aider",
+        artifact_desc=_AIDER_HISTORY_NAME,
+        warn=warn,
+    )

--- a/src/agentsweep/sources/_helpers.py
+++ b/src/agentsweep/sources/_helpers.py
@@ -1,12 +1,14 @@
-"""Format-specific helpers: SQLite copy-and-redact, JSONL, JSON, plaintext."""
+"""Format-specific helpers: SQLite copy-and-redact, JSONL, JSON, plaintext,
+plus discovery for agents that store history beside each project."""
 from __future__ import annotations
 
 import json
 import os
 import sqlite3
+import sys
 import tempfile
 from pathlib import Path
-from typing import Iterator
+from typing import Callable, Iterator
 
 from ..redactor import SafetyError
 from ._base import KeyPath, _line_ending, _set_by_path, _walk_json
@@ -255,6 +257,123 @@ def _iter_plaintext_lines(path: Path) -> Iterator[tuple[int, KeyPath, str]]:
     for i, line in enumerate(text.splitlines(), 1):
         if line.strip():
             yield (i, [i], line)
+
+
+# ---------------------------------------------------------------------------
+# Per-project discovery (agents that keep history beside each project rather
+# than in one central directory: Aider, Crush)
+# ---------------------------------------------------------------------------
+
+# Vendor / VCS / build-cache dirs — never a project root, so they are pruned at
+# ANY depth. A directory with one of these names holds tooling, not a project
+# the user ran an agent in, so dropping it can't hide a real history.
+_PROJECT_SKIP_DIRS: frozenset[str] = frozenset({
+    ".git",
+    "node_modules",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".tox",
+    ".nox",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".cache",
+    ".npm",
+    ".yarn",
+    ".pnpm-store",
+    ".cargo",
+    ".rustup",
+})
+
+# OS-profile trees (caches, not project roots) — pruned ONLY when they sit
+# directly under $HOME. Unlike the vendor set, these are ordinary words a real
+# project directory can legitimately be named ("Library", "AppData", "Trash"),
+# so pruning them at any depth silently dropped real histories — a secret
+# scanner reporting a false all-clear. `.config` is deliberately NOT here:
+# people keep git-tracked dotfiles (e.g. ~/.config/nvim) there and run agents in
+# them, so it must be walked; the depth cap + vendor set above bound the cost.
+# ponytail: home-top-only prune, not per-name cache-child pruning. If ~/.config
+# on some box (large browser profiles) makes a scan slow, add the specific
+# cache-child dir names — don't re-blanket-prune .config and lose real repos.
+_PROJECT_SKIP_DIRS_HOME_TOP: frozenset[str] = frozenset({
+    "AppData",
+    "Library",
+    ".Trash",
+    "Trash",
+    ".local",
+})
+
+
+def _iter_project_histories(
+    root: Path,
+    *,
+    find: Callable[[Path, list[str], list[str]], Iterator[Path]],
+    max_depth: int,
+    source_label: str,
+    artifact_desc: str,
+    warn: bool = False,
+) -> Iterator[Path]:
+    """Yield history artifacts under root with junk dirs pruned.
+
+    `find` receives each walked (dirpath, dirnames, filenames) and yields the
+    artifacts it recognises there, so a source can match a file at a project
+    root (Aider) or a file inside a data dir (Crush).
+
+    Vendor/cache dirs are pruned at any depth; OS-profile dirs only when they
+    sit directly under $HOME (so a project named "Library" or a dotfiles repo
+    under ~/.config is still scanned). Descent stops at `max_depth`; when that
+    happens and `warn` is True (the scan path, not detection), a one-line stderr
+    warning naming `source_label`/`artifact_desc` is emitted so the cap is never
+    silent — a scanner that quietly skips files hides live secrets.
+    """
+    if not root.exists():
+        return
+    root = root.resolve()
+    home = Path.home().resolve()
+    capped = 0
+
+    def _onerror(_err: OSError) -> None:
+        # Permission / reparse-point noise under $HOME is expected. Skip and
+        # keep walking the rest of the tree.
+        return
+
+    # os.walk so we can mutate dirs in place and skip huge subtrees.
+    for dirpath, dirnames, filenames in os.walk(
+        root, topdown=True, onerror=_onerror,
+    ):
+        # Depth relative to root (root itself is depth 0). ``resolved`` is
+        # reused for the home-top check, so there's no extra resolve() per dir.
+        try:
+            resolved = Path(dirpath).resolve()
+            rel = resolved.relative_to(root)
+            depth = 0 if str(rel) == "." else len(rel.parts)
+        except ValueError:
+            # Walked outside root (symlink / mount edge case). Stop descending.
+            dirnames.clear()
+            continue
+        if depth >= max_depth:
+            if dirnames:
+                capped += 1
+            dirnames.clear()
+        else:
+            at_home_top = resolved == home
+            dirnames[:] = [
+                d for d in dirnames
+                if d not in _PROJECT_SKIP_DIRS
+                and not (at_home_top and d in _PROJECT_SKIP_DIRS_HOME_TOP)
+            ]
+        yield from find(Path(dirpath), dirnames, filenames)
+
+    if warn and capped:
+        print(
+            f"warning: {source_label} discovery reached the depth cap "
+            f"({max_depth}) in {capped} "
+            f"director{'y' if capped == 1 else 'ies'}; any "
+            f"{artifact_desc} nested deeper was not scanned — "
+            f"pass --root <path> to reach it",
+            file=sys.stderr,
+        )
 
 
 def _apply_plaintext_redactions(

--- a/src/agentsweep/sources/_more.py
+++ b/src/agentsweep/sources/_more.py
@@ -21,6 +21,7 @@ from typing import Iterator
 
 from ..preflight import (
     CODEBUFF_MARKERS,
+    CRUSH_MARKERS,
     GROK_CLI_MARKERS,
     JETBRAINS_AI_MARKERS,
     JUNIE_MARKERS,
@@ -43,6 +44,7 @@ from ._helpers import (
     _iter_json_file_strings,
     _iter_jsonl_strings,
     _iter_plaintext_lines,
+    _iter_project_histories,
     _redact_sqlite_copy,
     sqlite_sidecars,
 )
@@ -150,6 +152,79 @@ class _GenericSqliteSource(Source):
 
 
 # ── SQLite agents ─────────────────────────────────────────────────────────────
+
+_CRUSH_DATA_DIR = ".crush"
+_CRUSH_DB_NAME = "crush.db"
+_CRUSH_ARTIFACT = f"{_CRUSH_DATA_DIR}/{_CRUSH_DB_NAME}"
+# Crush resolves its data dir upward only as far as the git worktree root, so a
+# db sits at a project root, not deep inside one. Same soft cap as Aider, the
+# other per-project source; users with odd layouts can pass --root.
+_CRUSH_MAX_DEPTH = 12
+
+
+def _find_crush_db(
+    dirpath: Path, dirnames: list[str], _filenames: list[str],
+) -> Iterator[Path]:
+    if _CRUSH_DATA_DIR in dirnames:
+        db = dirpath / _CRUSH_DATA_DIR / _CRUSH_DB_NAME
+        if db.is_file():
+            yield db
+
+
+class CrushSource(_GenericSqliteSource):
+    """Crush (Charm) — per-project SQLite db at <project>/.crush/crush.db.
+
+    Crush resolves its data directory relative to the working directory,
+    searching upward no further than the git worktree root, so there is no
+    central history store: every project the user ran Crush in has its own db.
+    Discovery therefore walks from Path.home() (or an explicit --root) like
+    Aider, rather than reading one fixed platform path.
+
+    Message text lives in messages.parts as JSON, session titles in
+    sessions.title, and files.content holds whole file bodies Crush read — so a
+    .env it opened is in the db verbatim. _GenericSqliteSource scans every text
+    column of every table, which covers all three without hard-coding a schema
+    that upstream may change.
+    """
+
+    name = "crush"
+    display_name = "Crush"
+    process_markers = CRUSH_MARKERS
+
+    @classmethod
+    def default_root(cls) -> Path:
+        return Path.home()
+
+    def files(self) -> list[Path]:
+        return sorted(self.iter_files())
+
+    def iter_files(self) -> Iterator[Path]:
+        # warn=True: this is the scan path, so a reached depth cap is surfaced.
+        yield from _iter_project_histories(
+            self.root,
+            find=_find_crush_db,
+            max_depth=_CRUSH_MAX_DEPTH,
+            source_label="crush",
+            artifact_desc=_CRUSH_ARTIFACT,
+            warn=True,
+        )
+
+    def is_detected(self) -> bool:
+        # Home always exists, so root.exists() would report Crush as installed
+        # on every machine. An early-exit pruned walk instead, so detection
+        # reflects real history. warn=False: detection must not print
+        # scan-time warnings.
+        for _ in _iter_project_histories(
+            self.root,
+            find=_find_crush_db,
+            max_depth=_CRUSH_MAX_DEPTH,
+            source_label="crush",
+            artifact_desc=_CRUSH_ARTIFACT,
+            warn=False,
+        ):
+            return True
+        return False
+
 
 class WarpSource(_GenericSqliteSource):
     """Warp terminal — single warp.sqlite (agent_conversations, ai_queries,

--- a/tests/test_crush_source.py
+++ b/tests/test_crush_source.py
@@ -1,0 +1,203 @@
+"""Crush source: per-project db discovery, scanning, and redaction round-trip.
+
+Crush keeps no central history: each project it runs in gets its own
+<project>/.crush/crush.db, so discovery walks from home like Aider rather than
+reading one platform path.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep import pipeline  # noqa: E402
+from agentsweep.cli import main  # noqa: E402
+from agentsweep.sources import SOURCES, CrushSource  # noqa: E402
+
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+GH_TOKEN = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+
+# Crush's schema, from internal/db/migrations/20250424200609_initial.sql.
+_SCHEMA = """
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    parent_session_id TEXT,
+    title TEXT NOT NULL,
+    message_count INTEGER NOT NULL DEFAULT 0,
+    prompt_tokens INTEGER NOT NULL DEFAULT 0,
+    completion_tokens INTEGER NOT NULL DEFAULT 0,
+    cost REAL NOT NULL DEFAULT 0.0,
+    updated_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE TABLE messages (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    parts TEXT NOT NULL DEFAULT '[]',
+    model TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    finished_at INTEGER
+);
+CREATE TABLE files (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    path TEXT NOT NULL,
+    content TEXT NOT NULL,
+    version INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+"""
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _no_agent_running(monkeypatch):
+    monkeypatch.setattr(pipeline, "is_agent_running", lambda markers: (False, ""))
+
+
+def _mk_crush_db(project: Path, *, age_seconds: int = 3700) -> Path:
+    """Create <project>/.crush/crush.db holding a secret in parts and content."""
+    data_dir = project / ".crush"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    db = data_dir / "crush.db"
+    con = sqlite3.connect(db)
+    try:
+        con.executescript(_SCHEMA)
+        con.execute(
+            "INSERT INTO sessions VALUES (?,?,?,?,?,?,?,?,?)",
+            ("s1", None, "deploy help", 2, 10, 20, 0.01, 1, 1),
+        )
+        con.execute(
+            "INSERT INTO messages VALUES (?,?,?,?,?,?,?,?)",
+            (
+                "m1", "s1", "user",
+                json.dumps([{"type": "text", "text": f"my key is {AWS_KEY}"}]),
+                "claude", 1, 1, 1,
+            ),
+        )
+        con.execute(
+            "INSERT INTO files VALUES (?,?,?,?,?,?,?)",
+            ("f1", "s1", ".env", f"GITHUB_TOKEN={GH_TOKEN}\n", 0, 1, 1),
+        )
+        con.commit()
+    finally:
+        con.close()
+    past = time.time() - age_seconds
+    os.utime(db, (past, past))
+    return db
+
+
+def test_registered_in_sources():
+    assert SOURCES["crush"] is CrushSource
+
+
+def test_default_root_is_home(_isolate_home):
+    assert CrushSource().root == Path.home()
+
+
+def test_discovers_per_project_db(tmp_path):
+    project = tmp_path / "work" / "myrepo"
+    project.mkdir(parents=True)
+    db = _mk_crush_db(project)
+    assert CrushSource(root=tmp_path).files() == [db]
+
+
+def test_discovers_multiple_projects(tmp_path):
+    a = tmp_path / "repo_a"
+    b = tmp_path / "nested" / "repo_b"
+    a.mkdir(parents=True)
+    b.mkdir(parents=True)
+    _mk_crush_db(a)
+    _mk_crush_db(b)
+    assert len(CrushSource(root=tmp_path).files()) == 2
+
+
+def test_skips_pruned_dirs(tmp_path):
+    buried = tmp_path / "node_modules" / "pkg"
+    buried.mkdir(parents=True)
+    _mk_crush_db(buried)
+    assert CrushSource(root=tmp_path).files() == []
+
+
+def test_data_dir_without_db_is_ignored(tmp_path):
+    (tmp_path / "proj" / ".crush").mkdir(parents=True)
+    assert CrushSource(root=tmp_path).files() == []
+
+
+def test_is_detected_tracks_real_history(tmp_path, _isolate_home):
+    assert CrushSource(root=tmp_path).is_detected() is False
+    _mk_crush_db(tmp_path / "proj")
+    assert CrushSource(root=tmp_path).is_detected() is True
+
+
+def test_iter_strings_finds_secret(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    db = _mk_crush_db(project)
+    values = [v for _, _, v in CrushSource(root=tmp_path).iter_strings(db)]
+    assert any(AWS_KEY in v for v in values)
+    assert any(GH_TOKEN in v for v in values)
+
+
+def test_scan_finds_secret(tmp_path, capsys):
+    project = tmp_path / "proj"
+    project.mkdir()
+    _mk_crush_db(project)
+    code = main(["scan", "--source", "crush", "--root", str(tmp_path), "--json"])
+    assert code == 1
+    findings = json.loads(capsys.readouterr().out)
+    assert any(f["rule"] == "aws-access-key" for f in findings)
+
+
+def test_fix_redacts_and_db_stays_valid(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    db = _mk_crush_db(project)
+
+    code = main(["fix", "--source", "crush", "--root", str(tmp_path),
+                 "--force", "--allow-production"])
+    assert code == 0
+
+    con = sqlite3.connect(db)
+    try:
+        assert con.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        parts = con.execute("SELECT parts FROM messages WHERE id='m1'").fetchone()[0]
+        content = con.execute("SELECT content FROM files WHERE id='f1'").fetchone()[0]
+    finally:
+        con.close()
+
+    assert AWS_KEY not in parts
+    assert "[REDACTED:aws-access-key]" in parts
+    assert json.loads(parts)[0]["type"] == "text"
+    assert GH_TOKEN not in content
+    assert db.with_name(db.name + ".bak").exists()
+
+
+def test_undo_restores_db(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    db = _mk_crush_db(project)
+    original = db.read_bytes()
+
+    assert main(["fix", "--source", "crush", "--root", str(tmp_path),
+                 "--force", "--allow-production"]) == 0
+    assert main(["undo", "--source", "crush", "--root", str(tmp_path)]) == 0
+    assert db.read_bytes() == original

--- a/tests/test_more_sources.py
+++ b/tests/test_more_sources.py
@@ -208,7 +208,13 @@ def test_all_new_sources_registered_with_distinct_roots() -> None:
     # default_root resolves for every registered source without raising,
     # and no two sources share the same root.
     roots = {slug: str(cls().default_root()) for slug, cls in SOURCES.items()}
-    assert len(set(roots.values())) == len(roots), "sources share a default_root"
+    # Per-project sources (aider, crush) have no central store — they walk from
+    # $HOME for a per-repo artifact, so sharing that root is correct, not a
+    # copy-paste slip. The check guards fixed history paths, where a duplicate
+    # would mean one source silently scanning another's store.
+    home = str(Path.home())
+    fixed = {slug: r for slug, r in roots.items() if r != home}
+    assert len(set(fixed.values())) == len(fixed), "sources share a default_root"
 
 
 def test_new_sources_flagged_experimental() -> None:


### PR DESCRIPTION
## What & why

Adds [Crush](https://github.com/charmbracelet/crush) (Charm's terminal coding agent) as a scannable source. It persists sessions in local SQLite, so pasted keys sit in cleartext on disk exactly like every other agent here.

**The path/format question in the issue, answered from Crush's source rather than a guess.** The data directory is resolved *relative to the working directory* and searched upward no further than the git worktree root (`internal/config/load.go`, `projectBoundary` → `worktreeRoot`), with `defaultDataDirectory = ".crush"`. So the db lands at:

```
<project>/.crush/crush.db
```

There is **no central store and no platform data dir** — every project the user ran Crush in has its own db. That makes Crush the *second per-project source* after Aider, which drives the design below.

Secrets live in three places, per `internal/db/migrations/20250424200609_initial.sql`:

| Table.column | Holds |
|---|---|
| `messages.parts` | message text (JSON) |
| `sessions.title` | session title |
| `files.content` | **whole file bodies Crush read** — a `.env` it opened is in the db verbatim |

`_GenericSqliteSource` already scans every text column of every table and redacts via the copy-and-verify path, so `CrushSource` only overrides discovery and inherits the write contract untouched.

Closes #50

## Type of change

- [ ] Bug fix
- [x] New agent source
- [ ] New detection rule
- [ ] Feature / enhancement
- [ ] Refactor / docs / chore

## Notes for review

**Discovery is shared with Aider rather than copied.** Per-project storage means walking from `$HOME`, which Aider already does — with prune sets, a depth cap, and a deliberately non-silent cap warning. Rather than duplicate ~45 subtle lines (and let the copies drift), that walk moves to `_iter_project_histories` in `_helpers.py`, parameterised by the artifact matcher, depth, and warning label. **Aider's behaviour and warning text are unchanged and its 12 discovery tests pass untouched** — that was the bar for the refactor.

**No `menu.py` / `ui/widgets.py` entry, despite step 4 of the issue.** `ui/picker.py` builds its list from the `SOURCES` registry and appends the `(experimental)` tag itself, so registration is sufficient — that instruction looks stale. Verified:

```
$ agentsweep list-sources --json
{"source": "crush", "display": "Crush", "experimental": true, "root": "C:\\Users\\priya", "detected": false}
```

**One existing test needed narrowing.** `test_all_new_sources_registered_with_distinct_roots` asserted every source has a unique `default_root`. Per-project sources legitimately share `$HOME` — `aider` already did, `crush` is the second — so the check now applies to fixed-path sources, where a duplicate really would mean one source silently scanning another's store. Flagging it since it's a deliberate change to an existing assertion, not an oversight.

**`is_detected` walks instead of checking a config path.** `$HOME` always exists, so `root.exists()` would report Crush installed on every machine; the `Source` docstring asks detection to reflect real history, so it early-exits on the first db found.

**Marked `experimental`.** The path and schema come from reading Crush's source, not from a real install — the same footing Warp / Grok CLI / Kiro CLI shipped on. A follow-up verification issue in the style of #37–40 can drop the tag; happy to open one.

## Testing

New `tests/test_crush_source.py` (11 tests) builds the fixture db in-test with Crush's real schema, so no binary is committed:

- discovery: finds a per-project db, finds several across projects, skips pruned dirs (`node_modules`), ignores a `.crush/` with no db
- `is_detected` flips false → true only once real history exists
- `iter_strings` finds secrets in both `messages.parts` and `files.content`
- `scan --source crush --json` reports `aws-access-key`
- `fix`: secret gone, `[REDACTED:aws-access-key]` present, `parts` still parses as JSON, `PRAGMA integrity_check` = ok, `.bak` created
- `undo` restores the db byte-for-byte

```
$ pytest tests/test_crush_source.py -q
11 passed in 1.12s

$ pytest tests/test_aider_discovery.py -q      # the refactor's guardrail
12 passed in 0.96s

$ pytest -q
497 passed, 10 skipped in 113.23s
```

Windows / Python 3.11.9, clean venv, rebased onto current `main` (`e4d697f`). `ruff check` is clean on every file this PR touches.

## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13) — local Windows/3.11 green as above; deferring the rest of the matrix to CI
- [x] No real secrets, tokens, or raw history-file contents are committed — the fixture db is built in-test from synthetic rows using the same non-live `AKIAIOSFODNN7EXAMPLE` / `ghp_…` examples as the rest of the suite
- [x] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail) — `redactor.py` is untouched; `CrushSource` inherits `_GenericSqliteSource`'s copy-and-verify path unchanged, and the round-trip test asserts `integrity_check`, the `.bak`, and byte-exact `undo`
- [ ] **New detection rule?** — n/a
- [x] **New source?** Registered in `SOURCES` with process markers, a menu entry, and a round-trip test (see CLAUDE.md → "Adding a new Source") — registered with `CRUSH_MARKERS`; menu entry is automatic via the registry (see above)
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths) — no output paths touched; the depth-cap warning goes to stderr, matching Aider
- [x] Did not re-introduce `force-include` in `pyproject.toml` — `pyproject.toml` is not modified by this PR
