### PR TITLE
feat(cli): add SARIF 2.1.0 output for CI and code scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,9 +251,28 @@ agentsweep scan --json
 agentsweep scan --json -o findings.json
 agentsweep scan --json --output /tmp/report.json
 
+# SARIF 2.1.0 for GitHub code scanning / VS Code SARIF viewer (scan only)
+agentsweep scan --format sarif -o agentsweep.sarif
+agentsweep scan --all --format sarif -o agentsweep.sarif
+
 # Skip .agentsweepignore files
 agentsweep scan --no-ignore
 ```
+
+#### SARIF in CI
+
+`--format sarif` emits [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html), so findings show up as code-scanning annotations instead of something you have to parse. Rotation guidance rides along in each rule's `help` text, and only the masked preview is included — the secret itself is never written to the report.
+
+```yaml
+- name: Scan agent history for secrets
+  run: |
+    pipx run agentsweep scan --all --format sarif -o agentsweep.sarif || true
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: agentsweep.sarif
+```
+
+`|| true` keeps the upload step reachable — `scan` exits 1 when it finds something, which is what you want the SARIF to report rather than a failed step.
 
 ### Fix-only flags
 

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -247,6 +247,10 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
                          "flooding the terminal.")
     ap.add_argument("--json", action="store_true",
                     help="Emit findings as JSON to stdout (no banner/styling).")
+    ap.add_argument("--format", choices=["sarif"],
+                    help="Emit findings in an interchange format instead of "
+                         "the default report: sarif = SARIF 2.1.0 for GitHub "
+                         "code scanning and SARIF viewers (scan only).")
     ap.add_argument("--no-ignore", action="store_true",
                     help="Ignore any .agentsweepignore files.")
     # Redaction flags (used by `fix` / legacy --fix; harmless on `scan`).
@@ -258,6 +262,13 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
                     help="Allow --fix against the default production root.")
     args = ap.parse_args(rest)
     args.fix = (verb == "fix")
+
+    if args.format is not None:
+        if args.json:
+            ap.error("cannot use --json with --format sarif; pick one output "
+                     "format")
+        if args.fix:
+            ap.error("--format is a scan output format; not valid with fix")
 
     if args.all:
         if args.source is not None:

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -17,7 +17,7 @@ from . import __version__, ui
 from . import ignore as ignore_mod
 from .preflight import is_agent_running, is_production_root
 from .redactor import SafetyError, safe_write, safety_check
-from .scanner import ROTATION_GUIDANCE, Finding, scan_text
+from .scanner import ROTATION_GUIDANCE, RULES, Finding, scan_text
 from .sources import SOURCES, Source
 
 
@@ -51,15 +51,28 @@ def run(args, *, _findings_out: list | None = None,
     source: Source = source_cls(root=args.root) if args.root else source_cls()
     output: Path | None = _opt(args, "output")
 
+    as_sarif = _opt(args, "format") == "sarif"
+    # Both machine formats share every no-banner/no-styling branch below; they
+    # differ only in what an empty result set looks like on stdout.
+    machine = bool(args.json) or as_sarif
+
+    def _print_empty_machine_output() -> None:
+        # stdout must stay parseable in every machine-format run, including
+        # user errors — for SARIF that means a valid document, not "[]".
+        if as_sarif:
+            print(json.dumps(_sarif_document([]), indent=2))
+        elif args.json:
+            print("[]")
+
     if args.root is not None and not source.root.exists():
         print(f"Path not found: {source.root}", file=sys.stderr)
         for hint in _suggest_paths(source.root):
             print(f"  did you mean: {source.root.parent / hint}", file=sys.stderr)
-        if args.json:
-            print("[]")  # stdout stays parseable JSON even on user error
+        if machine:
+            _print_empty_machine_output()
         return 2
 
-    if not args.json:
+    if not machine:
         ui.banner(__version__)
         if getattr(source, "experimental", False):
             ui.warn_line(
@@ -67,7 +80,7 @@ def run(args, *, _findings_out: list | None = None,
                 f"path/format is inferred from research and not yet verified "
                 f"against a real install, so it may find nothing")
 
-    if not args.json:
+    if not machine:
         files: list[Path] = []
         with ui.console.status("") as status:
             for f in source.iter_files():
@@ -80,8 +93,8 @@ def run(args, *, _findings_out: list | None = None,
         files = list(source.iter_files())
     if not files:
         print(f"No history files found under {source.root}", file=sys.stderr)
-        if args.json:
-            print("[]")  # stdout must stay parseable JSON in every --json run
+        if machine:
+            _print_empty_machine_output()
         else:
             ui.stage(1, "warn", "DISCOVER", source.name,
                      f"no history files under {source.root}", err=True)
@@ -90,11 +103,14 @@ def run(args, *, _findings_out: list | None = None,
     ignores = (ignore_mod.IgnoreSet() if _opt(args, "no_ignore")
                else ignore_mod.load([source.root, Path.cwd()]))
 
-    if args.json:
+    if machine:
         found_by_file, _, suppressed, truncated = _scan(source, files, ignores)
         if truncated:
             print(f"warning: {len(truncated)} file(s) exceeded the scan budget "
                   f"and were truncated", file=sys.stderr)
+        if as_sarif:
+            return _emit_sarif(_json_payload(found_by_file, source),
+                               output, suppressed)
         return _output_json(found_by_file, source, output, suppressed)
 
     ui.stage(1, "ok", "DISCOVER", source.name, f"{len(files)} file(s)", source.root)
@@ -281,7 +297,8 @@ def run_all(args) -> int:
         return 2
 
     output: Path | None = _opt(args, "output")
-    as_json = bool(_opt(args, "json", False))
+    as_sarif = _opt(args, "format") == "sarif"
+    as_json = bool(_opt(args, "json", False)) or as_sarif
     detected_only = bool(_opt(args, "detected", False))
     no_ignore = bool(_opt(args, "no_ignore", False))
 
@@ -412,6 +429,8 @@ def run_all(args) -> int:
                 f"and were truncated",
                 file=sys.stderr,
             )
+        if as_sarif:
+            return _emit_sarif(payload, output, total_suppressed)
         return _emit_json_payload(payload, output, total_suppressed)
 
     ui.stage(2, "ok", "SCAN", f"{total_files} file(s)",
@@ -679,6 +698,98 @@ def _json_payload(found_by_file: dict, source: Source) -> list[dict]:
                 "masked": finding.masked,
             })
     return payload
+
+
+SARIF_SCHEMA = (
+    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/"
+    "sarif-schema-2.1.0.json"
+)
+SARIF_VERSION = "2.1.0"
+_PROJECT_URL = "https://github.com/Ishannaik/agent-sweep"
+
+
+def _sarif_document(payload: list[dict]) -> dict:
+    """Build a SARIF 2.1.0 document from the JSON findings payload.
+
+    Only rules that actually matched become tool.driver.rules, so a run
+    carries guidance for what was found rather than all of RULES. Message
+    text reuses each finding's `masked` preview; the plaintext secret is
+    never read here, so it cannot reach the report.
+    """
+    displays = {rule: display for rule, display, _pattern in RULES}
+
+    rule_ids: list[str] = []
+    for f in payload:
+        if f["rule"] not in rule_ids:
+            rule_ids.append(f["rule"])
+
+    rules: list[dict] = []
+    for rule_id in rule_ids:
+        descriptor: dict = {
+            "id": rule_id,
+            "name": displays.get(rule_id, rule_id),
+            "shortDescription": {"text": displays.get(rule_id, rule_id)},
+        }
+        guidance = ROTATION_GUIDANCE.get(rule_id)
+        if guidance:
+            descriptor["help"] = {"text": guidance}
+        rules.append(descriptor)
+
+    index_of = {rule_id: i for i, rule_id in enumerate(rule_ids)}
+    results: list[dict] = []
+    for f in payload:
+        results.append({
+            "ruleId": f["rule"],
+            "ruleIndex": index_of[f["rule"]],
+            "level": "error",
+            "message": {
+                "text": (f"{f['display']} found in {f['source']} history: "
+                         f"{f['masked']}"),
+            },
+            "locations": [{
+                "physicalLocation": {
+                    "artifactLocation": {
+                        "uri": Path(f["file"]).resolve().as_uri(),
+                    },
+                    "region": {"startLine": max(1, int(f["line"]))},
+                },
+            }],
+        })
+
+    return {
+        "$schema": SARIF_SCHEMA,
+        "version": SARIF_VERSION,
+        "runs": [{
+            "tool": {"driver": {
+                "name": "agentsweep",
+                "version": __version__,
+                "informationUri": _PROJECT_URL,
+                "rules": rules,
+            }},
+            "results": results,
+        }],
+    }
+
+
+def _emit_sarif(payload: list[dict], output: Path | None,
+                suppressed: int) -> int:
+    """Emit a SARIF report to `output` or stdout.
+
+    Machine-clean like the JSON path — no banner, no styling — and the exit
+    code matches it: 1 with findings, 0 clean.
+    """
+    code = 0 if not payload else 1
+    text = json.dumps(_sarif_document(payload), indent=2) + "\n"
+
+    if output is not None:
+        _write_text(output, text)
+        print(f"{len(payload)} finding(s) written to {output}", file=sys.stderr)
+        return code
+
+    print(text, end="")
+    if suppressed:
+        print(f"({suppressed} suppressed by .agentsweepignore)", file=sys.stderr)
+    return code
 
 
 def _emit_json_payload(payload: list[dict], output: Path | None,

--- a/tests/test_sarif_output.py
+++ b/tests/test_sarif_output.py
@@ -1,0 +1,171 @@
+"""SARIF 2.1.0 output: structure, masking, exit codes, and CLI contract.
+
+Structural assertions only — no vendored schema and no network, per the
+project's hermetic-test rule.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import url2pathname
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.cli import main  # noqa: E402
+
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+GH_TOKEN = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+
+_LINE = (
+    '{{"type":"user","message":{{"role":"user","content":'
+    '[{{"type":"text","text":"{secret}"}}]}}}}\n'
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
+def _seed(base: Path, *secrets: str) -> Path:
+    root = base / "scan_root"
+    root.mkdir(parents=True, exist_ok=True)
+    f = root / "session.jsonl"
+    f.write_text(
+        "".join(_LINE.format(secret=f"key={s}") for s in secrets),
+        encoding="utf-8",
+    )
+    past = time.time() - 3700
+    os.utime(f, (past, past))
+    return root
+
+
+def _scan_sarif(root: Path, capsys) -> dict:
+    code = main(["scan", "--root", str(root), "--format", "sarif"])
+    out = capsys.readouterr().out
+    doc = json.loads(out)
+    doc["_exit"] = code
+    return doc
+
+
+def test_sarif_shape(tmp_path, capsys):
+    doc = _scan_sarif(_seed(tmp_path, AWS_KEY), capsys)
+
+    assert doc["version"] == "2.1.0"
+    assert "$schema" in doc
+    assert len(doc["runs"]) == 1
+    driver = doc["runs"][0]["tool"]["driver"]
+    assert driver["name"] == "agentsweep"
+    assert driver["informationUri"]
+    assert driver["version"]
+
+
+def test_rules_carry_rotation_guidance(tmp_path, capsys):
+    doc = _scan_sarif(_seed(tmp_path, AWS_KEY), capsys)
+
+    rules = doc["runs"][0]["tool"]["driver"]["rules"]
+    aws = next(r for r in rules if r["id"] == "aws-access-key")
+    assert aws["name"] == "AWS access key"
+    assert "aws iam create-access-key" in aws["help"]["text"]
+
+
+def test_only_matched_rules_are_emitted(tmp_path, capsys):
+    doc = _scan_sarif(_seed(tmp_path, AWS_KEY), capsys)
+
+    rules = doc["runs"][0]["tool"]["driver"]["rules"]
+    assert [r["id"] for r in rules] == ["aws-access-key"]
+
+
+def test_result_location_points_at_the_file(tmp_path, capsys):
+    root = _seed(tmp_path, AWS_KEY)
+    doc = _scan_sarif(root, capsys)
+
+    result = doc["runs"][0]["results"][0]
+    assert result["ruleId"] == "aws-access-key"
+    assert result["level"] == "error"
+    loc = result["locations"][0]["physicalLocation"]
+    assert loc["region"]["startLine"] == 1
+    uri = loc["artifactLocation"]["uri"]
+    assert uri.startswith("file://")
+    resolved = Path(url2pathname(urlparse(uri).path))
+    assert resolved.name == "session.jsonl"
+
+
+def test_rule_index_resolves_into_rules(tmp_path, capsys):
+    doc = _scan_sarif(_seed(tmp_path, AWS_KEY, GH_TOKEN), capsys)
+
+    run = doc["runs"][0]
+    rules = run["tool"]["driver"]["rules"]
+    for result in run["results"]:
+        assert rules[result["ruleIndex"]]["id"] == result["ruleId"]
+
+
+def test_secret_plaintext_never_appears(tmp_path, capsys):
+    doc = _scan_sarif(_seed(tmp_path, AWS_KEY, GH_TOKEN), capsys)
+    doc.pop("_exit")
+
+    blob = json.dumps(doc)
+    assert AWS_KEY not in blob
+    assert GH_TOKEN not in blob
+    assert "AKIAIO" in blob  # the masked preview is still there
+
+
+def test_exit_code_matches_json_path(tmp_path, capsys):
+    assert _scan_sarif(_seed(tmp_path, AWS_KEY), capsys)["_exit"] == 1
+
+
+def test_clean_root_is_valid_empty_sarif(tmp_path, capsys):
+    root = tmp_path / "clean"
+    root.mkdir()
+    f = root / "session.jsonl"
+    f.write_text('{"type":"user","message":"nothing here"}\n', encoding="utf-8")
+    past = time.time() - 3700
+    os.utime(f, (past, past))
+
+    doc = _scan_sarif(root, capsys)
+    assert doc["_exit"] == 0
+    assert doc["runs"][0]["results"] == []
+
+
+def test_missing_root_still_emits_valid_sarif(tmp_path, capsys):
+    code = main(["scan", "--root", str(tmp_path / "nope"), "--format", "sarif"])
+    doc = json.loads(capsys.readouterr().out)
+
+    assert code == 2
+    assert doc["version"] == "2.1.0"
+    assert doc["runs"][0]["results"] == []
+
+
+def test_output_file_keeps_stdout_clean(tmp_path, capsys):
+    root = _seed(tmp_path, AWS_KEY)
+    dest = tmp_path / "out.sarif"
+
+    code = main(["scan", "--root", str(root), "--format", "sarif",
+                 "-o", str(dest)])
+    captured = capsys.readouterr()
+
+    assert code == 1
+    assert captured.out == ""
+    doc = json.loads(dest.read_text(encoding="utf-8"))
+    assert doc["version"] == "2.1.0"
+    assert AWS_KEY not in dest.read_text(encoding="utf-8")
+
+
+def test_sarif_rejects_json_combination(tmp_path):
+    with pytest.raises(SystemExit):
+        main(["scan", "--root", str(tmp_path), "--format", "sarif", "--json"])
+
+
+def test_sarif_rejected_on_fix(tmp_path):
+    with pytest.raises(SystemExit):
+        main(["fix", "--root", str(tmp_path), "--format", "sarif"])


### PR DESCRIPTION
## What & why

`scan --json` emits our own schema, so wiring agentsweep into CI means parsing it. `--format sarif` emits [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) — what GitHub code scanning, the VS Code SARIF viewer and most dashboards already read — so findings arrive as annotations instead.

Real output from a fixture (`scan --root <fixture> --format sarif`):

```json
{
  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
  "version": "2.1.0",
  "runs": [{
    "tool": {"driver": {
      "name": "agentsweep",
      "version": "0.1.9",
      "informationUri": "https://github.com/Ishannaik/agent-sweep",
      "rules": [{
        "id": "aws-access-key",
        "name": "AWS access key",
        "shortDescription": {"text": "AWS access key"},
        "help": {"text": "Rotate: aws iam create-access-key, then aws iam delete-access-key --access-key-id <ID>"}
      }]
    }},
    "results": [{
      "ruleId": "aws-access-key",
      "ruleIndex": 0,
      "level": "error",
      "message": {"text": "AWS access key found in claude-code history: AKIAIO********MPLE"},
      "locations": [{"physicalLocation": {
        "artifactLocation": {"uri": "file:///.../session.jsonl"},
        "region": {"startLine": 1}
      }}]
    }]
  }]
}
```

Closes #46

## Type of change

- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [x] Feature / enhancement
- [ ] Refactor / docs / chore

## Notes for review

**The secret can't leak by construction, not by remembering to strip it.** The document is built from the existing `_json_payload`, and message text reuses each finding's `masked` preview — `finding.value` is never read on this path. A test asserts the raw values appear nowhere in the emitted document.

**Built from the existing payload** rather than a second collection pass, so JSON and SARIF can't drift apart on what counts as a finding. Only rules that actually matched become `tool.driver.rules`, each with its `ROTATION_GUIDANCE` in `help.text` — a run carries guidance for what was found rather than all 191 rules.

**One behavioural wrinkle worth a look.** `--json` prints `[]` on a user error / empty run so stdout stays parseable. `[]` is not valid SARIF, so those same paths (missing `--root`, no history files, clean scan) emit a document with `results: []` instead. Everything else — no banner, no styling, exit codes 1/0/2 — is shared with the `--json` branches rather than duplicated.

Works for `scan` and `scan --all`. Rejected with `--json` (pick one format) and on `fix`, since it's a scan output format.

**On the "loads in VS Code's SARIF viewer (screenshot)" criterion** — I haven't done that, so I'm not claiming it. What I did verify is the structure, the masking, the file URI resolving back to the real path, and `ruleIndex` resolving into `tool.driver.rules` (the field viewers actually dereference). Happy to add a screenshot if you'd like it before merge.

Per the issue, tests use structural assertions rather than a vendored schema, and no network.

## Testing

New `tests/test_sarif_output.py` (12 tests): document shape, matched-rules-only, rotation guidance in `help.text`, `ruleIndex` → `rules` resolution, file URI round-tripping to the right file, `startLine`, exit-code parity with `--json`, valid empty SARIF for a clean root and a missing root, `-o` keeping stdout clean, and both rejection paths (`--json` combo, `fix`).

```
$ pytest tests/test_sarif_output.py -q
12 passed in 0.28s

$ pytest -q
498 passed, 10 skipped in 109.85s
```

Windows / Python 3.11.9, clean venv, based on current `main` (`e4d697f`). `ruff check` clean on every touched file.

README documents the flag plus a copy-pasteable `upload-sarif` CI snippet.

## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13) — local Windows/3.11 green as above; deferring the rest of the matrix to CI
- [x] No real secrets, tokens, or raw history-file contents are committed — fixtures are synthetic, and a test asserts no plaintext reaches the SARIF
- [x] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail) — n/a, scan-only output path; `redactor.py` untouched
- [ ] **New detection rule?** — n/a
- [ ] **New source?** — n/a
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths) — `--format sarif` reuses the same machine-clean branches; the only stderr output is the existing scan-budget/suppressed notes, matching `--json`
- [x] Did not re-introduce `force-include` in `pyproject.toml` — `pyproject.toml` is not modified by this PR
