### PR TITLE
ci: add bandit SAST job, triage all 22 findings (#82)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,22 @@ jobs:
 
       - name: Run mypy
         run: python -m mypy src/
+
+  security:
+    name: Bandit SAST
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: 'pip'
+
+      - name: Install package and dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run bandit
+        run: python -m bandit -r src/ -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,16 @@ pytest -v
 
 The test suite is fully hermetic — it never touches `~/.claude/` or any real history directory. Every test uses `tmp_path`. If you add a test that reaches outside `tmp_path`, the PR will be rejected.
 
+## Security linting
+
+CI runs [bandit](https://bandit.readthedocs.io/) (`bandit -r src/`) on every PR as a SAST gate — fitting for a tool that redacts secrets and rewrites users' files. Run it locally before pushing:
+
+```
+bandit -r src/ -q
+```
+
+If a finding is a false positive or an accepted risk, annotate it inline with `# nosec BXXX # one-line reason` rather than disabling the check globally — see the existing annotations in `preflight.py`, `cli.py`, and `sources/_helpers.py` for examples. Because bandit's own comment parser treats everything after `nosec` up to the next `#` as a list of test IDs, always put the reason after a second `#` (`# nosec B608 # reason`, not `# nosec B608 — reason`) or it will misparse your prose as test-id tokens.
+
 ## Safety-first review
 
 Any PR that touches `redactor.py` or the write path must:

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ agentsweep runs against your most sensitive data, so a malicious contribution wo
 - **Pulls in an unvetted dependency** or repins an existing one to an unexpected source/version.
 - **Edits CI/workflows to exfiltrate secrets or tokens** (e.g. printing `GITHUB_TOKEN`, adding a step that phones home, or touching the PyPI Trusted-Publisher release path).
 
-Every PR also runs GitGuardian in CI, and workflows from first-time contributors require maintainer approval before they execute. Maintainers merge only after this review — a green checkmark alone is never sufficient.
+Every PR also runs GitGuardian and a [bandit](https://bandit.readthedocs.io/) SAST scan in CI (see [Security linting](CONTRIBUTING.md#security-linting)), and workflows from first-time contributors require maintainer approval before they execute. Maintainers merge only after this review — a green checkmark alone is never sufficient.
 
 ## Contributors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,9 @@ fail_under = 74
 # add minutes to every CI leg). --benchmark-disable makes each benched function
 # run once; scripts/benchmark_compare.sh passes --benchmark-only to actually time.
 addopts = "--benchmark-disable"
+
+[tool.bandit]
+# CI already scopes the scan to src/ (bandit -r src/); this excludes tests/
+# too for ad-hoc local runs (bandit -r .), since test fixtures are
+# intentionally secret-shaped synthetic data, not a security surface.
+exclude_dirs = ["tests"]

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -43,7 +43,7 @@ def check_for_update(timeout: int = 2) -> tuple[str | None, str | None]:
     (None, error_string) so the caller can decide whether to surface it.
     """
     try:
-        with urllib.request.urlopen(_PYPI_URL, timeout=timeout) as resp:
+        with urllib.request.urlopen(_PYPI_URL, timeout=timeout) as resp:  # nosec B310 # _PYPI_URL is a hardcoded https:// constant, never user input
             data = json.loads(resp.read())
         return data["info"]["version"], None
     except Exception as exc:  # network error, JSON error, key error, …
@@ -88,10 +88,10 @@ def _background_update_notice(args: argparse.Namespace) -> None:
 
     def _fetch() -> None:
         try:
-            with urllib.request.urlopen(_PYPI_URL, timeout=1.5) as resp:
+            with urllib.request.urlopen(_PYPI_URL, timeout=1.5) as resp:  # nosec B310 # _PYPI_URL is a hardcoded https:// constant, never user input
                 data = json.loads(resp.read())
             result[0] = data["info"]["version"]
-        except Exception:
+        except Exception:  # nosec B110 # best-effort background version check; any network/parse error must not crash the main flow
             pass
         finally:
             done.set()
@@ -435,7 +435,7 @@ def _run_completion(rest: list[str]) -> int:
         print("  Install it using: pip install argcomplete", file=sys.stderr)
         return 2
 
-    print(shellcode(["agentsweep", "asweep"], shell=args.shell))
+    print(shellcode(["agentsweep", "asweep"], shell=args.shell))  # nosec B604 # argcomplete.shellcode's own "target shell" kwarg (choices=bash/zsh/fish/powershell), not subprocess shell=True
     return 0
 
 

--- a/src/agentsweep/menu.py
+++ b/src/agentsweep/menu.py
@@ -166,7 +166,7 @@ def _open_repo() -> None:
     try:
         if webbrowser.open(__repo__):
             ui.console.print("  [dim]opened the repo in your browser...[/]")
-    except Exception:
+    except Exception:  # nosec B110 # best-effort browser launch on a hardcoded repo URL; headless/no-display environments must not crash
         pass
 
 

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -305,7 +305,7 @@ def run_all(args) -> int:
     for key, cls in SOURCES.items():
         try:
             src = cls()
-        except Exception:
+        except Exception:  # nosec B112 # skip a source whose constructor fails (e.g. unresolvable home dir) rather than aborting scan --all for every other source
             continue
         if detected_only and not src.is_detected():
             continue

--- a/src/agentsweep/preflight.py
+++ b/src/agentsweep/preflight.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import subprocess
+import subprocess  # nosec B404 # used only to list running processes for is_agent_running(); no shell, no untrusted input
 import sys
 
 
@@ -268,14 +268,14 @@ def is_claude_code_running() -> tuple[bool, str]:
 def _list_process_cmdlines() -> list[str] | None:
     try:
         if sys.platform == "win32":
-            out = subprocess.check_output(
+            out = subprocess.check_output(  # nosec B603 B607 # fixed argv, no shell, timeout-bounded; tasklist resolved via PATH same as any local dev tool
                 ["tasklist", "/FO", "CSV", "/NH"],
                 text=True,
                 timeout=5,
                 stderr=subprocess.DEVNULL,
             )
         else:
-            out = subprocess.check_output(
+            out = subprocess.check_output(  # nosec B603 B607 # fixed argv, no shell, timeout-bounded; ps resolved via PATH same as any local dev tool
                 ["ps", "-eo", "args="],
                 text=True,
                 timeout=5,

--- a/src/agentsweep/sources/_community.py
+++ b/src/agentsweep/sources/_community.py
@@ -17,6 +17,7 @@ from ._base import JsonlSource, KeyPath, Source
 from ._helpers import (
     _apply_jsonl_redactions,
     _iter_jsonl_strings,
+    _quote_ident,
     _redact_sqlite_copy,
     sqlite_sidecars,
 )
@@ -321,7 +322,7 @@ class LlmSource(Source):
                 # PRAGMA table_info, so a bad-column OperationalError here would
                 # be a real bug, not an expected miss — let it surface.
                 for rowid, value in con.execute(
-                    f"SELECT rowid, {col} FROM {table}"  # noqa: S608
+                    f"SELECT rowid, {_quote_ident(col)} FROM {_quote_ident(table)}"  # nosec B608 # table/col are SQL-escaped via _quote_ident(), not raw interpolation; bandit can't see through the helper
                 ):
                     if isinstance(value, str) and value:
                         yield (max(rowid, 1), [table, rowid, col], value)
@@ -344,7 +345,7 @@ class LlmSource(Source):
         for table, cols in self._KNOWN_COLUMNS.items():
             if table not in tables:
                 continue
-            actual = {row[1] for row in con.execute(f"PRAGMA table_info({table})")}
+            actual = {row[1] for row in con.execute(f"PRAGMA table_info({_quote_ident(table)})")}
             present = [c for c in cols if c in actual]
             if not present:
                 raise RuntimeError(

--- a/src/agentsweep/sources/_core.py
+++ b/src/agentsweep/sources/_core.py
@@ -21,6 +21,7 @@ from ._helpers import (
     _iter_json_file_strings,
     _iter_plaintext_lines,
     _iter_project_histories,
+    _quote_ident,
     _redact_sqlite_copy,
     sqlite_sidecars,
 )
@@ -210,7 +211,7 @@ class OpenCodeSource(Source):
                 # silently eating it is exactly what hid the schema drift of
                 # issue #14 (scan reported CLEAN while missing part.data).
                 cur = con.execute(
-                    f"SELECT rowid, {col} FROM {table}"  # noqa: S608
+                    f"SELECT rowid, {_quote_ident(col)} FROM {_quote_ident(table)}"  # nosec B608 # table/col are SQL-escaped via _quote_ident(), not raw interpolation; bandit can't see through the helper
                 )
                 for rowid, value in cur:
                     if not isinstance(value, str) or not value:

--- a/src/agentsweep/sources/_helpers.py
+++ b/src/agentsweep/sources/_helpers.py
@@ -18,6 +18,20 @@ from ._base import KeyPath, _line_ending, _set_by_path, _walk_json
 # SQLite helpers
 # ---------------------------------------------------------------------------
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQLite identifier (table/column name) per the SQL standard.
+
+    Table/column names here are never user-supplied query input -- they come
+    either from a fixed Python-literal whitelist or from introspecting the
+    very same file being redacted (sqlite_master / PRAGMA table_info). But an
+    identifier can itself legally contain a double quote (SQLite lets you
+    CREATE TABLE "foo""bar"), so bare f-string interpolation isn't safe
+    against a maliciously-crafted db file. Doubling embedded quotes and
+    wrapping in "..." is SQLite's own escaping rule for identifiers.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
 def sqlite_sidecars(db: Path) -> list[Path]:
     """The `-wal` / `-shm` files SQLite keeps beside `db`, if they exist.
 
@@ -108,7 +122,8 @@ def _fts5_optimize(con: sqlite3.Connection) -> None:
         "AND lower(sql) NOT LIKE '%using fts5vocab%'"
     ).fetchall()
     for (name,) in rows:
-        con.execute(f'INSERT INTO "{name}"("{name}") VALUES (\'optimize\')')
+        q = _quote_ident(name)
+        con.execute(f"INSERT INTO {q}({q}) VALUES ('optimize')")  # nosec B608 # q is SQL-escaped via _quote_ident(), not raw interpolation; bandit can't see through the helper
 
 
 def _apply_sqlite_updates(
@@ -124,15 +139,16 @@ def _apply_sqlite_updates(
         table, rowid, col = kp[0], kp[1], kp[2]
         if (table, col) not in allowed:
             continue
+        q_table, q_col = _quote_ident(table), _quote_ident(col)
         sub_kp = kp[3:]
         if not sub_kp:
             con.execute(
-                f"UPDATE {table} SET {col} = ? WHERE rowid = ?",  # noqa: S608
+                f"UPDATE {q_table} SET {q_col} = ? WHERE rowid = ?",  # nosec B608 # q_table/q_col are SQL-escaped via _quote_ident(), not raw interpolation; bandit can't see through the helper
                 (new_val, rowid),
             )
         else:
             cur = con.execute(
-                f"SELECT {col} FROM {table} WHERE rowid = ?",  # noqa: S608
+                f"SELECT {q_col} FROM {q_table} WHERE rowid = ?",  # nosec B608 # q_table/q_col are SQL-escaped via _quote_ident(), not raw interpolation; bandit can't see through the helper
                 (rowid,),
             )
             row = cur.fetchone()
@@ -144,7 +160,7 @@ def _apply_sqlite_updates(
                 continue
             _set_by_path(obj, sub_kp, new_val)
             con.execute(
-                f"UPDATE {table} SET {col} = ? WHERE rowid = ?",  # noqa: S608
+                f"UPDATE {q_table} SET {q_col} = ? WHERE rowid = ?",  # nosec B608 # q_table/q_col are SQL-escaped via _quote_ident(), not raw interpolation; bandit can't see through the helper
                 (json.dumps(obj, ensure_ascii=False), rowid),
             )
 

--- a/src/agentsweep/sources/_more.py
+++ b/src/agentsweep/sources/_more.py
@@ -45,6 +45,7 @@ from ._helpers import (
     _iter_jsonl_strings,
     _iter_plaintext_lines,
     _iter_project_histories,
+    _quote_ident,
     _redact_sqlite_copy,
     sqlite_sidecars,
 )
@@ -80,7 +81,7 @@ def _all_table_columns(con: sqlite3.Connection) -> list[tuple[str, str]]:
         return pairs
     for table in tables:
         try:
-            cols = con.execute(f'PRAGMA table_info("{table}")').fetchall()
+            cols = con.execute(f"PRAGMA table_info({_quote_ident(table)})").fetchall()
         except sqlite3.Error:
             continue
         for col in cols:
@@ -96,7 +97,8 @@ def _iter_sqlite_all_columns(path: Path, columns_fn) -> Iterator[tuple[int, KeyP
     try:
         for table, col in columns_fn(con):
             try:
-                cur = con.execute(f'SELECT rowid, "{col}" FROM "{table}"')
+                cur = con.execute(
+                    f"SELECT rowid, {_quote_ident(col)} FROM {_quote_ident(table)}")  # nosec B608 # table/col are SQL-escaped via _quote_ident(), not raw interpolation; bandit can't see through the helper
             except sqlite3.Error:
                 continue  # WITHOUT ROWID tables, virtual tables, etc.
             for rowid, value in cur:

--- a/src/agentsweep/sources/_vscode.py
+++ b/src/agentsweep/sources/_vscode.py
@@ -18,6 +18,7 @@ from ._helpers import (
     _apply_plaintext_redactions,
     _iter_jsonl_strings,
     _iter_plaintext_lines,
+    _quote_ident,
     _redact_sqlite_copy,
     sqlite_sidecars,
 )
@@ -62,7 +63,7 @@ class _VSCodeSqliteSource(Source):
             for table, col in self._sqlite_text_columns(con):
                 try:
                     cur = con.execute(
-                        f"SELECT rowid, {col} FROM {table}"  # noqa: S608
+                        f"SELECT rowid, {_quote_ident(col)} FROM {_quote_ident(table)}"  # nosec B608 # table/col are SQL-escaped via _quote_ident(), not raw interpolation; bandit can't see through the helper
                     )
                 except sqlite3.OperationalError:
                     continue

--- a/src/agentsweep/tips.py
+++ b/src/agentsweep/tips.py
@@ -25,7 +25,7 @@ TIPS: list[str] = [
 
 def random_tip() -> str:
     """Return a randomly selected tip string (no 'Tip:' prefix)."""
-    return random.choice(TIPS)
+    return random.choice(TIPS)  # nosec B311 # cosmetic tip selection, not security-sensitive
 
 
 def tip_for(n: int) -> str:

--- a/src/agentsweep/ui/banner.py
+++ b/src/agentsweep/ui/banner.py
@@ -204,7 +204,7 @@ def _animate_banner(lines: list[str], styles: list[str], tagline: str) -> None:
     width = max(len(line) for line in lines)
     bar = "█" if _encodes(console, "█") else "#"
     pool = _noise_pool()
-    rng = random.Random()
+    rng = random.Random()  # nosec B311 # visual noise timing for a cinematic banner, not security-sensitive
     with Live(console=console, auto_refresh=False, transient=False) as live:
         def frame(renderable: Group, hold: float) -> None:
             live.update(renderable, refresh=True)

--- a/src/agentsweep/ui/shutdown.py
+++ b/src/agentsweep/ui/shutdown.py
@@ -16,7 +16,7 @@ from .console import _icons, _safe, err_console
 def _animate_shutdown(message: str) -> None:
     """~0.4s farewell: the message locks in left-to-right out of red noise."""
     pool = _noise_pool()
-    rng = random.Random()
+    rng = random.Random()  # nosec B311 # visual noise timing for a farewell animation, not security-sensitive
     ic = _icons(err_console)
     with Live(console=err_console, auto_refresh=False, transient=True) as live:
         steps = 14


### PR DESCRIPTION
<!--
Thanks for contributing to agentsweep! Fill in the sections below.
Keep PRs focused — one concern per PR (a CI fix and a feature should be
two PRs). See CLAUDE.md for the project's conventions.
-->

## What & why

Add a bandit SAST job to CI (bandit was already a dev dep but never wired up). Triaged all 22 existing findings: 8 real fixes (new `_quote_ident()` helper in `sources/_helpers.py` properly escapes SQL table/column identifiers, applied everywhere one is interpolated into a query) and 14 `# nosec`-annotated with reasons (cosmetic randomness, best-effort try/except, hardcoded-URL urlopen, argcomplete's `shell=` kwarg, ps/tasklist process listing). Also documents the SAST gate in CONTRIBUTING.md/README.md and adds a `[tool.bandit]` exclude for tests/.

Closes #82

## Type of change

- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [ ] Feature / enhancement
- [x] Refactor / docs / chore

## Testing

<!-- How did you verify this? Paste the relevant `pytest` summary. -->

$ pytest -q
552 passed, 12 skipped in 5.54s

$ bandit -r src/
No issues identified.
Total issues (by severity): Medium: 0, High: 0
Total potential issues skipped due to specifically being disabled (#nosec): 22

$ ruff check src/
All checks passed!

$ mypy src/agentsweep
Success: no issues found in 28 source files


## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13)
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [x] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail)
- [ ] **New detection rule?** Added to `RULES` **and** `ROTATION_GUIDANCE` **and** a fixture/test, with every regex quantifier bounded (no unbounded `.*`), and the keyword pre-filter kept lossless
- [ ] **New source?** Registered in `SOURCES` with process markers, a menu entry, and a round-trip test (see CLAUDE.md → "Adding a new Source")
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths)
- [x] Did not re-introduce `force-include` in `pyproject.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated security scanning to continuous integration.
  * Improved protection for database queries involving dynamic identifiers.
  * Documented local security checks and guidance for handling accepted findings.
* **Documentation**
  * Updated contribution security guidance, including approval requirements for workflows from first-time contributors.
* **Maintenance**
  * Clarified security-scan exceptions for safe, intentional behaviors without changing application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

