### PR TITLE
fix(cli): make update-availability notice respect NO_COLOR and add po…markdownfix: Update availability notice respects NO_COLOR and --no-colorfix: Update availability notice respects NO_COLOR and --no-color

### DIFF
--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -19,6 +19,7 @@ Usage shapes, all supported:
 
 Run logic lives in pipeline.py; interaction in menu.py.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -73,6 +74,7 @@ def _background_update_notice(args: argparse.Namespace) -> None:
     # Guard: skip in non-interactive / machine-readable contexts, or when the
     # user has explicitly opted out via env var (useful in CI / slow networks).
     import os
+
     try:
         if os.environ.get("AGENTSWEEP_NO_UPDATE"):
             return
@@ -105,9 +107,9 @@ def _background_update_notice(args: argparse.Namespace) -> None:
     latest = result[0]
     if latest is not None and _version_tuple(latest) > _version_tuple(__version__):
         # Print a single dim-yellow notice before any other output.
-        print(
-            f"\033[2;33m  ★ agentsweep {latest} available"
-            f" — pip install --upgrade agentsweep\033[0m"
+        ui.console.print(
+            f"[dim yellow]  ★ agentsweep {latest} available"
+            f" — pip install --upgrade agentsweep[/dim yellow]"
         )
 
 
@@ -146,6 +148,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         import argcomplete
+
         completion_parser = _get_completion_parser()
         argcomplete.autocomplete(completion_parser)
     except ImportError:
@@ -160,6 +163,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if argv and argv[0] == "list-sources":
         from .pipeline import list_sources
+
         return list_sources(_parse_list_sources(argv[1:]))
 
     if argv and argv[0] == "completion":
@@ -167,6 +171,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if not argv and _interactive():
         from .menu import run_menu
+
         try:
             return run_menu()
         except KeyboardInterrupt:
@@ -178,10 +183,12 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if verb == "undo":
             from .pipeline import undo
+
             return undo(_parse_undo(rest))
 
         if verb == "purge":
             from .pipeline import purge
+
             return purge(_parse_purge(rest))
 
         args = _parse_run(verb, rest)
@@ -225,10 +232,15 @@ def _route(argv: list[str]) -> tuple[str, list[str]]:
 
 
 def _add_common(ap: argparse.ArgumentParser) -> None:
-    ap.add_argument("--source", choices=list(SOURCES), default="claude-code",
-                    help="Which agent's history (default: claude-code).")
-    ap.add_argument("--root", type=Path,
-                    help="Override the source's default root directory.")
+    ap.add_argument(
+        "--source",
+        choices=list(SOURCES),
+        default="claude-code",
+        help="Which agent's history (default: claude-code).",
+    )
+    ap.add_argument(
+        "--root", type=Path, help="Override the source's default root directory."
+    )
 
 
 def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
@@ -238,46 +250,78 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
     )
     # default=None so we can tell "user passed --source" from the implicit
     # default when validating mutual exclusion with --all.
-    ap.add_argument("--source", choices=list(SOURCES), default=None,
-                    help="Which agent's history (default: claude-code).")
-    ap.add_argument("--root", type=Path,
-                    help="Override the source's default root directory.")
-    ap.add_argument("--all", action="store_true",
-                    help="Every registered agent source: scan aggregates "
-                         "findings; fix redacts each source in turn, gated "
-                         "and confirmed separately.")
-    ap.add_argument("--detected", action="store_true",
-                    help="With --all, only scan sources whose history root "
-                         "exists on this machine (same signal as "
-                         "list-sources --detected).")
-    ap.add_argument("-o", "--output", type=Path,
-                    help="Write findings as JSON to this file instead of "
-                         "flooding the terminal.")
-    ap.add_argument("--json", action="store_true",
-                    help="Emit findings as JSON to stdout (no banner/styling).")
-    ap.add_argument("--no-color", action="store_true",
-                    help="Disable ANSI colors/styling in human output "
-                         "(also honored via the NO_COLOR env var).")
-    ap.add_argument("--format", choices=["sarif"],
-                    help="Emit findings in an interchange format instead of "
-                         "the default report: sarif = SARIF 2.1.0 for GitHub "
-                         "code scanning and SARIF viewers (scan only).")
-    ap.add_argument("--no-ignore", action="store_true",
-                    help="Ignore any .agentsweepignore files.")
+    ap.add_argument(
+        "--source",
+        choices=list(SOURCES),
+        default=None,
+        help="Which agent's history (default: claude-code).",
+    )
+    ap.add_argument(
+        "--root", type=Path, help="Override the source's default root directory."
+    )
+    ap.add_argument(
+        "--all",
+        action="store_true",
+        help="Every registered agent source: scan aggregates "
+        "findings; fix redacts each source in turn, gated "
+        "and confirmed separately.",
+    )
+    ap.add_argument(
+        "--detected",
+        action="store_true",
+        help="With --all, only scan sources whose history root "
+        "exists on this machine (same signal as "
+        "list-sources --detected).",
+    )
+    ap.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Write findings as JSON to this file instead of flooding the terminal.",
+    )
+    ap.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit findings as JSON to stdout (no banner/styling).",
+    )
+    ap.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI colors/styling in human output "
+        "(also honored via the NO_COLOR env var).",
+    )
+    ap.add_argument(
+        "--format",
+        choices=["sarif"],
+        help="Emit findings in an interchange format instead of "
+        "the default report: sarif = SARIF 2.1.0 for GitHub "
+        "code scanning and SARIF viewers (scan only).",
+    )
+    ap.add_argument(
+        "--no-ignore", action="store_true", help="Ignore any .agentsweepignore files."
+    )
     # Redaction flags (used by `fix` / legacy --fix; harmless on `scan`).
-    ap.add_argument("--no-backup", action="store_true",
-                    help="Skip .bak file creation (NOT recommended).")
-    ap.add_argument("--force", action="store_true",
-                    help="Bypass soft safety checks (mtime, running-process).")
-    ap.add_argument("--allow-production", action="store_true",
-                    help="Allow --fix against the default production root.")
+    ap.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Skip .bak file creation (NOT recommended).",
+    )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="Bypass soft safety checks (mtime, running-process).",
+    )
+    ap.add_argument(
+        "--allow-production",
+        action="store_true",
+        help="Allow --fix against the default production root.",
+    )
     args = ap.parse_args(rest)
-    args.fix = (verb == "fix")
+    args.fix = verb == "fix"
 
     if args.format is not None:
         if args.json:
-            ap.error("cannot use --json with --format sarif; pick one output "
-                     "format")
+            ap.error("cannot use --json with --format sarif; pick one output format")
         if args.fix:
             ap.error("--format is a scan output format; not valid with fix")
 
@@ -290,8 +334,9 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
         args.source = "claude-code"
     else:
         if args.detected:
-            ap.error("--detected requires --all "
-                     "(or use: agentsweep list-sources --detected)")
+            ap.error(
+                "--detected requires --all (or use: agentsweep list-sources --detected)"
+            )
         if args.source is None:
             args.source = "claude-code"
     return args
@@ -301,12 +346,16 @@ def _parse_list_sources(rest: list[str]) -> argparse.Namespace:
     ap = argparse.ArgumentParser(
         prog="agentsweep list-sources",
         description="List every supported agent source and whether its "
-                    "history root exists on this machine. Read-only.",
+        "history root exists on this machine. Read-only.",
     )
-    ap.add_argument("--json", action="store_true",
-                    help="Emit the source list as JSON to stdout.")
-    ap.add_argument("--detected", action="store_true",
-                    help="Show only sources whose history root exists here.")
+    ap.add_argument(
+        "--json", action="store_true", help="Emit the source list as JSON to stdout."
+    )
+    ap.add_argument(
+        "--detected",
+        action="store_true",
+        help="Show only sources whose history root exists here.",
+    )
     return ap.parse_args(rest)
 
 
@@ -323,14 +372,16 @@ def _parse_purge(rest: list[str]) -> argparse.Namespace:
     ap = argparse.ArgumentParser(
         prog="agentsweep purge",
         description="Delete *.bak backups once the leaked keys are rotated. "
-                    "The backups hold the pre-redaction originals, so this "
-                    "is permanent — `agentsweep undo` stops working for "
-                    "them.",
+        "The backups hold the pre-redaction originals, so this "
+        "is permanent — `agentsweep undo` stops working for "
+        "them.",
     )
     _add_common(ap)
-    ap.add_argument("--yes", action="store_true",
-                    help="Skip the confirmation prompt (required when not "
-                         "running on a terminal).")
+    ap.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt (required when not running on a terminal).",
+    )
     return ap.parse_args(rest)
 
 
@@ -351,60 +402,145 @@ def _get_completion_parser() -> argparse.ArgumentParser:
 
     # scan
     scan_p = subparsers.add_parser("scan", description="Scan history files.")
-    scan_source = scan_p.add_argument("--source", choices=list(SOURCES), default=None,
-                                      help="Which agent's history (default: claude-code).")
+    scan_source = scan_p.add_argument(
+        "--source",
+        choices=list(SOURCES),
+        default=None,
+        help="Which agent's history (default: claude-code).",
+    )
     scan_source.completer = source_completer
-    scan_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
-    scan_p.add_argument("--all", action="store_true", help="Scan every registered agent source.")
-    scan_p.add_argument("--detected", action="store_true", help="Only scan sources whose history root exists.")
-    scan_p.add_argument("-o", "--output", type=Path, help="Write findings as JSON to this file.")
-    scan_p.add_argument("--json", action="store_true", help="Emit findings as JSON to stdout.")
-    scan_p.add_argument("--no-color", action="store_true", help="Disable ANSI colors/styling in human output.")
-    scan_p.add_argument("--no-ignore", action="store_true", help="Ignore any .agentsweepignore files.")
-    scan_p.add_argument("--no-backup", action="store_true", help="Skip .bak file creation.")
+    scan_p.add_argument(
+        "--root", type=Path, help="Override the source's default root directory."
+    )
+    scan_p.add_argument(
+        "--all", action="store_true", help="Scan every registered agent source."
+    )
+    scan_p.add_argument(
+        "--detected",
+        action="store_true",
+        help="Only scan sources whose history root exists.",
+    )
+    scan_p.add_argument(
+        "-o", "--output", type=Path, help="Write findings as JSON to this file."
+    )
+    scan_p.add_argument(
+        "--json", action="store_true", help="Emit findings as JSON to stdout."
+    )
+    scan_p.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI colors/styling in human output.",
+    )
+    scan_p.add_argument(
+        "--no-ignore", action="store_true", help="Ignore any .agentsweepignore files."
+    )
+    scan_p.add_argument(
+        "--no-backup", action="store_true", help="Skip .bak file creation."
+    )
     scan_p.add_argument("--force", action="store_true", help="Bypass safety checks.")
-    scan_p.add_argument("--allow-production", action="store_true", help="Allow against default production root.")
+    scan_p.add_argument(
+        "--allow-production",
+        action="store_true",
+        help="Allow against default production root.",
+    )
 
     # fix
     fix_p = subparsers.add_parser("fix", description="Redact secrets in history.")
-    fix_source = fix_p.add_argument("--source", choices=list(SOURCES), default=None,
-                                     help="Which agent's history (default: claude-code).")
+    fix_source = fix_p.add_argument(
+        "--source",
+        choices=list(SOURCES),
+        default=None,
+        help="Which agent's history (default: claude-code).",
+    )
     fix_source.completer = source_completer
-    fix_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
-    fix_p.add_argument("--all", action="store_true", help="Redact every agent source with findings, one at a time.")
-    fix_p.add_argument("--detected", action="store_true", help="With --all, only sources whose history root exists.")
-    fix_p.add_argument("-o", "--output", type=Path, help="Write findings as JSON to this file.")
-    fix_p.add_argument("--json", action="store_true", help="Emit findings as JSON to stdout.")
-    fix_p.add_argument("--no-color", action="store_true", help="Disable ANSI colors/styling in human output.")
-    fix_p.add_argument("--no-ignore", action="store_true", help="Ignore any .agentsweepignore files.")
-    fix_p.add_argument("--no-backup", action="store_true", help="Skip .bak file creation.")
+    fix_p.add_argument(
+        "--root", type=Path, help="Override the source's default root directory."
+    )
+    fix_p.add_argument(
+        "--all",
+        action="store_true",
+        help="Redact every agent source with findings, one at a time.",
+    )
+    fix_p.add_argument(
+        "--detected",
+        action="store_true",
+        help="With --all, only sources whose history root exists.",
+    )
+    fix_p.add_argument(
+        "-o", "--output", type=Path, help="Write findings as JSON to this file."
+    )
+    fix_p.add_argument(
+        "--json", action="store_true", help="Emit findings as JSON to stdout."
+    )
+    fix_p.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI colors/styling in human output.",
+    )
+    fix_p.add_argument(
+        "--no-ignore", action="store_true", help="Ignore any .agentsweepignore files."
+    )
+    fix_p.add_argument(
+        "--no-backup", action="store_true", help="Skip .bak file creation."
+    )
     fix_p.add_argument("--force", action="store_true", help="Bypass safety checks.")
-    fix_p.add_argument("--allow-production", action="store_true", help="Allow against default production root.")
+    fix_p.add_argument(
+        "--allow-production",
+        action="store_true",
+        help="Allow against default production root.",
+    )
 
     # undo
     undo_p = subparsers.add_parser("undo", description="Restore backups.")
-    undo_source = undo_p.add_argument("--source", choices=list(SOURCES), default="claude-code",
-                                       help="Which agent's history.")
+    undo_source = undo_p.add_argument(
+        "--source",
+        choices=list(SOURCES),
+        default="claude-code",
+        help="Which agent's history.",
+    )
     undo_source.completer = source_completer
-    undo_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
+    undo_p.add_argument(
+        "--root", type=Path, help="Override the source's default root directory."
+    )
 
     # purge
     purge_p = subparsers.add_parser("purge", description="Delete backups.")
-    purge_source = purge_p.add_argument("--source", choices=list(SOURCES), default="claude-code",
-                                         help="Which agent's history.")
+    purge_source = purge_p.add_argument(
+        "--source",
+        choices=list(SOURCES),
+        default="claude-code",
+        help="Which agent's history.",
+    )
     purge_source.completer = source_completer
-    purge_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
-    purge_p.add_argument("--yes", action="store_true", help="Skip the confirmation prompt.")
+    purge_p.add_argument(
+        "--root", type=Path, help="Override the source's default root directory."
+    )
+    purge_p.add_argument(
+        "--yes", action="store_true", help="Skip the confirmation prompt."
+    )
 
     # list-sources
-    ls_p = subparsers.add_parser("list-sources", description="List supported agent sources.")
-    ls_p.add_argument("--json", action="store_true", help="Emit the source list as JSON to stdout.")
-    ls_p.add_argument("--detected", action="store_true", help="Show only sources whose history root exists.")
+    ls_p = subparsers.add_parser(
+        "list-sources", description="List supported agent sources."
+    )
+    ls_p.add_argument(
+        "--json", action="store_true", help="Emit the source list as JSON to stdout."
+    )
+    ls_p.add_argument(
+        "--detected",
+        action="store_true",
+        help="Show only sources whose history root exists.",
+    )
 
     # completion
-    comp_p = subparsers.add_parser("completion", description="Generate shell completion scripts.")
-    comp_p.add_argument("shell", choices=["bash", "zsh", "fish", "powershell"],
-                        help="The shell to generate completions for.")
+    comp_p = subparsers.add_parser(
+        "completion", description="Generate shell completion scripts."
+    )
+    comp_p.add_argument(
+        "shell",
+        choices=["bash", "zsh", "fish", "powershell"],
+        help="The shell to generate completions for.",
+    )
 
     return ap
 
@@ -414,8 +550,11 @@ def _parse_completion(rest: list[str]) -> argparse.Namespace:
         prog="agentsweep completion",
         description="Generate shell completion scripts for agentsweep.",
     )
-    ap.add_argument("shell", choices=["bash", "zsh", "fish", "powershell"],
-                    help="The shell to generate completions for.")
+    ap.add_argument(
+        "shell",
+        choices=["bash", "zsh", "fish", "powershell"],
+        help="The shell to generate completions for.",
+    )
     return ap.parse_args(rest)
 
 

--- a/tests/test_ui_output.py
+++ b/tests/test_ui_output.py
@@ -1,5 +1,6 @@
-﻿"""Contract tests for the pipeline UI: --json purity, exit codes, masking,
+"""Contract tests for the pipeline UI: --json purity, exit codes, masking,
 gate rendering, redact rows, and encoding degradation."""
+
 from __future__ import annotations
 
 import io
@@ -50,6 +51,7 @@ def _mkroot(tmp_path: Path, content: str = FIXTURE_LINE) -> Path:
 
 # ---------------------------------------------------------------- json mode
 
+
 def test_json_mode_is_machine_clean(tmp_path, capsys):
     root = _mkroot(tmp_path)
     code = main(["--root", str(root), "--json"])
@@ -95,6 +97,7 @@ def test_json_with_fix_is_scan_only(tmp_path, capsys):
 
 
 # ---------------------------------------------------------------- scan mode
+
 
 def test_scan_exit_codes(tmp_path, capsys):
     dirty = _mkroot(tmp_path)
@@ -146,8 +149,10 @@ def test_bracketed_path_segments_survive_rendering(tmp_path, capsys):
 
 # ----------------------------------------------------------------- gates
 
+
 def test_production_gate_blocks_and_still_shows_rotation(
-        tmp_path, _isolated_home, capsys):
+    tmp_path, _isolated_home, capsys
+):
     fake_root = _isolated_home / ".claude" / "projects"
     fake_root.mkdir(parents=True)
     (fake_root / "session.jsonl").write_text(FIXTURE_LINE, encoding="utf-8")
@@ -165,8 +170,9 @@ def test_production_gate_blocks_and_still_shows_rotation(
 
 def test_active_session_gate_blocks(tmp_path, monkeypatch, capsys):
     root = _mkroot(tmp_path)
-    monkeypatch.setattr(pipeline, "is_agent_running",
-                        lambda markers: (True, "claude.exe"))
+    monkeypatch.setattr(
+        pipeline, "is_agent_running", lambda markers: (True, "claude.exe")
+    )
 
     code = main(["--root", str(root), "--fix"])
     captured = capsys.readouterr()
@@ -180,8 +186,9 @@ def test_active_session_gate_blocks(tmp_path, monkeypatch, capsys):
 
 def test_force_overrides_active_session_gate(tmp_path, monkeypatch, capsys):
     root = _mkroot(tmp_path)
-    monkeypatch.setattr(pipeline, "is_agent_running",
-                        lambda markers: (True, "claude.exe"))
+    monkeypatch.setattr(
+        pipeline, "is_agent_running", lambda markers: (True, "claude.exe")
+    )
 
     code = main(["--root", str(root), "--fix", "--force"])
     captured = capsys.readouterr()
@@ -192,6 +199,7 @@ def test_force_overrides_active_session_gate(tmp_path, monkeypatch, capsys):
 
 
 # ----------------------------------------------------------------- redact
+
 
 def test_fix_redacts_end_to_end_with_force(tmp_path, _no_claude, capsys):
     root = _mkroot(tmp_path)
@@ -205,8 +213,7 @@ def test_fix_redacts_end_to_end_with_force(tmp_path, _no_claude, capsys):
     assert (root / "session.jsonl.bak").exists()
 
 
-def test_fix_write_error_shows_fail_row_and_exits_2(
-        tmp_path, _no_claude, capsys):
+def test_fix_write_error_shows_fail_row_and_exits_2(tmp_path, _no_claude, capsys):
     root = _mkroot(tmp_path)
     # Pre-existing .bak makes safe_write refuse — exercises the FAIL row.
     (root / "session.jsonl.bak").write_text("old", encoding="utf-8")
@@ -233,7 +240,8 @@ def test_fix_no_backup(tmp_path, _no_claude, capsys):
 
 
 def test_fix_writes_audit_log_in_isolated_home(
-        tmp_path, _isolated_home, _no_claude, capsys):
+    tmp_path, _isolated_home, _no_claude, capsys
+):
     root = _mkroot(tmp_path)
     code = main(["--root", str(root), "--fix", "--force"])
 
@@ -245,6 +253,7 @@ def test_fix_writes_audit_log_in_isolated_home(
 
 
 # --------------------------------------------------------- path forgiveness
+
 
 def test_root_not_found_exits_2_with_suggestion(tmp_path, capsys):
     (tmp_path / "history").mkdir()
@@ -267,15 +276,20 @@ def test_root_not_found_json_keeps_stdout_parseable(tmp_path, capsys):
 
 # --------------------------------------------------------------- no color
 
+
 def _force_color(monkeypatch):
     """Make the shared consoles emit color as if on a terminal.
 
     capsys stdout is not a tty, so rich stays plain by default — force a color
     system on so a no-color regression would actually show escapes to catch.
     """
-    monkeypatch.setattr(ui.console, "_color_system", ui.console._color_system
-                        or __import__("rich.color", fromlist=["ColorSystem"])
-                        .ColorSystem.TRUECOLOR, raising=False)
+    monkeypatch.setattr(
+        ui.console,
+        "_color_system",
+        ui.console._color_system
+        or __import__("rich.color", fromlist=["ColorSystem"]).ColorSystem.TRUECOLOR,
+        raising=False,
+    )
 
 
 def test_resolve_no_color_reads_env_and_flag(monkeypatch):
@@ -299,7 +313,7 @@ def test_no_color_env_suppresses_ansi(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
 
     assert code == 1
-    assert "AGENTSWEEP" in out          # human report still rendered
+    assert "AGENTSWEEP" in out  # human report still rendered
     assert not ANSI_ESCAPE.search(out)  # ...just without escapes
 
 
@@ -314,7 +328,75 @@ def test_no_color_flag_suppresses_ansi(tmp_path, monkeypatch, capsys):
     assert not ANSI_ESCAPE.search(out)
 
 
+def test_color_is_emitted_when_enabled(tmp_path, monkeypatch, capsys):
+    _force_color(monkeypatch)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    ui.apply_no_color(False)
+    root = _mkroot(tmp_path)
+    code = main(["--root", str(root)])
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "AGENTSWEEP" in out
+    assert ANSI_ESCAPE.search(out)
+
+
+def test_update_notice_respects_no_color(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "__version__", "0.0.1")
+
+    import urllib.request
+    from unittest.mock import MagicMock
+
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = b'{"info": {"version": "9.9.9"}}'
+    mock_resp.__enter__.return_value = mock_resp
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *args, **kwargs: mock_resp)
+
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+
+    _force_color(monkeypatch)
+    monkeypatch.setenv("NO_COLOR", "1")
+    ui.apply_no_color(True)
+
+    class DummyArgs:
+        json = False
+
+    cli._background_update_notice(DummyArgs())
+    out = capsys.readouterr().out
+
+    assert "agentsweep 9.9.9 available" in out
+    assert not ANSI_ESCAPE.search(out)
+
+
+def test_update_notice_emits_color_when_enabled(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "__version__", "0.0.1")
+
+    import urllib.request
+    from unittest.mock import MagicMock
+
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = b'{"info": {"version": "9.9.9"}}'
+    mock_resp.__enter__.return_value = mock_resp
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *args, **kwargs: mock_resp)
+
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+
+    _force_color(monkeypatch)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    ui.apply_no_color(False)
+
+    class DummyArgs:
+        json = False
+
+    cli._background_update_notice(DummyArgs())
+    out = capsys.readouterr().out
+
+    assert "agentsweep 9.9.9 available" in out
+    assert ANSI_ESCAPE.search(out)
+
+
 # ----------------------------------------------------------------- menu
+
 
 def _feed_menu(monkeypatch, answers: list[str]):
     monkeypatch.setattr(cli, "_interactive", lambda: True)
@@ -345,8 +427,10 @@ def test_menu_scan_action_then_quit(monkeypatch, _isolated_home, capsys):
     # (e.g. APPDATA/Cursor, APPDATA/Windsurf) that are not isolated by tmp_path.
     import sys as _sys
     from agentsweep import menu as _menu
+
     def _fast_scan_all():
         print("No history files found for any source.", file=_sys.stderr)
+
     monkeypatch.setattr(_menu, "_scan_all_sources", _fast_scan_all)
     _feed_menu(monkeypatch, ["1", "", "q"])
     assert main([]) == 0
@@ -355,15 +439,15 @@ def test_menu_scan_action_then_quit(monkeypatch, _isolated_home, capsys):
 
 
 def test_menu_folder_typo_then_retry_shows_count(
-        tmp_path, monkeypatch, _isolated_home, capsys):
+    tmp_path, monkeypatch, _isolated_home, capsys
+):
     good = tmp_path / "history"
     good.mkdir()
     (good / "s.jsonl").write_text(FIXTURE_LINE, encoding="utf-8")
 
     # 2 → typo (suggestion shown) → corrected path (count shown, scan runs)
     # → Enter skips the post-scan redaction offer → Enter → q quit.
-    _feed_menu(monkeypatch, ["2", str(tmp_path / "histori"), str(good), "", "",
-                             "q"])
+    _feed_menu(monkeypatch, ["2", str(tmp_path / "histori"), str(good), "", "", "q"])
     assert main([]) == 0
     captured = capsys.readouterr()
 
@@ -374,12 +458,14 @@ def test_menu_folder_typo_then_retry_shows_count(
 
 
 def test_menu_empty_folder_offers_scan_anyway(
-        tmp_path, monkeypatch, _isolated_home, capsys):
+    tmp_path, monkeypatch, _isolated_home, capsys
+):
     empty = tmp_path / "empty"
     empty.mkdir()
     # decline the scan-anyway offer twice more → _ask_folder gives up → menu → quit
-    _feed_menu(monkeypatch, ["2", str(empty), "n", str(empty), "n", str(empty),
-                             "n", "", "q"])
+    _feed_menu(
+        monkeypatch, ["2", str(empty), "n", str(empty), "n", str(empty), "n", "", "q"]
+    )
     assert main([]) == 0
     out = capsys.readouterr().out
     assert "found 0 .jsonl file(s)" in out
@@ -393,7 +479,8 @@ def test_menu_invalid_choice_reprompts(monkeypatch, _isolated_home, capsys):
 
 
 def test_menu_redact_requires_typed_confirmation(
-        monkeypatch, _isolated_home, _no_claude, capsys):
+    monkeypatch, _isolated_home, _no_claude, capsys
+):
     fake_root = _isolated_home / ".claude" / "projects"
     fake_root.mkdir(parents=True)
     session = fake_root / "session.jsonl"
@@ -407,7 +494,8 @@ def test_menu_redact_requires_typed_confirmation(
 
 
 def test_menu_redact_confirmed_writes_and_undo_restores(
-        monkeypatch, _isolated_home, _no_claude, capsys):
+    monkeypatch, _isolated_home, _no_claude, capsys
+):
     fake_root = _isolated_home / ".claude" / "projects"
     fake_root.mkdir(parents=True)
     session = fake_root / "session.jsonl"
@@ -425,6 +513,7 @@ def test_menu_redact_confirmed_writes_and_undo_restores(
 
 
 # ----------------------------------------------------- post-scan redaction offer
+
 
 def test_post_scan_offer_declined_keeps_exit_1(tmp_path, monkeypatch, capsys):
     root = _mkroot(tmp_path)
@@ -444,8 +533,7 @@ def test_post_scan_offer_declined_keeps_exit_1(tmp_path, monkeypatch, capsys):
     assert AWS_KEY in (root / "session.jsonl").read_text(encoding="utf-8")
 
 
-def test_post_scan_offer_accepted_redacts(
-        tmp_path, monkeypatch, _no_claude, capsys):
+def test_post_scan_offer_accepted_redacts(tmp_path, monkeypatch, _no_claude, capsys):
     root = _mkroot(tmp_path)
     monkeypatch.setattr(cli, "_interactive", lambda: True)
     # Fresh file trips the mtime gate, so the guided --force retry kicks in.
@@ -472,6 +560,7 @@ def test_json_mode_never_prompts(tmp_path, monkeypatch, capsys):
 
 # ------------------------------------------------------- graceful shutdown
 
+
 def _raise_interrupt(*args, **kwargs):
     raise KeyboardInterrupt
 
@@ -488,7 +577,8 @@ def test_ctrl_c_mid_scan_exits_130_no_traceback(tmp_path, monkeypatch, capsys):
 
 
 def test_ctrl_c_during_fix_reassures_about_backups(
-        tmp_path, monkeypatch, _no_claude, capsys):
+    tmp_path, monkeypatch, _no_claude, capsys
+):
     root = _mkroot(tmp_path)
     monkeypatch.setattr(pipeline, "_redact_all", _raise_interrupt)
     code = main(["--root", str(root), "--fix", "--force"])
@@ -510,8 +600,7 @@ def test_ctrl_c_json_mode_keeps_stdout_clean(tmp_path, monkeypatch, capsys):
     assert "interrupted" in captured.err
 
 
-def test_ctrl_c_at_menu_prompt_exits_gracefully(
-        monkeypatch, _isolated_home, capsys):
+def test_ctrl_c_at_menu_prompt_exits_gracefully(monkeypatch, _isolated_home, capsys):
     monkeypatch.setattr(cli, "_interactive", lambda: True)
     monkeypatch.setattr("builtins.input", _raise_interrupt)
     assert main([]) == 0
@@ -520,8 +609,10 @@ def test_ctrl_c_at_menu_prompt_exits_gracefully(
 
 # ------------------------------------------------------- encoding fallback
 
+
 def _console_with_encoding(encoding: str):
     from rich.console import Console
+
     stream = io.TextIOWrapper(io.BytesIO(), encoding=encoding)
     # legacy_windows=False isolates the stream-encoding probe: on Windows,
     # rich marks any non-terminal stream legacy, which forces ASCII anyway.
@@ -532,6 +623,7 @@ def test_ascii_fallback_on_cp1252_stream():
     c = _console_with_encoding("cp1252")
     assert ui._icons(c) == ui._ICONS_ASCII
     from rich import box
+
     assert ui._box(c, box.DOUBLE) is box.ASCII
 
 
@@ -562,10 +654,13 @@ def test_custom_folder_scan_wires_progress(tmp_path, monkeypatch, capsys):
     class _TrackingProgress:
         def __enter__(self):
             return self
+
         def __exit__(self, *exc):
             return False
+
         def advance(self, current: str) -> None:
             advanced.append(current)
+
         def detection(self, *a) -> None:
             pass
 


### PR DESCRIPTION
The update availability notice previously used raw ANSI escape codes, bypassing `NO_COLOR` and `--no-color` settings and printing uninterpreted codes in terminals. This PR refactors the notice to leverage `rich`'s console printing, ensuring it correctly respects user and environmental color preferences.

### Key Changes

*   **`src/agentsweep/cli.py`**:
*     *   Modified the `_background_update_notice` function to replace direct ANSI escape code printing with `ui.console.print()` using Rich-style markup (`[dim yellow]...[/dim yellow]`). This change ensures the update notice respects `NO_COLOR` and `--no-color` arguments/environment variables.
*     *   Applied minor formatting and whitespace adjustments across the file, including import statements and `ArgumentParser.add_argument()` calls, for improved readability and consistency.
### Verification / Testing

To verify these changes:

1.  **Trigger the update notice**: Ensure your `agentsweep` version is older than the latest available on PyPI (e.g., by checking PyPI or locally modifying `__version__` in `src/agentsweep/__init__.py`).
2. 2.  **Verify colored output**: Run `agentsweep` (e.g., `agentsweep scan`). Observe that the update notice appears in dim yellow text, without any visible raw ANSI escape codes.
3. 3.  **Verify NO_COLOR behavior**: Run `NO_COLOR=1 agentsweep` (or `agentsweep --no-color scan`). Confirm that the update notice appears in plain text, with no coloring and no raw ANSI escape codes visible.
4. 4.  **Confirm no regressions**: Ensure overall CLI functionality and output remain consistent when the notice is (or is not) displayed.
### Related Issues

Closes #79