### PR TITLE
feat(scan): warn about leftover .bak files that still hold secrets

### DIFF
--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -108,6 +108,7 @@ def run(args, *, _findings_out: list | None = None,
         if truncated:
             print(f"warning: {len(truncated)} file(s) exceeded the scan budget "
                   f"and were truncated", file=sys.stderr)
+        _warn_leftover_backups(source, as_json=True)
         if as_sarif:
             return _emit_sarif(_json_payload(found_by_file, source),
                                output, suppressed)
@@ -135,6 +136,7 @@ def run(args, *, _findings_out: list | None = None,
         ui.stage(3, "ok", "FINDINGS", "no secrets found")
         ui.stage(4, "skip", "REDACT", "nothing to redact")
         ui.stage(5, "skip", "ROTATE", "nothing to rotate")
+        _warn_leftover_backups(source, as_json=False)
         ui.contribute_line()
         return 0
 
@@ -147,6 +149,7 @@ def run(args, *, _findings_out: list | None = None,
                  "skipped — run with --fix to redact in place (.bak backups)")
         ui.stage(5, "warn", "ROTATE", "these keys are still live")
         ui.rotation_panel(_rotation_items(found_by_file))
+        _warn_leftover_backups(source, as_json=False)
         ui.contribute_line()
         if _findings_out is not None:
             _findings_out.append((source, found_by_file))
@@ -423,6 +426,8 @@ def run_all(args) -> int:
                 f"and were truncated",
                 file=sys.stderr,
             )
+        _warn_leftover_backups_multi([s for _k, s, *_ in per_source],
+                                     as_json=True)
         if as_sarif:
             return _emit_sarif(payload, output, total_suppressed)
         return _emit_json_payload(payload, output, total_suppressed)
@@ -444,6 +449,8 @@ def run_all(args) -> int:
         ui.stage(3, "ok", "FINDINGS", "no secrets found")
         ui.stage(4, "skip", "REDACT", "nothing to redact")
         ui.stage(5, "skip", "ROTATE", "nothing to rotate")
+        _warn_leftover_backups_multi([s for _k, s, *_ in per_source],
+                                     as_json=False)
         ui.contribute_line()
         return 0
 
@@ -504,6 +511,7 @@ def run_all(args) -> int:
     ui.stage(5, "warn", "ROTATE", "these keys are still live")
     # Flatten across sources — do not merge by Path (collisions across roots).
     ui.rotation_panel(_rotation_items_multi(dirty))
+    _warn_leftover_backups_multi([s for _k, s, *_ in per_source], as_json=False)
     ui.contribute_line()
     return 1
 
@@ -969,6 +977,52 @@ _BACKUP_GLOBS = ("*.jsonl.bak", "*.json.bak", "*.md.bak",
                  "*.db-wal.bak", "*.db-shm.bak",
                  "*.vscdb-wal.bak", "*.vscdb-shm.bak",
                  "*.sqlite.bak", "*.sqlite-wal.bak", "*.sqlite-shm.bak")
+
+
+def _leftover_backups(source: Source) -> list[Path]:
+    """Existing .bak sidecars under the source's roots.
+
+    Each still holds the pre-redaction plaintext secret — safe_write writes
+    it before replacing the file, and only `purge` deletes it. Same discovery
+    undo/purge use, so scan flags exactly what they would act on.
+    """
+    return sorted({p for root in source.roots() if root.exists()
+                   for pat in _BACKUP_GLOBS
+                   for p in root.rglob(pat)})
+
+
+def _warn_leftover_backups(source: Source, as_json: bool) -> None:
+    """After a scan, note any .bak sidecars still holding plaintext secrets.
+
+    A user who ran `fix` but not `purge` is not actually clean — the secret
+    lives on in the backup. A scan that finds nothing in the redacted files
+    would otherwise report an all-clear over those live secrets. Existence and
+    count only; the .bak contents are not scanned or shown.
+    """
+    _emit_backup_warning(len(_leftover_backups(source)), as_json)
+
+
+def _warn_leftover_backups_multi(sources: list[Source], as_json: bool) -> None:
+    """Aggregate leftover-.bak warning across the sources a --all scan visited.
+
+    scan --all is the CI-facing entry point (and what the pre-commit hook
+    runs), so it must flag leftover backups too. Counts distinct .bak paths so
+    sources sharing a root can't double-count.
+    """
+    baks = {p for s in sources for p in _leftover_backups(s)}
+    _emit_backup_warning(len(baks), as_json)
+
+
+def _emit_backup_warning(count: int, as_json: bool) -> None:
+    if not count:
+        return
+    msg = (f"{count} leftover .bak backup(s) still contain plaintext secrets "
+           f"— run `agentsweep purge` after rotating, or `agentsweep undo` to "
+           f"restore them")
+    if as_json:
+        print(f"warning: {msg}", file=sys.stderr)
+    else:
+        ui.warn_line(msg)
 
 
 def undo(args) -> int:

--- a/tests/test_leftover_backups.py
+++ b/tests/test_leftover_backups.py
@@ -1,0 +1,138 @@
+"""scan warns about leftover .bak sidecars that still hold plaintext secrets.
+
+After `fix` writes `<path>.bak` and before `purge` deletes it, the secret is
+still on disk. A scan of the redacted files finds nothing, so without this
+warning the user reads an all-clear over a live secret.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep import pipeline  # noqa: E402
+from agentsweep.cli import main  # noqa: E402
+
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+_CLEAN = '{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}\n'
+_SECRET = (
+    '{"type":"user","message":{"content":'
+    '[{"type":"text","text":"key=AKIAIOSFODNN7EXAMPLE"}]}}\n'
+)
+_WARN = "leftover .bak"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg" / "share"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg" / "config"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    monkeypatch.setenv("AGENTSWEEP_NO_UPDATE", "1")
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _no_agent_running(monkeypatch):
+    monkeypatch.setattr(pipeline, "is_agent_running", lambda markers: (False, ""))
+
+
+def _mk_root(base: Path, *, clean: bool = True, bak: bool = False) -> Path:
+    root = base / "projects"
+    d = root / "proj"
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "session.jsonl"
+    f.write_text(_CLEAN if clean else _SECRET, encoding="utf-8")
+    past = time.time() - 3700
+    os.utime(f, (past, past))
+    if bak:
+        (d / "session.jsonl.bak").write_text(_SECRET, encoding="utf-8")
+    return root
+
+
+def test_warning_text_and_count_human(tmp_path, capsys):
+    root = _mk_root(tmp_path, clean=True, bak=True)
+    code = main(["scan", "--source", "claude-code", "--root", str(root)])
+    # warn_line writes to stderr (keeps stdout clean); assert on it.
+    err = capsys.readouterr().err
+    assert code == 0
+    assert _WARN in err
+    assert "1 leftover" in err
+    assert "purge" in err
+
+
+def test_warns_on_stderr_in_json_mode(tmp_path, capsys):
+    root = _mk_root(tmp_path, clean=True, bak=True)
+    code = main(["scan", "--source", "claude-code", "--root", str(root), "--json"])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert json.loads(captured.out) == []      # stdout stays parseable
+    assert _WARN in captured.err               # warning goes to stderr
+
+
+def test_no_warning_without_bak(tmp_path, capsys):
+    root = _mk_root(tmp_path, clean=False, bak=False)
+    code = main(["scan", "--source", "claude-code", "--root", str(root)])
+    captured = capsys.readouterr()
+    assert code == 1          # the live secret is still found
+    assert _WARN not in (captured.out + captured.err)
+
+
+def test_warns_even_when_findings_present(tmp_path, capsys):
+    # Both a live secret in the file AND a leftover .bak — warn about both.
+    root = _mk_root(tmp_path, clean=False, bak=True)
+    code = main(["scan", "--source", "claude-code", "--root", str(root)])
+    err = capsys.readouterr().err
+    assert code == 1
+    assert _WARN in err
+
+
+def test_bak_contents_not_leaked_to_output(tmp_path, capsys):
+    root = _mk_root(tmp_path, clean=True, bak=True)
+    main(["scan", "--source", "claude-code", "--root", str(root)])
+    captured = capsys.readouterr()
+    # The warning reports existence + count, never the secret inside the .bak.
+    assert AWS_KEY not in captured.out
+    assert AWS_KEY not in captured.err
+
+
+def test_scan_all_warns_about_backups(tmp_path, capsys):
+    # scan --all is what the pre-commit hook runs, so it must warn too.
+    home = tmp_path / "home"
+    d = home / ".claude" / "projects" / "proj"
+    d.mkdir(parents=True)
+    f = d / "session.jsonl"
+    f.write_text(_CLEAN, encoding="utf-8")
+    past = time.time() - 3700
+    os.utime(f, (past, past))
+    (d / "session.jsonl.bak").write_text(_SECRET, encoding="utf-8")
+
+    code = main(["scan", "--all", "--json"])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert _WARN in captured.err
+
+
+def test_leftover_backups_helper_counts_all_glob_types(tmp_path):
+    from agentsweep.pipeline import _leftover_backups
+    from agentsweep.sources import ClaudeCodeSource
+
+    root = tmp_path / "projects"
+    d = root / "proj"
+    d.mkdir(parents=True)
+    (d / "a.jsonl.bak").write_text("x", encoding="utf-8")
+    (d / "b.db.bak").write_text("x", encoding="utf-8")
+    (d / "c.jsonl").write_text("x", encoding="utf-8")  # not a backup
+
+    found = _leftover_backups(ClaudeCodeSource(root=root))
+    assert len(found) == 2


### PR DESCRIPTION
## What & why

When `fix` redacts a file it writes `<path>.bak` holding the **pre-redaction plaintext secret**, and only `purge` deletes it. So a user who runs `fix` but forgets `purge` still has the secret on disk — and a later `scan` of the (now redacted) files finds nothing, reporting an all-clear over a live secret. Exactly what a user asked on the launch thread: *"what about the keys inside the `.bak` files?"*

`scan` now checks the source roots for `.bak` sidecars and warns, with the count and a pointer to `purge`/`undo`:

```
! 1 leftover .bak backup(s) still contain plaintext secrets — run `agentsweep purge` after rotating, or `agentsweep undo` to restore them
```

Closes #61

## Type of change

- [x] Feature / enhancement

## Notes for review

**Reuses the existing discovery.** The check walks `source.roots()` with the same `_BACKUP_GLOBS` that `undo`/`purge` use, so scan flags exactly what those commands would act on — no second, drifting definition of "what's a backup".

**Existence and count only — the `.bak` contents are never read or printed.** So the secret can't leak through the warning itself; a test asserts no plaintext reaches stdout or stderr.

**Fires at every scan-only exit, including the dangerous no-findings case** (redacted everything, backups remain — the exact "looks clean but isn't" scenario). Human mode warns via `ui.warn_line` (stderr, so stdout stays clean); `--json`/`--sarif` warn to stderr so stdout stays parseable.

**`scan --all` warns too.** It's the CI entry point and what the pre-commit hook (#44) runs, so leaving it out would miss backups in the automated path that matters most. Counts distinct `.bak` paths so sources sharing a root can't double-count.

**No behavior change when there are no `.bak` files.**

## Testing

New `tests/test_leftover_backups.py` (7 tests): warning text + count in human mode (stderr), `--json` warns on stderr while stdout stays `[]`, `scan --all` warns, no warning without a `.bak`, warns even when live findings are also present, no secret plaintext in output, and the `_leftover_backups` helper covering multiple glob types.

```
$ pytest tests/test_leftover_backups.py -q
7 passed

$ pytest -q          # full suite
exit 0, zero failures
```

Windows / Python 3.11.9, clean venv, based on current `main` (`ab902e1`). `ruff check` clean on both touched files.

## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13) — local Windows/3.11 green (exit 0, 0 failures); deferring the rest to CI
- [x] No real secrets, tokens, or raw history-file contents are committed — synthetic `AKIAIOSFODNN7EXAMPLE` fixtures under `tmp_path`, and a test asserts the `.bak` contents never reach output
- [x] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail) — read-only scan-side check; `redactor.py` and the write path are untouched
- [ ] **New detection rule?** — n/a
- [ ] **New source?** — n/a
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths) — the warning goes to stderr in `--json`/`--sarif` mode; stdout stays parseable, asserted by a test
- [x] Did not re-introduce `force-include` in `pyproject.toml` — not modified by this PR
