### PR TITLE
ci: add pip cache and shallow checkout for faster workflow setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install package and dev dependencies
         run: pip install -e ".[dev]"


### PR DESCRIPTION
## What & why
- What: Add CI speedups: `fetch-depth: 1` on `actions/checkout` and `cache: 'pip'` on `setup-python`.
- Why: Reduce CI setup time by using a shallow clone and caching pip packages between runs.

## Type of change
- [x] Refactor / docs / chore

## Testing
- Skipping local `pytest` for this CI-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated build setup with faster source checkout and Python dependency caching.
  * No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->