### PR TITLE
perf: parallelize scan --all across sources (fixes #92)

### DIFF
--- a/docs/PERF.md
+++ b/docs/PERF.md
@@ -6,20 +6,33 @@ multi-MB embedded transcripts), so per-byte and per-string costs both matter.
 
 ## Landed
 
-- **Keyword pre-filter (≈7.5×).** Each rule carries a required literal
-  anchor (`akia`, `ghp_`, `twitter`, …) extracted from its pattern; the
+- **Keyword pre-filter (approx 7.5x).** Each rule carries a required literal
+  anchor (`akia`, `ghp_`, `twitter`, ...) extracted from its pattern; the
   regex is skipped when the anchor is absent. 180/189 rules are gated.
   Provably lossless (a match always contains its anchor); gated by the
   per-rule fixture tests. See `scanner.py:_prefilter_literals`.
 - **Mnemonic gate.** `detect_mnemonics` returns early when a string has
-  fewer than 11 word separators — it cannot hold a 12-word phrase — so big
+  fewer than 11 word separators -- it cannot hold a 12-word phrase -- so big
   tokenless blobs (base64, minified JS, long paths) skip tokenization.
 - **Single-pass Aho-Corasick anchors.** `pyahocorasick` collapses per-string
   prefilter checks into one O(n) pass (substring fallback if the wheel is
   absent). See `scanner.py:_triggered_indices`.
 - **Aider discovery prune.** Default Aider scans no longer `rglob` the
-  entire home tree. Junk dirs (`node_modules`, `.git`, `AppData`, …) are
+  entire home tree. Junk dirs (`node_modules`, `.git`, `AppData`, ...) are
   skipped and depth is capped. See `sources._core._iter_aider_histories`.
+- **Cross-source parallelism for scan --all.** Phase 1 (discovery) and
+  Phase 2 (scanning) in `run_all()` now run all selected sources
+  concurrently via `ThreadPoolExecutor` instead of sequentially. Each source
+  is fully independent (separate root, separate files, separate ignore set)
+  so there is no shared mutable state between workers. Source-level
+  concurrency is capped at 4 workers; combined with each source's own
+  inner file-level pool (up to 8 workers) the total thread count stays
+  bounded at ~32. Rich's Live progress display is protected by a
+  `threading.Lock` so it is never updated from two threads simultaneously.
+  Results are re-ordered by original index after all futures complete, so
+  findings output remains deterministic regardless of which source finishes
+  first. See `pipeline.py:run_all`.
+
 
 ## Evaluated and dropped
 

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -9,6 +9,7 @@ import difflib
 import json
 import os
 import sys
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -331,32 +332,77 @@ def run_all(args) -> int:
                 f"— history path/format not yet verified against a real install"
             )
 
-    # Phase 1: discover files per source (stream status so large roots
-    # don't look hung — same contract as single-source run()).
-    discovered: list[tuple[str, Source, list[Path]]] = []
+    # Phase 1: discover files for all sources concurrently.  Each source
+    # walks its own independent root directory so there is no shared state
+    # between workers.  Results are collected into a list keyed by the
+    # original index so the final ordering matches `selected` regardless of
+    # which worker finishes first.
+    #
+    # Discovery workers are capped at the number of selected sources — we
+    # never need more workers than there are sources, and Python threads are
+    # cheap enough that one-per-source is fine for the typical count (<30).
+
+    def _discover_one(key: str, source: Source) -> tuple[str, Source, list[Path]]:
+        """Collect every file for a single source; safe to call from a thread."""
+        try:
+            files = list(source.iter_files())
+        except Exception:
+            files = []
+        return key, source, files
+
+    discover_workers = min(len(selected), max(1, len(selected)))
+    discovered_by_index: dict[int, tuple[str, Source, list[Path]]] = {}
+
     if as_json:
-        for key, source in selected:
-            try:
-                source_files = list(source.iter_files())
-            except Exception:
-                source_files = []
-            if source_files:
-                discovered.append((key, source, source_files))
+        with ThreadPoolExecutor(max_workers=discover_workers) as disc_pool:
+            disc_futures = {
+                disc_pool.submit(_discover_one, key, source): idx
+                for idx, (key, source) in enumerate(selected)
+            }
+            for fut in as_completed(disc_futures):
+                idx = disc_futures[fut]
+                key, source, files = fut.result()
+                if files:
+                    discovered_by_index[idx] = (key, source, files)
     else:
+        completed_count = 0
+        completed_lock = threading.Lock()
+
+        def _discover_with_status(
+            key: str, source: Source
+        ) -> tuple[str, Source, list[Path]]:
+            result = _discover_one(key, source)
+            nonlocal completed_count
+            with completed_lock:
+                completed_count += 1
+
+            return result
+
         with ui.console.status("") as status:
-            for key, source in selected:
-                try:
-                    discovered_files: list[Path] = []
-                    for f in source.iter_files():
-                        discovered_files.append(f)
-                        status.update(
-                            f"[dim]Discovering[/] [bold]{key}[/bold]"
-                            f" … [yellow]{len(discovered_files):,}[/] file(s)"
-                        )
-                except Exception:
-                    discovered_files = []
-                if discovered_files:
-                    discovered.append((key, source, discovered_files))
+            with ThreadPoolExecutor(max_workers=discover_workers) as disc_pool:
+                disc_futures = {
+                    disc_pool.submit(_discover_with_status, key, source): idx
+                    for idx, (key, source) in enumerate(selected)
+                }
+                for fut in as_completed(disc_futures):
+                    idx = disc_futures[fut]
+                    key, source, files = fut.result()
+                    if files:
+                        discovered_by_index[idx] = (key, source, files)
+                    with completed_lock:
+                        done = completed_count
+                    status.update(
+                        f"[dim]Discovering[/] [bold]{done}/{len(selected)}[/bold]"
+                        f" source(s) … "
+                        f"[yellow]{sum(len(f) for _, _, f in discovered_by_index.values()):,}[/]"
+                        f" file(s) so far"
+                    )
+
+    # Rebuild in the original selection order so output is deterministic.
+    discovered: list[tuple[str, Source, list[Path]]] = [
+        discovered_by_index[i]
+        for i in sorted(discovered_by_index)
+    ]
 
     total_files = sum(len(f) for _, _, f in discovered)
 
@@ -378,41 +424,124 @@ def run_all(args) -> int:
         ui.stage(1, "ok", "DISCOVER", f"{len(discovered)} source(s)",
                  f"{total_files} file(s)")
 
-    # Phase 2: scan sources sequentially; one shared progress bar over all
-    # files (inner _scan still parallelizes within a source).
-    per_source: list[tuple[str, Source, list[Path], dict, int, int, list[Path]]] = []
+    # Phase 2: scan all sources concurrently.  Each source is independent
+    # (separate root, separate files, separate ignore set) so there is no
+    # shared mutable state between source-level workers.
+    #
+    # Thread budget: source-level concurrency is capped at 4.  Each source
+    # internally spins up its own _scan_all thread pool (up to 8 file
+    # workers), giving at most 4*8 = 32 threads alive at one time — well
+    # within the practical limit for local I/O without hammering the GIL.
+    #
+    # Progress bar safety: Rich's Live.update() must only be called from one
+    # thread at a time.  A threading.Lock serialises every call to
+    # progress.advance() and progress.detection() so the Live display is
+    # never touched from two workers simultaneously.
+    #
+    # Result ordering: futures are mapped to their original index in
+    # `discovered` and results are re-inserted by that index so the findings
+    # table output is deterministic regardless of completion order.
+
+    _SCAN_SOURCE_WORKERS = 4
+
+    per_source_by_index: dict[
+        int,
+        tuple[str, Source, list[Path], dict, int, int, list[Path]]
+    ] = {}
     total_strings = 0
     total_suppressed = 0
     total_truncated: list[Path] = []
 
     t0 = time.perf_counter()
     if as_json:
-        for key, source, files in discovered:
-            ignores = (ignore_mod.IgnoreSet() if no_ignore
-                       else ignore_mod.load([source.root, Path.cwd()]))
-            found_by_file, strings_scanned, suppressed, truncated = _scan(
-                source, files, ignores)
-            per_source.append(
-                (key, source, files, found_by_file, strings_scanned,
-                 suppressed, truncated)
-            )
-            total_strings += strings_scanned
-            total_suppressed += suppressed
-            total_truncated.extend(truncated)
-    else:
-        with ui.scan_progress(total_files) as progress:
-            for key, source, files in discovered:
-                ignores = (ignore_mod.IgnoreSet() if no_ignore
-                           else ignore_mod.load([source.root, Path.cwd()]))
-                found_by_file, strings_scanned, suppressed, truncated = _scan(
-                    source, files, ignores, progress)
-                per_source.append(
-                    (key, source, files, found_by_file, strings_scanned,
-                     suppressed, truncated)
+        scan_workers = min(_SCAN_SOURCE_WORKERS, len(discovered))
+        with ThreadPoolExecutor(max_workers=scan_workers) as scan_pool:
+            def _scan_json_source(
+                key: str, source: Source, files: list[Path]
+            ) -> tuple[str, Source, list[Path], dict, int, int, list[Path]]:
+                """Run a full source scan; safe to call from a thread."""
+                ignores = (
+                    ignore_mod.IgnoreSet() if no_ignore
+                    else ignore_mod.load([source.root, Path.cwd()])
                 )
-                total_strings += strings_scanned
-                total_suppressed += suppressed
-                total_truncated.extend(truncated)
+                found_by_file, strings_scanned, suppressed, truncated = _scan(
+                    source, files, ignores
+                )
+                return (
+                    key, source, files, found_by_file,
+                    strings_scanned, suppressed, truncated
+                )
+
+            scan_futures = {
+                scan_pool.submit(_scan_json_source, key, source, files): idx
+                for idx, (key, source, files) in enumerate(discovered)
+            }
+            for fut in as_completed(scan_futures):
+                idx = scan_futures[fut]
+                per_source_by_index[idx] = fut.result()
+    else:
+        progress_lock = threading.Lock()
+
+        with ui.scan_progress(total_files) as progress:
+            def _scan_tty_source(
+                key: str, source: Source, files: list[Path]
+            ) -> tuple[str, Source, list[Path], dict, int, int, list[Path]]:
+                """Run a full source scan with thread-safe progress updates.
+
+                All calls to progress.advance() and progress.detection() are
+                serialised through progress_lock so that Rich's Live display
+                is never updated from two threads at the same time.
+                """
+                ignores = (
+                    ignore_mod.IgnoreSet() if no_ignore
+                    else ignore_mod.load([source.root, Path.cwd()])
+                )
+
+                # Wrap the shared progress object with lock-protected callbacks
+                # rather than passing the raw object to _scan.  This keeps the
+                # locking concern contained here instead of spreading it into
+                # the inner _scan/_scan_all path.
+                class _LockedProgress:
+                    def advance(self_inner, current: str) -> None:
+                        with progress_lock:
+                            progress.advance(current)
+
+                    def detection(
+                        self_inner,
+                        rule_display: str,
+                        masked: str,
+                        location: str,
+                    ) -> None:
+                        with progress_lock:
+                            progress.detection(rule_display, masked, location)
+
+                found_by_file, strings_scanned, suppressed, truncated = _scan(
+                    source, files, ignores, _LockedProgress()
+                )
+                return (
+                    key, source, files, found_by_file,
+                    strings_scanned, suppressed, truncated
+                )
+
+            scan_workers = min(_SCAN_SOURCE_WORKERS, len(discovered))
+            with ThreadPoolExecutor(max_workers=scan_workers) as scan_pool:
+                scan_futures = {
+                    scan_pool.submit(_scan_tty_source, key, source, files): idx
+                    for idx, (key, source, files) in enumerate(discovered)
+                }
+                for fut in as_completed(scan_futures):
+                    idx = scan_futures[fut]
+                    per_source_by_index[idx] = fut.result()
+
+    # Rebuild in the original discovery order for deterministic output.
+    per_source: list[tuple[str, Source, list[Path], dict, int, int, list[Path]]] = [
+        per_source_by_index[i] for i in sorted(per_source_by_index)
+    ]
+    for _k, _s, _f, _fbf, strings_scanned, suppressed, truncated in per_source:
+        total_strings += strings_scanned
+        total_suppressed += suppressed
+        total_truncated.extend(truncated)
+
     elapsed = time.perf_counter() - t0
 
     if as_json:

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -338,9 +338,9 @@ def run_all(args) -> int:
     # original index so the final ordering matches `selected` regardless of
     # which worker finishes first.
     #
-    # Discovery workers are capped at the number of selected sources — we
-    # never need more workers than there are sources, and Python threads are
-    # cheap enough that one-per-source is fine for the typical count (<30).
+    # Discovery workers are capped at _SOURCE_WORKERS_CAP to ensure bounded
+    # concurrency across the entire pipeline.
+    _SOURCE_WORKERS_CAP = 4
 
     def _discover_one(key: str, source: Source) -> tuple[str, Source, list[Path]]:
         """Collect every file for a single source; safe to call from a thread."""
@@ -350,7 +350,7 @@ def run_all(args) -> int:
             files = []
         return key, source, files
 
-    discover_workers = min(len(selected), max(1, len(selected)))
+    discover_workers = min(_SOURCE_WORKERS_CAP, max(1, len(selected)))
     discovered_by_index: dict[int, tuple[str, Source, list[Path]]] = {}
 
     if as_json:
@@ -442,8 +442,6 @@ def run_all(args) -> int:
     # `discovered` and results are re-inserted by that index so the findings
     # table output is deterministic regardless of completion order.
 
-    _SCAN_SOURCE_WORKERS = 4
-
     per_source_by_index: dict[
         int,
         tuple[str, Source, list[Path], dict, int, int, list[Path]]
@@ -454,7 +452,7 @@ def run_all(args) -> int:
 
     t0 = time.perf_counter()
     if as_json:
-        scan_workers = min(_SCAN_SOURCE_WORKERS, len(discovered))
+        scan_workers = min(_SOURCE_WORKERS_CAP, len(discovered))
         with ThreadPoolExecutor(max_workers=scan_workers) as scan_pool:
             def _scan_json_source(
                 key: str, source: Source, files: list[Path]
@@ -476,9 +474,9 @@ def run_all(args) -> int:
                 scan_pool.submit(_scan_json_source, key, source, files): idx
                 for idx, (key, source, files) in enumerate(discovered)
             }
-            for fut in as_completed(scan_futures):
-                idx = scan_futures[fut]
-                per_source_by_index[idx] = fut.result()
+            for scan_fut in as_completed(scan_futures):
+                idx = scan_futures[scan_fut]
+                per_source_by_index[idx] = scan_fut.result()
     else:
         progress_lock = threading.Lock()
 
@@ -523,15 +521,15 @@ def run_all(args) -> int:
                     strings_scanned, suppressed, truncated
                 )
 
-            scan_workers = min(_SCAN_SOURCE_WORKERS, len(discovered))
+            scan_workers = min(_SOURCE_WORKERS_CAP, len(discovered))
             with ThreadPoolExecutor(max_workers=scan_workers) as scan_pool:
                 scan_futures = {
                     scan_pool.submit(_scan_tty_source, key, source, files): idx
                     for idx, (key, source, files) in enumerate(discovered)
                 }
-                for fut in as_completed(scan_futures):
-                    idx = scan_futures[fut]
-                    per_source_by_index[idx] = fut.result()
+                for scan_fut in as_completed(scan_futures):
+                    idx = scan_futures[scan_fut]
+                    per_source_by_index[idx] = scan_fut.result()
 
     # Rebuild in the original discovery order for deterministic output.
     per_source: list[tuple[str, Source, list[Path], dict, int, int, list[Path]]] = [


### PR DESCRIPTION
Parallelizes the scan --all command across multiple sources using ThreadPoolExecutor, significantly speeding up the process while keeping terminal progress updates thread-safe and output deterministic. Fixes #92.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved multi-source discovery and scanning speed with concurrent worker execution.
  * Enhanced `--all` processing by running discovery and scanning in parallel while preserving deterministic result ordering.
  * Kept source-level concurrency capped for efficient throughput.
* **User Experience**
  * Stabilized Rich progress reporting during parallel operations.
  * Continued consistent aggregation of totals, warnings, and overflow reporting.
* **Documentation**
  * Refreshed performance documentation wording and added details on cross-source parallelism improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->