### PR TITLE
feat(scanner.py): Add Google OAuth client secret and service-account key detectors

### DIFF
--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -42,6 +42,13 @@ RULES: list[tuple[str, str, re.Pattern]] = [
         re.compile(r"\bsk-ant-(?:api|sid)[0-9]*-[A-Za-z0-9_-]{32,}\b")),
     ("google-api", "Google API key",
         re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b")),
+    ("google-oauth-client-secret", "Google OAuth client secret",
+        re.compile(r"\bGOCSPX-[A-Za-z0-9_-]{28}\b")),
+    ("google-service-account-key", "Google service-account key",
+        # Anchored on the JSON "type": "service_account" marker and confirmed
+        # by a nearby private_key_id, so a bare PEM block (already caught by
+        # private-key-pem) doesn't also trip this rule.
+        re.compile(r'"type":\s*"service_account"[\s\S]{0,200}?"private_key_id":\s*"[a-f0-9]{40}"')),
     ("slack-bot", "Slack bot token",
         re.compile(r"\bxoxb-[A-Za-z0-9-]{10,}\b")),
     ("slack-user", "Slack user token",
@@ -707,6 +714,8 @@ ROTATION_GUIDANCE: dict[str, str] = {
     "openai": "Revoke: https://platform.openai.com/api-keys",
     "anthropic": "Revoke: https://console.anthropic.com/settings/keys",
     "google-api": "Rotate: https://console.cloud.google.com/apis/credentials",
+    "google-oauth-client-secret": "Rotate: https://console.cloud.google.com/apis/credentials (OAuth 2.0 Client IDs > reset secret)",
+    "google-service-account-key": "Revoke: https://console.cloud.google.com/iam-admin/serviceaccounts (delete the compromised key, generate a new one)",
     "slack-bot": "Rotate: https://api.slack.com/apps (OAuth & Permissions)",
     "slack-user": "Rotate: https://api.slack.com/apps (OAuth & Permissions)",
     "slack-webhook": "Regenerate the webhook in the Slack app that owns it.",

--- a/tests/test_ported_rules.py
+++ b/tests/test_ported_rules.py
@@ -75,6 +75,8 @@ FIXTURES: dict[str, str] = {
     'gitlab-runner-auth-routable': 'glrt-t1_a1b2c3a1b2c3a1b2' 'c3a1b2c3a1b2c3.a1b2c3a1b',
     'gitlab-scim': 'glsoat-a1b2c3' 'a1b2c3a1b2c3a1',
     'gitlab-session-cookie': '_gitlab_session=a1b2c3a1' 'b2c3a1b2c3a1b2c3a1b2c3a1',
+    'google-oauth-client-secret': 'GOCSPX-a1b2c3d4e5f6a1b2' 'c3d4e5f6a1b2',
+    'google-service-account-key': '{"type": "service_account", "private_key_id": "' 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"}',
     'grafana-api-key': 'eyJrIjoia1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1' 'b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3',
     'grafana-cloud-token': 'glc_a1b2c3a1b2c3a1b2' 'c3a1b2c3a1b2c3a1b2c3',
     'grafana-service-account': 'glsa_a1b2c3a1b2c3a1b2c3' 'a1b2c3a1b2c3a1_a1b2c3a1',


### PR DESCRIPTION

<!--
Thanks for contributing to agentsweep! Fill in the sections below.
Keep PRs focused — one concern per PR (a CI fix and a feature should be
two PRs). See CLAUDE.md for the project's conventions.
-->

## What & why

Add detection rules for two Google credential types not currently covered: OAuth client secrets (`GOCSPX-...`) and service-account JSON key files. `google-api` keys (`AIza...`) were already detected — this closes the remaining gap.

Closes #30 

## Type of change

- [ ] Bug fix
- [ ] New agent source
- [x] New detection rule
- [ ] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing

<!-- How did you verify this? Paste the relevant `pytest` summary. -->

```
$ pytest -q
552 passed, 12 skipped in 5.62s

$ pytest -v -k google tests/test_ported_rules.py
test_ported_rule_detects_its_fixture[google-oauth-client-secret] PASSED
test_ported_rule_detects_its_fixture[google-service-account-key] PASSED
2 passed

$ ruff check src/agentsweep/scanner.py tests/test_ported_rules.py
All checks passed!

$ mypy src/agentsweep/scanner.py
Success: no issues found in 1 source file
```

## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13)
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [ ] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail)
- [x] **New detection rule?** Added to `RULES` **and** `ROTATION_GUIDANCE` **and** a fixture/test, with every regex quantifier bounded (no unbounded `.*`), and the keyword pre-filter kept lossless
- [ ] **New source?** Registered in `SOURCES` with process markers, a menu entry, and a round-trip test (see CLAUDE.md → "Adding a new Source")
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths)
- [x] Did not re-introduce `force-include` in `pyproject.toml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for Google OAuth client secrets and Google service-account keys.
  * Added tailored remediation guidance for each newly detected credential type.

* **Bug Fixes**
  * Improved secret scanning coverage for Google credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->