### PR TITLE
fix: FORCE_COLOR=0 should not override NO_COLOR

### DIFF
--- a/src/agentsweep/ui/console.py
+++ b/src/agentsweep/ui/console.py
@@ -19,12 +19,14 @@ def resolve_no_color(flag: bool = False) -> bool:
 
     True when ``--no-color`` was passed (``flag``) or the ``NO_COLOR``
     convention (https://no-color.org) is in effect: the env var present with
-    any value. ``FORCE_COLOR`` wins over ``NO_COLOR`` when both are set, per
-    the informal precedence most tools follow.
+    any value. ``FORCE_COLOR`` wins over ``NO_COLOR`` when both are set and
+    ``FORCE_COLOR`` is a non-empty, non-``0`` value — ``FORCE_COLOR=0`` (or
+    empty) does not force color and leaves ``NO_COLOR`` in effect.
     """
     if flag:
         return True
-    if os.environ.get("FORCE_COLOR"):
+    force = os.environ.get("FORCE_COLOR")
+    if force not in (None, "", "0"):
         return False
     return "NO_COLOR" in os.environ
 

--- a/tests/test_ui_output.py
+++ b/tests/test_ui_output.py
@@ -290,6 +290,12 @@ def test_resolve_no_color_reads_env_and_flag(monkeypatch):
     monkeypatch.setenv("FORCE_COLOR", "1")  # FORCE_COLOR wins over NO_COLOR
     assert ui.resolve_no_color() is False
 
+    monkeypatch.setenv("FORCE_COLOR", "0")  # FORCE_COLOR=0 does not force color
+    assert ui.resolve_no_color() is True
+
+    monkeypatch.setenv("FORCE_COLOR", "")  # empty also does not force color
+    assert ui.resolve_no_color() is True
+
 
 def test_no_color_env_suppresses_ansi(tmp_path, monkeypatch, capsys):
     _force_color(monkeypatch)


### PR DESCRIPTION
﻿## Summary
- Treat `FORCE_COLOR=0` and empty `FORCE_COLOR` as disabled so they no longer defeat `NO_COLOR`
- Extend `test_resolve_no_color_reads_env_and_flag` to cover these cases

## Test plan
- [x] `pytest tests/test_ui_output.py::test_resolve_no_color_reads_env_and_flag`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected color output handling so `FORCE_COLOR=0` or an empty value no longer forces colored output.
  * Updated color precedence behavior for more predictable terminal display settings.

* **Tests**
  * Added coverage confirming disabled or empty force-color settings preserve no-color behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->