### PR TITLE
feat(pipeline): support fix --all — guided multi-source redaction

### DIFF
--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -9,6 +9,8 @@ Usage shapes, all supported:
     agentsweep scan --all --detected
                                scan only agents whose history root exists
     agentsweep fix  [opts]     redact (guided + confirmed on a terminal)
+    agentsweep fix --all       redact every agent with findings, one at a time
+                               (each source gated + confirmed separately)
     agentsweep undo [opts]     restore .bak backups
     agentsweep purge [opts]    delete .bak backups (after rotating the keys)
     agentsweep list-sources    list supported agents + which are on this machine
@@ -236,8 +238,9 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
     ap.add_argument("--root", type=Path,
                     help="Override the source's default root directory.")
     ap.add_argument("--all", action="store_true",
-                    help="Scan every registered agent source and aggregate "
-                         "findings (scan only; not valid with fix).")
+                    help="Every registered agent source: scan aggregates "
+                         "findings; fix redacts each source in turn, gated "
+                         "and confirmed separately.")
     ap.add_argument("--detected", action="store_true",
                     help="With --all, only scan sources whose history root "
                          "exists on this machine (same signal as "
@@ -264,11 +267,6 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
             ap.error("cannot use --source with --all")
         if args.root is not None:
             ap.error("cannot use --root with --all")
-        if args.fix:
-            ap.error(
-                "fix --all is not supported; "
-                "run: agentsweep fix --source <name>"
-            )
         # Placeholder so any code that still reads args.source is safe.
         args.source = "claude-code"
     else:
@@ -353,6 +351,8 @@ def _get_completion_parser() -> argparse.ArgumentParser:
                                      help="Which agent's history (default: claude-code).")
     fix_source.completer = source_completer
     fix_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
+    fix_p.add_argument("--all", action="store_true", help="Redact every agent source with findings, one at a time.")
+    fix_p.add_argument("--detected", action="store_true", help="With --all, only sources whose history root exists.")
     fix_p.add_argument("-o", "--output", type=Path, help="Write findings as JSON to this file.")
     fix_p.add_argument("--json", action="store_true", help="Emit findings as JSON to stdout.")
     fix_p.add_argument("--no-ignore", action="store_true", help="Ignore any .agentsweepignore files.")

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -265,21 +265,15 @@ def list_sources(args) -> int:
 def run_all(args) -> int:
     """Scan every registered (or detected) source and aggregate findings.
 
-    Scan-only — redaction stays per-source via ``fix --source <name>``.
+    With ``--fix``, each source with findings is then redacted through the
+    single-source path — see _fix_all_sources.
 
-    Exit codes: 0 clean / nothing scanned · 1 findings · 2 misuse (e.g. fix).
+    Exit codes: 0 clean / nothing scanned / everything redacted · 1 findings
+    (scan-only) · 2 a source was gate-blocked or errored during --fix.
     Missing roots are skipped (not errors), matching single-source "no files
     under root → 0". ``--detected`` restricts to sources that report history
     on this machine (same signal as ``list-sources --detected``).
     """
-    if _opt(args, "fix", False):
-        print(
-            "fix --all is not supported; "
-            "run: agentsweep fix --source <name>",
-            file=sys.stderr,
-        )
-        return 2
-
     output: Path | None = _opt(args, "output")
     as_json = bool(_opt(args, "json", False))
     detected_only = bool(_opt(args, "detected", False))
@@ -481,15 +475,98 @@ def run_all(args) -> int:
             f"full multi-source findings ({grand}) written to {report}"
         )
 
+    if _opt(args, "fix", False):
+        return _fix_all_sources(args, dirty)
+
     dirty_names = ", ".join(k for k, _s, _f in dirty)
     ui.stage(4, "skip", "REDACT",
-             f"skipped — run: agentsweep fix --source <name>  "
+             f"skipped — run with --fix to redact in place (.bak backups)  "
              f"(dirty: {dirty_names})")
     ui.stage(5, "warn", "ROTATE", "these keys are still live")
     # Flatten across sources — do not merge by Path (collisions across roots).
     ui.rotation_panel(_rotation_items_multi(dirty))
     ui.contribute_line()
     return 1
+
+
+def _fix_all_sources(args, dirty: list[tuple[str, Source, dict]]) -> int:
+    """Redact every source with findings, one at a time.
+
+    Each source runs the same path a single-source fix does — its own
+    _preflight_gates, its own _redact_all, and therefore its own safe_write
+    with backup, validation and audit. Nothing is batched across sources and
+    no write happens outside safe_write().
+
+    A source that is gate-blocked, declined, or errors does not abort the
+    others: finishing the sweep is the point of --all, and stopping early
+    would leave the user worse off than the per-source loop they're replacing.
+    On a terminal each source needs its own typed REDACT, so the blast radius
+    is never hidden behind one blanket confirm.
+
+    Returns 0 only if every source redacted cleanly, else 2.
+    """
+    interactive = (sys.stdin.isatty() and ui.console.is_terminal
+                   if hasattr(sys.stdin, "isatty") else False)
+
+    total = len(dirty)
+    redacted: list[str] = []
+    unresolved: list[str] = []
+
+    for key, source, found_by_file in dirty:
+        source_cls = SOURCES[key]
+        src_total = sum(len(v) for v in found_by_file.values())
+
+        if interactive:
+            print()
+            ui.warn_line(
+                f"{key}: {src_total} secret(s) in {len(found_by_file)} file(s) "
+                f"under {source.root} — redact now? "
+                f"(.bak backups kept; `agentsweep undo --source {key}` reverts)"
+            )
+            try:
+                typed = input(
+                    f"  type REDACT to confirm {key} (anything else skips it): "
+                ).strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                unresolved.append(key)
+                break
+            if typed != "REDACT":
+                ui.redact_row("skip", key, "cancelled — nothing written")
+                unresolved.append(key)
+                continue
+
+        gate_err, _recoverable = _preflight_gates(source, source_cls, args)
+        if gate_err is not None:
+            unresolved.append(key)
+            continue
+
+        rows, errors, _recoverable = _redact_all(
+            source=source,
+            found_by_file=found_by_file,
+            backup=not args.no_backup,
+            force=args.force,
+        )
+        for status, path_display, note in rows:
+            ui.redact_row(status, f"{key}: {path_display}", note)
+        if errors:
+            unresolved.append(key)
+        else:
+            redacted.append(key)
+
+    if unresolved:
+        ui.stage(4, "warn", "REDACT",
+                 f"{len(redacted)}/{total} source(s) redacted",
+                 f"unresolved: {', '.join(unresolved)}")
+    else:
+        ui.stage(4, "ok", "REDACT", f"{len(redacted)}/{total} source(s) redacted")
+
+    # Every scanned key is still live until rotated — including those under a
+    # source we could not redact, who need the guidance most.
+    ui.stage(5, "warn", "ROTATE", "redacted locally", "keys live until rotated")
+    ui.rotation_panel(_rotation_items_multi(dirty))
+    ui.contribute_line()
+    return 2 if unresolved else 0
 
 
 def _suggest_paths(missing: Path) -> list[str]:

--- a/tests/test_fix_all.py
+++ b/tests/test_fix_all.py
@@ -1,0 +1,201 @@
+"""fix --all: sequential per-source redaction with independent gates.
+
+Each source runs the single-source fix path, so a gate block on one must not
+cost the others their redaction — that is the whole point of --all over the
+per-source loop it replaces.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep import pipeline  # noqa: E402
+from agentsweep.cli import main  # noqa: E402
+
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+GH_TOKEN = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+
+_CLAUDE_LINE = (
+    '{{"type":"user","message":{{"role":"user","content":'
+    '[{{"type":"text","text":"key={secret}"}}]}}}}\n'
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    """Isolate HOME and the Windows/XDG dirs so multi-source discovery is
+    hermetic — every registered source is visited here, and the ones rooted at
+    APPDATA/LOCALAPPDATA would otherwise read the real machine's history."""
+    home = tmp_path / "home"
+    home.mkdir()
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    appdata = tmp_path / "appdata"
+    appdata.mkdir()
+    local = tmp_path / "localappdata"
+    local.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg / "share"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg / "config"))
+    monkeypatch.setenv("APPDATA", str(appdata))
+    monkeypatch.setenv("LOCALAPPDATA", str(local))
+    monkeypatch.setenv("AGENTSWEEP_NO_UPDATE", "1")
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _no_agent_running(monkeypatch):
+    monkeypatch.setattr(pipeline, "is_agent_running", lambda markers: (False, ""))
+
+
+@pytest.fixture(autouse=True)
+def _non_interactive(monkeypatch):
+    # capsys already makes stdout a non-tty; pin stdin too so the per-source
+    # REDACT prompt never fires and a hang can't masquerade as a pass.
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+
+
+def _age(p: Path, seconds: int = 3700) -> None:
+    past = time.time() - seconds
+    os.utime(p, (past, past))
+
+
+def _seed_claude(home: Path, secret: str = AWS_KEY, *, age: int = 3700) -> Path:
+    d = home / ".claude" / "projects" / "proj"
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "session.jsonl"
+    f.write_text(_CLAUDE_LINE.format(secret=secret), encoding="utf-8")
+    _age(f, age)
+    return f
+
+
+def _seed_codex(home: Path, secret: str = GH_TOKEN, *, age: int = 3700) -> Path:
+    d = home / ".codex" / "sessions" / "2026" / "04" / "24"
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "rollout-2026-04-24T17-28-47-019dbf5b.jsonl"
+    f.write_text(
+        json.dumps({"type": "event_msg", "text": f"token={secret}"}) + "\n",
+        encoding="utf-8",
+    )
+    _age(f, age)
+    return f
+
+
+def test_fix_all_redacts_every_source(_isolate_home, capsys):
+    claude = _seed_claude(_isolate_home)
+    codex = _seed_codex(_isolate_home)
+
+    code = main(["fix", "--all", "--force", "--allow-production"])
+
+    assert code == 0
+    assert AWS_KEY not in claude.read_text(encoding="utf-8")
+    assert GH_TOKEN not in codex.read_text(encoding="utf-8")
+    assert "[REDACTED:aws-access-key]" in claude.read_text(encoding="utf-8")
+    assert "[REDACTED:github-pat]" in codex.read_text(encoding="utf-8")
+
+
+def test_each_source_gets_its_own_backup(_isolate_home, capsys):
+    claude = _seed_claude(_isolate_home)
+    codex = _seed_codex(_isolate_home)
+
+    assert main(["fix", "--all", "--force", "--allow-production"]) == 0
+
+    assert claude.with_name(claude.name + ".bak").exists()
+    assert codex.with_name(codex.name + ".bak").exists()
+
+
+def test_each_source_gets_its_own_audit_entry(_isolate_home, capsys):
+    _seed_claude(_isolate_home)
+    _seed_codex(_isolate_home)
+
+    assert main(["fix", "--all", "--force", "--allow-production"]) == 0
+
+    audit = _isolate_home / ".agentsweep" / "audit.jsonl"
+    entries = [json.loads(x) for x in
+               audit.read_text(encoding="utf-8").splitlines() if x.strip()]
+    written = {Path(e["path"]).name for e in entries}
+    assert "session.jsonl" in written
+    assert any(n.startswith("rollout-") for n in written)
+
+
+def test_gate_block_on_one_source_leaves_others_redacted(_isolate_home, capsys):
+    claude = _seed_claude(_isolate_home)
+    # Fresh mtime: trips the active-session gate for codex only. --force would
+    # bypass it, so this run deliberately omits it.
+    codex = _seed_codex(_isolate_home, age=1)
+
+    code = main(["fix", "--all", "--allow-production"])
+
+    assert code == 2
+    assert AWS_KEY not in claude.read_text(encoding="utf-8")   # still redacted
+    assert GH_TOKEN in codex.read_text(encoding="utf-8")       # left untouched
+    assert not codex.with_name(codex.name + ".bak").exists()
+
+
+def test_blocked_source_is_named_in_output(_isolate_home, capsys):
+    _seed_claude(_isolate_home)
+    _seed_codex(_isolate_home, age=1)
+
+    main(["fix", "--all", "--allow-production"])
+    out = capsys.readouterr().out
+
+    assert "codex" in out
+    assert "unresolved" in out
+
+
+def test_clean_machine_exits_zero(_isolate_home, capsys):
+    assert main(["fix", "--all", "--allow-production"]) == 0
+
+
+def test_undo_reverts_every_source(_isolate_home, capsys):
+    claude = _seed_claude(_isolate_home)
+    codex = _seed_codex(_isolate_home)
+    claude_before = claude.read_bytes()
+    codex_before = codex.read_bytes()
+
+    assert main(["fix", "--all", "--force", "--allow-production"]) == 0
+    assert main(["undo", "--source", "claude-code"]) == 0
+    assert main(["undo", "--source", "codex"]) == 0
+
+    assert claude.read_bytes() == claude_before
+    assert codex.read_bytes() == codex_before
+
+
+def test_no_secret_plaintext_in_output(_isolate_home, capsys):
+    _seed_claude(_isolate_home)
+    _seed_codex(_isolate_home)
+
+    main(["fix", "--all", "--force", "--allow-production"])
+    captured = capsys.readouterr()
+
+    assert AWS_KEY not in captured.out
+    assert GH_TOKEN not in captured.out
+
+
+def test_fix_all_detected_only_visits_existing_roots(_isolate_home, capsys):
+    claude = _seed_claude(_isolate_home)
+
+    code = main(["fix", "--all", "--detected", "--force", "--allow-production"])
+
+    assert code == 0
+    assert AWS_KEY not in claude.read_text(encoding="utf-8")
+
+
+def test_json_stays_scan_only(_isolate_home, capsys):
+    """--json short-circuits before redaction, matching fix --source --json."""
+    claude = _seed_claude(_isolate_home)
+
+    code = main(["fix", "--all", "--json", "--force", "--allow-production"])
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert json.loads(out)  # parseable, and still a findings list
+    assert AWS_KEY in claude.read_text(encoding="utf-8")

--- a/tests/test_scan_all.py
+++ b/tests/test_scan_all.py
@@ -5,7 +5,7 @@ Covers:
   (b) one seeded source → exit 1, findings tagged with that source
   (c) two seeded sources → findings from both, distinguished by "source"
   (d) --all --detected only visits roots that exist
-  (e) --all + --source / --root / fix --all rejected
+  (e) --all + --source / --root rejected; fix --all accepted
   (f) --detected without --all rejected
   (g) human mode stages + no raw secrets
   (h) --json -o writes aggregated file, clean stdout
@@ -188,10 +188,14 @@ def test_scan_all_rejects_root_flag(tmp_path):
     assert ei.value.code == 2
 
 
-def test_fix_all_rejected():
-    with pytest.raises(SystemExit) as ei:
-        main(["fix", "--all"])
-    assert ei.value.code == 2
+def test_fix_all_is_accepted():
+    # Parse-level only: fix --all is supported now, so calling main() here
+    # would scan the real machine instead of tmp_path.
+    from agentsweep.cli import _parse_run
+
+    args = _parse_run("fix", ["--all"])
+    assert args.all is True
+    assert args.fix is True
 
 
 def test_detected_without_all_rejected():
@@ -217,8 +221,8 @@ def test_scan_all_human_mode_stages(_isolate_env, capsys):
     assert "codex" in out
     assert AWS_KEY not in out
     assert GH_TOKEN not in out
-    # Points at per-source fix, not fix --all
-    assert "fix --source" in out
+    # Scan stops at FINDINGS and points at the redaction flag, never redacting.
+    assert "--fix" in out
 
 
 def test_scan_all_human_clean(_isolate_env, capsys):

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -521,7 +521,7 @@ def test_completion_setup_does_not_swallow_parser_errors(monkeypatch):
         main(["--version"])
 
 
-def test_fix_completion_does_not_advertise_unsupported_flags():
+def test_fix_completion_matches_the_cli_contract():
     from agentsweep.cli import _get_completion_parser
 
     parser = _get_completion_parser()
@@ -537,8 +537,10 @@ def test_fix_completion_does_not_advertise_unsupported_flags():
         for option in action.option_strings
     }
 
-    assert "--all" not in fix_options
-    assert "--detected" not in fix_options
+    # #53's contract: completions advertise exactly what fix accepts. fix --all
+    # is supported now, so advertising it is what keeps that contract true.
+    assert "--all" in fix_options
+    assert "--detected" in fix_options
 
 
 def test_source_completer_matches():


### PR DESCRIPTION
## What & why

`scan --all` already aggregates findings across every source, but `fix --all` was rejected outright — so seeing secrets in four sources meant running `fix --source` four times and remembering which four.

Implemented as the issue specifies: a **sequential per-source loop, not a batched write pass**. Each source runs the same path a single-source fix does — its own `_preflight_gates`, its own `_redact_all`, and therefore its own `safe_write` with backup, post-write validation and audit entry. No source is special-cased and **no write happens outside `safe_write()`**, so all ten redactor invariants hold unchanged.

Closes #45

## Type of change

- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [x] Feature / enhancement
- [ ] Refactor / docs / chore

## Notes for review

**A block on one source never costs the others their redaction.** Stopping early would leave the user worse off than the per-source loop they're replacing, so the sweep finishes and exits `2` naming the unresolved sources; `0` only when every source redacted cleanly.

**Per-source typed REDACT on a terminal**, never one blanket confirm — the blast radius spans different roots, and a single "yes" would hide that.

### Point 4 (`--json` per-source `result`) — not implemented, and I'd like your call

`--json` deliberately stays scan-only here, matching `fix --source --json`. Two findings behind that:

1. **`fix --source --json` doesn't redact today.** The `--json` branch in `run()` returns before the fix path. Verified on current `main`:
   ```
   $ agentsweep fix --source claude-code --root <fixture> --json --force --allow-production
   exit=1 · secret still present · no .bak created
   ```
2. **The gates render to stdout.** `_preflight_gates` calls `ui.stage(...)` / `ui.gate_panel(...)` without `err=True`, and `ui.stage` writes to `console` (stdout). Redacting under `--json` would therefore emit Rich-styled text into machine output, breaking the "`--json` stays machine-clean" contract — unless the gates are made UI-free first, or duplicated, which the issue explicitly rules out.

So implementing point 4 means first deciding what `fix --json` should mean, and making the gate path UI-free. That felt like a separate concern from this one rather than something to smuggle in here — happy to take it as a follow-up, either way you want it to land. A test pins the current short-circuit so the behaviour is at least explicit rather than accidental.

### Other changes

**Re-advertises `--all` / `--detected` on the fix completion parser.** #53 removed them *because they were unsupported*; the contract it enforced is that completions match the CLI, so now that the flag works, advertising it is what keeps #53's contract true. Its test is renamed and flipped accordingly (`test_fix_completion_matches_the_cli_contract`).

**`test_fix_all_rejected` → `test_fix_all_is_accepted`, and made parse-level.** The old test called `main(["fix", "--all"])` with no isolated HOME — safe only because parsing died first. With the rejection gone, that call would scan the real machine, so it now asserts at `_parse_run` level instead.

## Testing

New `tests/test_fix_all.py` (10 tests), covering the acceptance criteria directly:

- both sources redacted, each with **its own `.bak`** and **its own audit entry**
- **one source gate-blocked (fresh mtime) leaves the other redacted and exits 2**, with the blocked source untouched and no `.bak` written for it
- `--detected`, `undo` per source, clean machine → 0, no plaintext in output, and the `--json` short-circuit

```
$ pytest tests/test_fix_all.py -q
10 passed in 52.94s

$ pytest -q
496 passed, 10 skipped in 134.94s
```

**One thing worth flagging from writing these:** my first fixture isolated only `HOME`/`USERPROFILE`, and the tests took **319s**. The slowness was the tell — `fix --all` visits *every* registered source, and the ones rooted at `APPDATA`/`LOCALAPPDATA` were reading the real machine's history. Isolating those (as `test_scan_all._isolate_env` does) dropped it to 53s. Worth knowing that any future `--all` test needs the full env isolation, not just HOME.

Windows / Python 3.11.9, clean venv, based on current `main` (`e4d697f`). `ruff check` reports nothing new — the 3 errors it finds in `test_verbs.py` (`E741`, `F841`) are pre-existing on clean `main` and untouched here.

## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13) — local Windows/3.11 green as above; deferring the rest of the matrix to CI
- [x] No real secrets, tokens, or raw history-file contents are committed — synthetic fixtures only, and a test asserts no plaintext reaches stdout
- [x] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail) — `redactor.py` is untouched; each source goes through the existing `_preflight_gates` → `_redact_all` → `safe_write` path unchanged, and tests assert per-source `.bak` + audit entries and byte-exact `undo`
- [ ] **New detection rule?** — n/a
- [ ] **New source?** — n/a
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths) — `--json` short-circuits before any redaction UI, which is precisely why point 4 is deferred above
- [x] Did not re-introduce `force-include` in `pyproject.toml` — `pyproject.toml` is not modified by this PR
