### PR TITLE
feat(sources): scan Claude Code profiles via CLAUDE_CONFIG_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The legacy flag form `agentsweep --fix` is still accepted and behaves identicall
 Pick which agent's history to target with `--source`. The default is `claude-code`.
 
 ```bash
-agentsweep scan --source claude-code          # ~/.claude/projects/ (default)
+agentsweep scan --source claude-code          # ~/.claude/projects/ (or $CLAUDE_CONFIG_DIR)
 agentsweep scan --source codex                # ~/.codex/sessions/
 agentsweep scan --source opencode             # OpenCode SQLite store
 agentsweep scan --source cursor               # Cursor history
@@ -233,6 +233,12 @@ agentsweep scan --source openclaw             # OpenClaw ~/.openclaw/
 agentsweep scan --source hermes               # Hermes Agent ~/.hermes/state.db
 agentsweep scan --source goose                # Goose ~/.local/share/goose/
 agentsweep scan --source llm                   # Datasette llm CLI logs.db (io.datasette.llm/)
+```
+
+Running Claude Code under a custom profile? Set `CLAUDE_CONFIG_DIR` (the same variable Claude Code honors) and agentsweep scans that profile's `projects/` instead of `~/.claude`. Several profiles at once — e.g. a personal side-project profile alongside your work one — go in a comma-separated list, and all are scanned:
+
+```bash
+CLAUDE_CONFIG_DIR=~/.claude,~/.claude-personal agentsweep scan --source claude-code
 ```
 
 Not sure which agents you have installed? `list-sources` prints every supported

--- a/src/agentsweep/sources/_core.py
+++ b/src/agentsweep/sources/_core.py
@@ -27,15 +27,62 @@ from ._helpers import (
 
 
 class ClaudeCodeSource(JsonlSource):
-    """Claude Code CLI — per-session JSONL under ~/.claude/projects/."""
+    """Claude Code CLI — per-session JSONL under <profile>/projects/.
+
+    The profile dir is ~/.claude by default, overridable via CLAUDE_CONFIG_DIR
+    (which Claude Code itself honours). A comma-separated CLAUDE_CONFIG_DIR is
+    treated as several profiles and all are scanned, so a side-project profile
+    like ~/.claude-personal is not left with unscanned secrets. An explicit
+    --root still targets exactly that one directory.
+    """
 
     name = "claude-code"
     display_name = "Claude Code"
     process_markers = CLAUDE_CODE_MARKERS
 
+    def __init__(self, root: Path | None = None):
+        # Explicit --root wins and stays single, matching every other source;
+        # only default discovery fans out across profiles.
+        self._project_roots = ([root] if root is not None
+                               else self._profile_roots())
+        self.root = self._project_roots[0]
+
+    @classmethod
+    def _profile_roots(cls) -> list[Path]:
+        env = os.environ.get("CLAUDE_CONFIG_DIR")
+        if env:
+            dirs = [Path(p.strip()).expanduser() for p in env.split(",")
+                    if p.strip()]
+        else:
+            dirs = []
+        if not dirs:
+            dirs = [Path.home() / ".claude"]
+        return [d / "projects" for d in dirs]
+
     @classmethod
     def default_root(cls) -> Path:
-        return Path.home() / ".claude" / "projects"
+        return cls._profile_roots()[0]
+
+    def roots(self) -> list[Path]:
+        return list(self._project_roots)
+
+    def files(self) -> list[Path]:
+        out: list[Path] = []
+        for r in self._project_roots:
+            if r.exists():
+                out.extend(p for p in r.rglob("*.jsonl") if p.is_file())
+        return sorted(out)
+
+    def iter_files(self) -> Iterator[Path]:
+        for r in self._project_roots:
+            if not r.exists():
+                continue
+            for p in r.rglob("*.jsonl"):
+                if p.is_file():
+                    yield p
+
+    def is_detected(self) -> bool:
+        return any(r.exists() for r in self._project_roots)
 
 
 class CodexSource(JsonlSource):

--- a/tests/test_claude_profiles.py
+++ b/tests/test_claude_profiles.py
@@ -1,0 +1,129 @@
+"""Claude Code multi-profile discovery via CLAUDE_CONFIG_DIR.
+
+Claude Code stores history under <profile>/projects/. agentsweep historically
+scanned only ~/.claude, so a side-project profile (e.g. ~/.claude-personal)
+went unscanned. These cover the env override and the default staying put.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep import pipeline  # noqa: E402
+from agentsweep.cli import main  # noqa: E402
+from agentsweep.sources import ClaudeCodeSource  # noqa: E402
+
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+_LINE = (
+    '{"type":"user","message":{"role":"user","content":'
+    '[{"type":"text","text":"key=AKIAIOSFODNN7EXAMPLE"}]}}\n'
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _no_agent_running(monkeypatch):
+    monkeypatch.setattr(pipeline, "is_agent_running", lambda markers: (False, ""))
+
+
+def _seed_profile(profile_dir: Path, *, age: int = 3700) -> Path:
+    projects = profile_dir / "projects" / "proj"
+    projects.mkdir(parents=True, exist_ok=True)
+    f = projects / "session.jsonl"
+    f.write_text(_LINE, encoding="utf-8")
+    past = time.time() - age
+    os.utime(f, (past, past))
+    return f
+
+
+def test_default_root_unchanged_without_env(_isolate_home):
+    assert ClaudeCodeSource().default_root() == _isolate_home / ".claude" / "projects"
+    assert ClaudeCodeSource().root == _isolate_home / ".claude" / "projects"
+
+
+def test_config_dir_env_redirects_root(_isolate_home, monkeypatch):
+    custom = _isolate_home / ".claude-personal"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+    src = ClaudeCodeSource()
+    assert src.root == custom / "projects"
+    assert src.roots() == [custom / "projects"]
+
+
+def test_scan_finds_secret_in_custom_profile(_isolate_home, monkeypatch, capsys):
+    custom = _isolate_home / ".claude-personal"
+    _seed_profile(custom)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+
+    code = main(["scan", "--source", "claude-code", "--json"])
+    assert code == 1
+    findings = json.loads(capsys.readouterr().out)
+    assert any(f["rule"] == "aws-access-key" for f in findings)
+
+
+def test_comma_separated_scans_every_profile(_isolate_home, monkeypatch, capsys):
+    a = _isolate_home / ".claude"
+    b = _isolate_home / ".claude-work"
+    _seed_profile(a)
+    _seed_profile(b)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", f"{a},{b}")
+
+    src = ClaudeCodeSource()
+    assert set(src.roots()) == {a / "projects", b / "projects"}
+    assert len(src.files()) == 2
+
+    code = main(["scan", "--source", "claude-code", "--json"])
+    findings = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert len(findings) == 2
+
+
+def test_default_profile_scanned_when_env_unset(_isolate_home, capsys):
+    _seed_profile(_isolate_home / ".claude")
+    code = main(["scan", "--source", "claude-code", "--json"])
+    assert code == 1
+    findings = json.loads(capsys.readouterr().out)
+    assert any(f["rule"] == "aws-access-key" for f in findings)
+
+
+def test_explicit_root_overrides_env(_isolate_home, monkeypatch):
+    custom = _isolate_home / ".claude-personal"
+    override = _isolate_home / "explicit"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+    src = ClaudeCodeSource(root=override)
+    assert src.roots() == [override]
+
+
+def test_fix_redacts_in_custom_profile(_isolate_home, monkeypatch):
+    custom = _isolate_home / ".claude-personal"
+    f = _seed_profile(custom)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+
+    code = main(["fix", "--source", "claude-code", "--force",
+                 "--allow-production"])
+    assert code == 0
+    assert AWS_KEY not in f.read_text(encoding="utf-8")
+    assert f.with_name(f.name + ".bak").exists()
+
+
+def test_is_detected_tracks_profiles(_isolate_home, monkeypatch):
+    custom = _isolate_home / ".claude-personal"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+    assert ClaudeCodeSource().is_detected() is False
+    _seed_profile(custom)
+    assert ClaudeCodeSource().is_detected() is True


### PR DESCRIPTION
## What & why

`ClaudeCodeSource` hardcoded `~/.claude/projects`, so a user who runs Claude Code under a separate profile — a `~/.claude-personal` for side projects, or `CLAUDE_CONFIG_DIR` pointed elsewhere — had that history **silently unscanned**, and a clean scan told them they were safe when they weren't. (Straight from the r/hacking launch thread: *"how to check other claude profiles? I created a `.claude-personal` profile for my side projects."*)

Now the profile dir is resolved from `CLAUDE_CONFIG_DIR` (the same variable Claude Code itself honors), falling back to `~/.claude`. A comma-separated value is treated as several profiles and all are scanned, each resolving to `<dir>/projects`.

```bash
CLAUDE_CONFIG_DIR=~/.claude,~/.claude-personal agentsweep scan --source claude-code
```

Closes #60

## Type of change

- [x] Feature / enhancement

## Notes for review

**Follows the existing multi-tree pattern, not a new one.** `CursorSource` already scans two roots by overriding `roots()` + `files()`/`iter_files()`; this does the same. `roots()` returns every profile's `projects` dir, so the redactor's containment check and `undo`'s backup discovery span them all, and discovery walks each.

**`--root` still wins and stays single** — an explicit override targets exactly that directory and never fans out, so the override contract is unchanged.

**Default behavior is untouched.** With `CLAUDE_CONFIG_DIR` unset, `root` stays `~/.claude/projects`, so `test_all_new_sources_registered_with_distinct_roots` and every existing claude-code test hold.

**`is_detected()` reports real history**, not merely that `$HOME` exists — it's true only when some profile actually holds a `projects/` dir.

**Scope call:** I implemented `CLAUDE_CONFIG_DIR` (single or comma-separated) but deliberately **skipped** the issue's optional "auto-discover sibling `~/.claude*/` dirs" idea. Globbing `~/.claude*` would sweep up `~/.claude-backup`, `~/.claude.bak`, etc. and scan directories the user never meant to expose — surprising for a security tool. An explicit env var is safer and is what Claude Code itself uses. Happy to add sibling discovery behind an explicit opt-in if you'd prefer.

## Testing

New `tests/test_claude_profiles.py` (8 tests): env redirect, comma-separated multi-profile scan finds a secret in each, default staying put when unset, explicit `--root` overriding the env, redaction + `.bak` in a custom profile, and `is_detected` tracking real history. Hermetic — `tmp_path` with `HOME`/`USERPROFILE`/`CLAUDE_CONFIG_DIR` monkeypatched.

```
$ pytest tests/test_claude_profiles.py -q
8 passed in 0.53s

$ pytest -q
504 passed, 10 skipped in 170.98s
```

Windows / Python 3.11.9, clean venv, based on current `main` (`ab902e1`). `ruff check` clean on every touched file.

## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13) — local Windows/3.11 green as above; deferring the rest to CI
- [x] No real secrets, tokens, or raw history-file contents are committed — synthetic `AKIAIOSFODNN7EXAMPLE` fixtures under `tmp_path`
- [x] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail) — `redactor.py` untouched; multi-profile `roots()` keeps every scanned file inside a declared root, and a test asserts redaction + `.bak` in a custom profile
- [ ] **New detection rule?** — n/a
- [x] **New source?** — not a new source, but this changes an existing one's discovery; covered by a round-trip test as the Source conventions require
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths) — no output paths touched
- [x] Did not re-introduce `force-include` in `pyproject.toml` — not modified by this PR
