### PR TITLE
fix: honor NO_COLOR for update-available notice

### DIFF
--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -104,10 +104,12 @@ def _background_update_notice(args: argparse.Namespace) -> None:
 
     latest = result[0]
     if latest is not None and _version_tuple(latest) > _version_tuple(__version__):
-        # Print a single dim-yellow notice before any other output.
-        print(
-            f"\033[2;33m  ★ agentsweep {latest} available"
-            f" — pip install --upgrade agentsweep\033[0m"
+        # Route through the shared console so NO_COLOR / --no-color are honored
+        # (a raw ANSI print would bypass apply_no_color entirely).
+        ui.console.print(
+            f"  ★ agentsweep {latest} available"
+            f" — pip install --upgrade agentsweep",
+            style="dim yellow",
         )
 
 

--- a/tests/test_ui_output.py
+++ b/tests/test_ui_output.py
@@ -2,6 +2,7 @@
 gate rendering, redact rows, and encoding degradation."""
 from __future__ import annotations
 
+import argparse
 import io
 import json
 import re
@@ -293,6 +294,7 @@ def test_resolve_no_color_reads_env_and_flag(monkeypatch):
 
 def test_no_color_env_suppresses_ansi(tmp_path, monkeypatch, capsys):
     _force_color(monkeypatch)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
     monkeypatch.setenv("NO_COLOR", "1")
     root = _mkroot(tmp_path)
     code = main(["--root", str(root)])
@@ -311,6 +313,59 @@ def test_no_color_flag_suppresses_ansi(tmp_path, monkeypatch, capsys):
 
     assert code == 1
     assert "AGENTSWEEP" in out
+    assert not ANSI_ESCAPE.search(out)
+
+
+def test_color_enabled_emits_ansi(tmp_path, monkeypatch, capsys):
+    """Positive control: color still works when NO_COLOR is unset.
+
+    Without this, the suppression tests could pass vacuously if `_force_color`
+    silently stopped working (both would see no ANSI either way).
+    """
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    # Prior NO_COLOR tests mutate the shared consoles in place — restore color.
+    ui.console.no_color = False
+    ui.err_console.no_color = False
+    _force_color(monkeypatch)
+
+    root = _mkroot(tmp_path)
+    code = main(["--root", str(root)])
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "AGENTSWEEP" in out
+    assert ANSI_ESCAPE.search(out)
+
+
+def test_update_notice_respects_no_color(monkeypatch, capsys):
+    """Update-available line must not emit raw ANSI under NO_COLOR."""
+    import urllib.request
+
+    class _FakeResp:
+        def read(self):
+            return json.dumps({"info": {"version": "99.0.0"}}).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.delenv("AGENTSWEEP_NO_UPDATE", raising=False)
+    ui.apply_no_color(True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: _FakeResp()
+    )
+
+    args = argparse.Namespace(json=False)
+    cli._background_update_notice(args)
+    out = capsys.readouterr().out
+
+    assert "agentsweep 99.0.0 available" in out
     assert not ANSI_ESCAPE.search(out)
 
 


### PR DESCRIPTION
﻿## Summary
- Route `_background_update_notice` through `ui.console.print` with dim yellow style instead of a raw ANSI print, so `NO_COLOR` / `--no-color` suppress color the same way as the rest of the CLI
- Add a positive-control test that ANSI is present when color is enabled (prevents vacuous NO_COLOR test passes)
- Add a regression test that the update notice emits no ANSI under `NO_COLOR`
- Clear `FORCE_COLOR` in the existing `NO_COLOR` env test so it is not defeated by a truthy `FORCE_COLOR=0` in the environment

Closes #79

## Test plan
- [x] pytest tests for color enabled, update notice NO_COLOR, env/flag suppression, and resolve_no_color


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the available-update notification to respect color settings, including `NO_COLOR` and `--no-color`.
  * Prevented unwanted ANSI escape codes from appearing when color output is disabled.
  * Preserved the update notification message while suppressing styling in no-color environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->