### PR TITLE
Honor NO_COLOR for the update-available notice

### DIFF
--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -104,10 +104,11 @@ def _background_update_notice(args: argparse.Namespace) -> None:
 
     latest = result[0]
     if latest is not None and _version_tuple(latest) > _version_tuple(__version__):
-        # Print a single dim-yellow notice before any other output.
-        print(
-            f"\033[2;33m  ★ agentsweep {latest} available"
-            f" — pip install --upgrade agentsweep\033[0m"
+        # Route through rich so NO_COLOR / --no-color strips styling.
+        ui.console.print(
+            f"  ★ agentsweep {latest} available"
+            f" — pip install --upgrade agentsweep",
+            style="dim yellow",
         )
 
 

--- a/tests/test_ui_output.py
+++ b/tests/test_ui_output.py
@@ -314,6 +314,60 @@ def test_no_color_flag_suppresses_ansi(tmp_path, monkeypatch, capsys):
     assert not ANSI_ESCAPE.search(out)
 
 
+def test_color_enabled_emits_ansi(tmp_path, monkeypatch, capsys):
+    """Positive control: with color forced on and NO_COLOR unset, ANSI is present.
+
+    Without this, the suppression tests could pass vacuously if `_force_color`
+    silently stopped working.
+    """
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    _force_color(monkeypatch)
+    # Undo any leftover no_color mutation from a prior test on the shared console.
+    ui.console.no_color = False
+    root = _mkroot(tmp_path)
+    code = main(["--root", str(root)])
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "AGENTSWEEP" in out
+    assert ANSI_ESCAPE.search(out)
+
+
+def test_update_notice_respects_no_color(monkeypatch, capsys):
+    """Update-available notice must not emit raw ANSI under NO_COLOR."""
+    import argparse
+
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+    ui.apply_no_color(True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.delenv("AGENTSWEEP_NO_UPDATE", raising=False)
+
+    # Pretend PyPI already returned a newer version before the wait timeout.
+    def _fake_urlopen(url, timeout=0):  # noqa: ARG001
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return b'{"info":{"version":"99.0.0"}}'
+
+        return _Resp()
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _fake_urlopen,
+    )
+    cli._background_update_notice(argparse.Namespace(json=False))
+    out = capsys.readouterr().out
+    assert "agentsweep 99.0.0 available" in out
+    assert not ANSI_ESCAPE.search(out)
+
+
 # ----------------------------------------------------------------- menu
 
 def _feed_menu(monkeypatch, answers: list[str]):


### PR DESCRIPTION
﻿## Summary
- Route the background update notice through rich `ui.console.print` instead of raw ANSI escapes so `NO_COLOR` / `--no-color` actually strip styling.
- Add a positive-control test that ANSI is present when color is enabled, plus a regression test that the update notice stays plain under `NO_COLOR`.

## Test plan
- [x] pytest NO_COLOR / color-enabled / update-notice tests pass
- [ ] With NO_COLOR=1, a forced newer-version notice prints without ANSI

Fixes #79


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the background update notification to respect color settings consistently, including `NO_COLOR` and `--no-color`.
  * Ensured update notifications remain visible without displaying unwanted ANSI escape characters.

* **Tests**
  * Added coverage confirming colored output when enabled and clean, uncolored output when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->