### PR TITLE
ci: add mypy static type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Run tests
         run: python -m pytest tests/ -q
+
+      - name: Run mypy
+        run: python -m mypy src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = ["rich>=13.0", "pyahocorasick>=2.0", "argcomplete>=3.0.0"]
 # or `uv sync --extra dev`.
 dev = [
     "pytest>=7.0",
+    "mypy>=1.10",
     "ruff>=0.8",       # lint + format + import sort + unused-import/var (F401/F841) + complexity (C901)
     "vulture>=2.16",   # module-level dead code (unused funcs/classes Ruff's F-rules miss)
     "bandit>=1.7",     # Python SAST — fitting for a secrets-redaction tool
@@ -64,3 +65,17 @@ include = [
     "/pyproject.toml",
 ]
 
+[tool.mypy]
+python_version = "3.11"
+files = ["src"]
+ignore_missing_imports = true
+warn_unused_configs = true
+pretty = true
+
+[[tool.mypy.overrides]]
+module = ["agentsweep.ui.picker"]
+disable_error_code = ["valid-type"]
+
+[[tool.mypy.overrides]]
+module = ["agentsweep.ui.keys"]
+disable_error_code = ["attr-defined"]

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -117,7 +117,7 @@ def _run_update_check() -> int:
     if err is not None:
         print(f"  warning: could not reach PyPI — {err}", file=sys.stderr)
         return 0
-    if _version_tuple(latest) > _version_tuple(__version__):
+    if latest is not None and _version_tuple(latest) > _version_tuple(__version__):
         print(
             f"  agentsweep {latest} is available — run: "
             f"pip install --upgrade agentsweep"
@@ -339,6 +339,11 @@ def source_completer(prefix: str, **kwargs) -> list[str]:
     return [s for s in SOURCES if s.startswith(prefix)]
 
 
+def _with_source_completer(action: argparse.Action) -> argparse.Action:
+    setattr(action, "completer", source_completer)
+    return action
+
+
 def _get_completion_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(
         prog="agentsweep",
@@ -353,7 +358,7 @@ def _get_completion_parser() -> argparse.ArgumentParser:
     scan_p = subparsers.add_parser("scan", description="Scan history files.")
     scan_source = scan_p.add_argument("--source", choices=list(SOURCES), default=None,
                                       help="Which agent's history (default: claude-code).")
-    scan_source.completer = source_completer
+    _with_source_completer(scan_source)
     scan_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
     scan_p.add_argument("--all", action="store_true", help="Scan every registered agent source.")
     scan_p.add_argument("--detected", action="store_true", help="Only scan sources whose history root exists.")
@@ -369,7 +374,7 @@ def _get_completion_parser() -> argparse.ArgumentParser:
     fix_p = subparsers.add_parser("fix", description="Redact secrets in history.")
     fix_source = fix_p.add_argument("--source", choices=list(SOURCES), default=None,
                                      help="Which agent's history (default: claude-code).")
-    fix_source.completer = source_completer
+    _with_source_completer(fix_source)
     fix_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
     fix_p.add_argument("--all", action="store_true", help="Redact every agent source with findings, one at a time.")
     fix_p.add_argument("--detected", action="store_true", help="With --all, only sources whose history root exists.")
@@ -385,14 +390,14 @@ def _get_completion_parser() -> argparse.ArgumentParser:
     undo_p = subparsers.add_parser("undo", description="Restore backups.")
     undo_source = undo_p.add_argument("--source", choices=list(SOURCES), default="claude-code",
                                        help="Which agent's history.")
-    undo_source.completer = source_completer
+    _with_source_completer(undo_source)
     undo_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
 
     # purge
     purge_p = subparsers.add_parser("purge", description="Delete backups.")
     purge_source = purge_p.add_argument("--source", choices=list(SOURCES), default="claude-code",
-                                         help="Which agent's history.")
-    purge_source.completer = source_completer
+                                          help="Which agent's history.")
+    _with_source_completer(purge_source)
     purge_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
     purge_p.add_argument("--yes", action="store_true", help="Skip the confirmation prompt.")
 

--- a/src/agentsweep/menu.py
+++ b/src/agentsweep/menu.py
@@ -41,7 +41,7 @@ def _check_updates_interactive() -> None:
     latest, err = check_for_update(timeout=5)
     if err is not None:
         ui.warn_line(f"could not reach PyPI — {err}")
-    elif _version_tuple(latest) > _version_tuple(__version__):
+    elif latest is not None and _version_tuple(latest) > _version_tuple(__version__):
         print(
             f"  agentsweep {latest} is available — run: "
             f"uv tool upgrade agentsweep  (or: pip install --upgrade agentsweep)"

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -334,26 +334,26 @@ def run_all(args) -> int:
     if as_json:
         for key, source in selected:
             try:
-                files = list(source.iter_files())
+                source_files = list(source.iter_files())
             except Exception:
-                files = []
-            if files:
-                discovered.append((key, source, files))
+                source_files = []
+            if source_files:
+                discovered.append((key, source, source_files))
     else:
         with ui.console.status("") as status:
             for key, source in selected:
                 try:
-                    files: list[Path] = []
+                    discovered_files: list[Path] = []
                     for f in source.iter_files():
-                        files.append(f)
+                        discovered_files.append(f)
                         status.update(
                             f"[dim]Discovering[/] [bold]{key}[/bold]"
-                            f" … [yellow]{len(files):,}[/] file(s)"
+                            f" … [yellow]{len(discovered_files):,}[/] file(s)"
                         )
                 except Exception:
-                    files = []
-                if files:
-                    discovered.append((key, source, files))
+                    discovered_files = []
+                if discovered_files:
+                    discovered.append((key, source, discovered_files))
 
     total_files = sum(len(f) for _, _, f in discovered)
 
@@ -612,7 +612,7 @@ def _scan(source, files, ignores, progress=None):
     det = getattr(progress, "detection", None) if progress is not None else None
 
     def _on_finding(fd: Finding) -> None:
-        if det is not None:
+        if det is not None and fd.file is not None and fd.line is not None:
             det(fd.display, fd.masked, f"{ui.rel(fd.file, source.root)}:{fd.line}")
 
     return _scan_all(source, files, ignores=ignores,

--- a/src/agentsweep/sources/_base.py
+++ b/src/agentsweep/sources/_base.py
@@ -22,6 +22,10 @@ class Source(ABC):
     # picker, the scan banner, and the README so users know what's verified.
     experimental: bool = False
 
+    def __init__(self, root: Path | None = None) -> None:
+        if root is not None:
+            self.root = root
+
     @abstractmethod
     def files(self) -> list[Path]:
         """Return every history file to scan under this source's root."""

--- a/src/agentsweep/sources/_vscode.py
+++ b/src/agentsweep/sources/_vscode.py
@@ -104,7 +104,7 @@ class _VSCodeSqliteSource(Source):
         self,
         path: Path,
         redactions: list[tuple[int, KeyPath, str]],
-    ) -> bytes:
+    ) -> str | bytes:
         return _redact_sqlite_copy(path, redactions, self._sqlite_text_columns)
 
     def sidecars(self, path: Path) -> list[Path]:

--- a/src/agentsweep/ui/picker.py
+++ b/src/agentsweep/ui/picker.py
@@ -8,6 +8,8 @@ They return plain data (strings / lists) and never call the pipeline.
 """
 from __future__ import annotations
 
+from typing import Literal, overload
+
 from rich import box
 from rich.live import Live
 from rich.padding import Padding
@@ -25,6 +27,28 @@ def _check(selected: bool, target: "console") -> str:  # type: ignore[valid-type
     if _encodes(target, "✓"):
         return "✓" if selected else " "
     return "x" if selected else " "
+
+
+@overload
+def _run_menu(
+    title: str,
+    rows: list[tuple[str, str]],
+    *,
+    multi: Literal[False] = False,
+    button_idx: int | None = None,
+    footer: str = "↑↓ move  Enter select  q quit",
+) -> int | None: ...
+
+
+@overload
+def _run_menu(
+    title: str,
+    rows: list[tuple[str, str]],
+    *,
+    multi: Literal[True],
+    button_idx: int | None = None,
+    footer: str = "↑↓ move  Enter select  q quit",
+) -> tuple[set[int], bool] | None: ...
 
 
 def _run_menu(

--- a/src/agentsweep/ui/progress.py
+++ b/src/agentsweep/ui/progress.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 import os
 import time
 from collections import deque
+from types import TracebackType
+from typing import Literal
+
+from rich.live import Live
+from rich.progress import TaskID
 
 from .console import _encodes, _safe, console
 from ..tips import tip_for
@@ -60,7 +65,12 @@ class _NullScanProgress:
     def __enter__(self) -> "_NullScanProgress":
         return self
 
-    def __exit__(self, *exc) -> bool:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Literal[False]:
         return False
 
     def advance(self, current: str) -> None:
@@ -102,10 +112,10 @@ class _RichScanProgress:
             auto_refresh=False,
         )
         self._total = total
-        self._task: int | None = None
+        self._task: TaskID | None = None
         self._hits: int = 0
         self._feed: deque[tuple[str, str, str]] = deque(maxlen=_MAX_FEED)
-        self._live: object | None = None  # rich.live.Live
+        self._live: Live | None = None
         self._start_time: float = 0.0
         self._flash_time: float = 0.0  # monotonic ts of the last detection
 
@@ -180,26 +190,36 @@ class _RichScanProgress:
     # ------------------------------------------------------------------ ctx mgr
 
     def __enter__(self) -> "_RichScanProgress":
-        from rich.live import Live
         self._start_time = time.monotonic()
         self._task = self._progress.add_task(
             "scan", total=self._total, current="")
-        self._live = Live(
+        live = Live(
             self._build_renderable(),
             console=console,
             transient=True,
             refresh_per_second=14,
             auto_refresh=True,
         )
-        self._live.__enter__()
+        self._live = live
+        live.__enter__()
         return self
 
-    def __exit__(self, *exc) -> bool:
-        return bool(self._live.__exit__(*exc))
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Literal[False]:
+        if self._live is None:
+            return False
+        self._live.__exit__(exc_type, exc, tb)
+        return False
 
     # ------------------------------------------------------------------ API
 
     def advance(self, current: str) -> None:
+        if self._task is None:
+            return
         self._progress.update(
             self._task, advance=1, current=_safe(console, current))
         if self._live is not None:


### PR DESCRIPTION
## Summary
Adds mypy as a dev dependency and CI gate for `src/`, with a pragmatic initial config. Fixes the source typing issues surfaced by the new gate while keeping the diff focused.

## Root cause
The project had tests and existing quality tooling, but no static type-checking gate, so annotation drift and Optional/dynamic attribute issues were not checked in CI.

## Changes
- Add `mypy` to the dev extra and configure `mypy src/`.
- Add a CI step that runs `python -m mypy src/`.
- Tighten small typing seams needed for the initial pass: source constructor typing, nullable update version checks, Rich progress types, picker overloads, and argcomplete dynamic completer assignment.

## Testing
- `.venv/bin/python -m mypy src/`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/ -q` (`532 passed`)
- `.venv/bin/ruff check src/agentsweep/sources/_base.py src/agentsweep/sources/_vscode.py src/agentsweep/ui/progress.py src/agentsweep/ui/picker.py src/agentsweep/pipeline.py src/agentsweep/menu.py src/agentsweep/cli.py`

Fixes #84