### PR TITLE
feat: add blast-radius report

### DIFF
--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -294,6 +294,11 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
         help="Emit findings as JSON to stdout (no banner/styling).",
     )
     ap.add_argument(
+        "--report",
+        action="store_true",
+        help="Include blast-radius report in JSON output (implies --json).",
+    )
+    ap.add_argument(
         "--no-color",
         action="store_true",
         help="Disable ANSI colors/styling in human output "
@@ -333,6 +338,14 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
             ap.error("cannot use --json with --format sarif; pick one output format")
         if args.fix:
             ap.error("--format is a scan output format; not valid with fix")
+
+    if getattr(args, "report", False):
+        if args.fix:
+            ap.error("--report is a scan output option; not valid with fix")
+        if args.format is not None:
+            ap.error("cannot use --report with --format sarif; blast-radius is JSON-only")
+        # Contract: --report always emits machine JSON (with blast_radius).
+        args.json = True
 
     if args.all:
         if args.source is not None:
@@ -439,6 +452,11 @@ def _get_completion_parser() -> argparse.ArgumentParser:
     )
     scan_p.add_argument(
         "--json", action="store_true", help="Emit findings as JSON to stdout."
+    )
+    scan_p.add_argument(
+        "--report",
+        action="store_true",
+        help="Include blast-radius report in JSON output (implies --json).",
     )
     scan_p.add_argument(
         "--no-color",

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -113,7 +113,13 @@ def run(args, *, _findings_out: list | None = None,
         if as_sarif:
             return _emit_sarif(_json_payload(found_by_file, source),
                                output, suppressed)
-        return _output_json(found_by_file, source, output, suppressed)
+        return _output_json(
+            found_by_file,
+            source,
+            output,
+            suppressed,
+            report=getattr(args, "report", False),
+        )
 
     ui.stage(1, "ok", "DISCOVER", source.name, f"{len(files)} file(s)", source.root)
 
@@ -297,6 +303,7 @@ def run_all(args) -> int:
     output: Path | None = _opt(args, "output")
     as_sarif = _opt(args, "format") == "sarif"
     as_json = bool(_opt(args, "json", False)) or as_sarif
+    report = getattr(args, "report", False)
     detected_only = bool(_opt(args, "detected", False))
     no_ignore = bool(_opt(args, "no_ignore", False))
 
@@ -544,8 +551,11 @@ def run_all(args) -> int:
 
     if as_json:
         payload: list[dict] = []
+        blast_radius: list[dict] = []
         for _key, source, _files, found_by_file, _sc, _sup, _tr in per_source:
             payload.extend(_json_payload(found_by_file, source))
+            if report:
+                blast_radius.extend(_blast_radius_payload(found_by_file))
         # Match single-source run(): scan-budget cap is reported, never silent.
         if total_truncated:
             print(
@@ -557,7 +567,18 @@ def run_all(args) -> int:
                                      as_json=True)
         if as_sarif:
             return _emit_sarif(payload, output, total_suppressed)
+        if report:
+            return _emit_json_payload(
+                {
+                    "findings": payload,
+                    "blast_radius": blast_radius,
+                },
+                output,
+                total_suppressed,
+            )
         return _emit_json_payload(payload, output, total_suppressed)
+    
+   
 
     ui.stage(2, "ok", "SCAN", f"{total_files} file(s)",
              f"{total_strings} string(s)", f"{elapsed:.1f}s")
@@ -893,6 +914,29 @@ def _rotation_items_multi(
         for rule in rules
     ]
 
+def _group_findings(found_by_file: dict) -> dict:
+    """Group findings by masked secret for blast-radius reporting."""
+
+    groups = {}
+
+    for path, items in found_by_file.items():
+        for line_num, _kp, _val, finding in items:
+            key = finding.masked
+
+            if key not in groups:
+                groups[key] = {
+                    "rule": finding.rule,
+                    "display": finding.display,
+                    "masked": finding.masked,
+                    "locations": [],
+                }
+
+            groups[key]["locations"].append({
+                "file": str(path),
+                "line": line_num,
+            })
+
+    return groups
 
 def _json_payload(found_by_file: dict, source: Source) -> list[dict]:
     payload = []
@@ -918,6 +962,22 @@ SARIF_SCHEMA = (
 )
 SARIF_VERSION = "2.1.0"
 _PROJECT_URL = "https://github.com/Ishannaik/agent-sweep"
+
+def _blast_radius_payload(found_by_file: dict) -> list[dict]:
+    groups = _group_findings(found_by_file)
+    report = []
+
+    for group in groups.values():
+        report.append({
+            "provider": group["display"],
+            "rule": group["rule"],
+            "masked": group["masked"],
+            "occurrences": len(group["locations"]),
+            "locations": group["locations"],
+            "rotation": ROTATION_GUIDANCE.get(group["rule"]),
+        })
+
+    return report
 
 
 def _sarif_document(payload: list[dict]) -> dict:
@@ -1004,38 +1064,63 @@ def _emit_sarif(payload: list[dict], output: Path | None,
     return code
 
 
-def _emit_json_payload(payload: list[dict], output: Path | None,
+def _emit_json_payload(payload, output: Path | None,
                        suppressed: int) -> int:
     """Shared JSON emission for single- and multi-source scans."""
-    code = 0 if not payload else 1
+
+    findings = payload["findings"] if isinstance(payload, dict) else payload
+    count = len(findings)
+    code = 0 if count == 0 else 1
 
     if output is not None:
         _write_text(output, json.dumps(payload, indent=2) + "\n")
-        print(f"{len(payload)} finding(s) written to {output}", file=sys.stderr)
+        print(f"{count} finding(s) written to {output}", file=sys.stderr)
         return code
 
-    flood = (len(payload) > JSON_FLOOD_LIMIT
-             and getattr(sys.stdout, "isatty", lambda: False)())
+    flood = (
+        count > JSON_FLOOD_LIMIT
+        and getattr(sys.stdout, "isatty", lambda: False)()
+    )
+
     if flood:
         target = Path.cwd() / DEFAULT_JSON_NAME
         _write_text(target, json.dumps(payload, indent=2) + "\n")
-        print(f"{len(payload)} findings — too many to print; written to "
-              f"{target}\n  view with:  cat {DEFAULT_JSON_NAME} | "
-              f"python -m json.tool   (or open it)", file=sys.stderr)
+        print(
+            f"{count} findings — too many to print; written to {target}\n"
+            f"  view with: cat {DEFAULT_JSON_NAME} | python -m json.tool",
+            file=sys.stderr,
+        )
         return code
 
     print(json.dumps(payload, indent=2))
+
     if suppressed:
         print(f"({suppressed} suppressed by .agentsweepignore)", file=sys.stderr)
+
     return code
 
+def _output_json(
+    found_by_file: dict,
+    source: Source,
+    output: Path | None,
+    suppressed: int,
+    report: bool = False,
+) -> int:
+    """Emit JSON output, optionally including a blast-radius report."""
 
-def _output_json(found_by_file: dict, source: Source, output: Path | None,
-                 suppressed: int) -> int:
-    """Emit JSON. With -o (or a flood-risk tty) write to a file and keep
-    stdout/scrollback clean; otherwise print to stdout for piping."""
-    return _emit_json_payload(_json_payload(found_by_file, source),
-                              output, suppressed)
+    findings = _json_payload(found_by_file, source)
+
+    if report:
+        return _emit_json_payload(
+            {
+                "findings": findings,
+                "blast_radius": _blast_radius_payload(found_by_file),
+            },
+            output,
+            suppressed,
+        )
+
+    return _emit_json_payload(findings, output, suppressed)
 
 
 def _show_findings(found_by_file: dict, source: Source,

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -324,6 +324,69 @@ def test_json_output_file_fingerprint_format(tmp_path, capsys):
 
 
 # ------------------------------------------------------------------ edge cases
+def test_group_findings_groups_same_masked_secret():
+    found_by_file = {
+      "a.json": [
+    (10, None, None, type("F", (), {
+        "rule": "openai",
+        "display": "OpenAI",
+        "masked": "sk-****1234",
+    })()),
+    (15, None, None, type("F", (), {
+        "rule": "openai",
+        "display": "OpenAI",
+        "masked": "sk-****1234",
+    })()),
+],
+        "b.json": [
+            (20, None, None, type("F", (), {
+                "rule": "openai",
+                "display": "OpenAI",
+                "masked": "sk-****1234",
+            })())
+        ],
+    }
+
+    groups = pipeline._group_findings(found_by_file)
+
+    assert len(groups) == 1
+
+    group = groups["sk-****1234"]
+
+    assert group["rule"] == "openai"
+    assert len(group["locations"]) == 3
+
+def test_blast_radius_payload_never_contains_plaintext_secret():
+    raw_secret = "sk-live-super-secret-value"
+
+    finding = type(
+        "F",
+        (),
+        {
+            "rule": "openai",
+            "display": "OpenAI",
+            "masked": "sk-****1234",
+        },
+    )()
+
+    found_by_file = {
+        "a.json": [
+            (10, None, raw_secret, finding),
+            (15, None, raw_secret, finding),
+        ],
+        "b.json": [
+            (20, None, raw_secret, finding),
+        ],
+    }
+
+    report = pipeline._blast_radius_payload(found_by_file)
+    blob = json.dumps(report)
+
+    assert raw_secret not in blob
+    assert "sk-****1234" in blob
+    assert report[0]["occurrences"] == 3
+
+
 
 def test_output_file_parent_does_not_exist_does_not_crash(tmp_path, capsys):
     """If -o points to a non-existent parent dir, _write_text logs to stderr
@@ -374,3 +437,67 @@ def test_scan_verb_json_output_exit_code(tmp_path, capsys):
     clean.mkdir()
     (clean / "s.jsonl").write_text('{"msg":"nothing"}\n', encoding="utf-8")
     assert main(["scan", "--root", str(clean), "--json"]) == 0
+
+
+def test_report_implies_json_and_includes_blast_radius(tmp_path, capsys):
+    """scan --report (no --json) still emits JSON with blast_radius."""
+    root = tmp_path / "hist"
+    root.mkdir()
+    # Use a clean tree so exit code is 0; shape still includes blast_radius.
+    (root / "s.jsonl").write_text('{"msg":"nothing secret here"}\n', encoding="utf-8")
+    code = main(["scan", "--root", str(root), "--report"])
+    assert code == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert isinstance(data, dict)
+    assert "findings" in data
+    assert "blast_radius" in data
+    assert data["blast_radius"] == []
+
+
+def test_report_with_findings_groups_masked(tmp_path, capsys):
+    """blast_radius groups by masked value when --report is set."""
+    # Two files, same AWS key → one blast-radius group with occurrences >= 2.
+    root = tmp_path / "hist"
+    root.mkdir()
+    line = (
+        '{"type":"user","message":{"content":[{"type":"text",'
+        f'"text":"key={AWS_KEY}"}}]}}}}\n'
+    )
+    (root / "a.jsonl").write_text(line, encoding="utf-8")
+    (root / "b.jsonl").write_text(line, encoding="utf-8")
+    code = main(["scan", "--root", str(root), "--report"])
+    assert code == 1
+    data = json.loads(capsys.readouterr().out)
+    assert "blast_radius" in data
+    blob = json.dumps(data)
+    assert AWS_KEY not in blob
+    assert data["blast_radius"], "expected at least one blast-radius group"
+    assert data["blast_radius"][0]["occurrences"] >= 2
+
+
+def test_report_rejects_sarif(tmp_path):
+    root = tmp_path / "hist"
+    root.mkdir()
+    (root / "s.jsonl").write_text('{"msg":"x"}\n', encoding="utf-8")
+    try:
+        main(["scan", "--root", str(root), "--report", "--format", "sarif"])
+        raised = False
+    except SystemExit as e:
+        raised = True
+        assert e.code == 2
+    assert raised, "expected argparse error exit 2"
+
+
+def test_report_rejects_fix(tmp_path):
+    root = tmp_path / "hist"
+    root.mkdir()
+    (root / "s.jsonl").write_text('{"msg":"x"}\n', encoding="utf-8")
+    try:
+        main(["fix", "--root", str(root), "--report", "--force", "--allow-production", "--no-backup"])
+        raised = False
+    except SystemExit as e:
+        raised = True
+        assert e.code == 2
+    assert raised
+

--- a/tests/test_sarif_output.py
+++ b/tests/test_sarif_output.py
@@ -152,6 +152,7 @@ def test_secret_plaintext_never_appears(tmp_path, capsys):
     assert "AKIAIO" in blob  # the masked preview is still there
 
 
+
 def test_exit_code_matches_json_path(tmp_path, capsys):
     assert _scan_sarif(_seed(tmp_path, AWS_KEY), capsys)["_exit"] == 1
 


### PR DESCRIPTION
## Summary

Implements an initial blast-radius report for scan results.

Closes #77.

## What & why

This PR introduces an initial implementation of the blast-radius report discussed in #77.

### Added

- Groups findings by the existing masked representation
- Reports occurrence count and locations for each grouped secret
- Reuses `ROTATION_GUIDANCE` for provider-specific rotation guidance
- Adds a machine-readable blast-radius report
- Follows the single-source-first approach discussed in the issue

I'd appreciate feedback on whether you'd prefer the report to remain behind `--report` or be folded into the existing `--json` output.

## Type of change

- [x] Feature / enhancement

## Testing

```text
523 passed, 10 skipped
```

## Checklist

- [x] `pytest` passes locally
- [x] No real secrets or tokens are committed
- [x] `--json` output remains machine-readable
- [ ] Cross-agent (`--all`) follow-up
- [ ] Additional blast-radius tests (grouping / no-plaintext invariant) if preferred during review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `--report` flag for scan runs that enhances machine JSON output with a `blast_radius` section, grouped by masked secret.
  * Ensures plaintext secrets are never included in the `blast_radius` payload, while blast-radius data is still emitted (empty when no findings).
* **Bug Fixes**
  * N/A
* **Tests**
  * Expanded output and CLI validation coverage for `--report`, including rejections when combined with `fix` or `--format sarif`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `--report` flag that augments JSON output with a `blast_radius` section, grouping findings by their masked representation and attaching occurrence counts, file/line locations, and rotation guidance per group.

- Adds `_group_findings` and `_blast_radius_payload` helpers; threads the `report` flag through `run()` and `run_all()`; makes `_emit_json_payload` accept both a plain list and a `{"findings":…,"blast_radius":…}` dict.
- The empty-scan code paths (`_print_empty_machine_output` and the `run_all` early-exit) still emit `[]` when no files are found, even when `--report` is active — producing a format mismatch that breaks machine consumers expecting the dict shape.
- CLI validation correctly rejects `--report` with `--fix` or `--format sarif`, and tests cover grouping, plaintext invariant, and argument rejection.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the empty-scan output mismatch; all other paths are correct and well-tested.

The `_print_empty_machine_output` closure and the `run_all` early-exit both hardcode `[]` regardless of the `--report` flag. A machine consumer running against a missing or empty directory receives a bare JSON array while the same consumer against a populated directory receives the dict form, breaking any code that dereferences `data["findings"]` or `data["blast_radius"]`. This is a present defect on the changed path that should be resolved before merging.

src/agentsweep/pipeline.py — the empty-scan early-exit branches in both `run()` and `run_all()`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentsweep/pipeline.py | Adds blast-radius grouping (_group_findings, _blast_radius_payload) and threads a `report` flag through run()/run_all(); _emit_json_payload is made polymorphic to accept dict or list. The empty-scan code paths (_print_empty_machine_output, run_all early-exit) still emit `[]` regardless of `--report`, producing a format mismatch for machine consumers. |
| src/agentsweep/cli.py | Adds --report argument to _parse_run and the completion parser; validates mutual exclusion with --fix and --format sarif, and sets args.json=True when --report is present. Logic is correct. |
| tests/test_output.py | Adds unit tests for _group_findings, _blast_radius_payload plaintext invariant, and integration tests for --report including rejection of --format sarif and --fix. Does not cover the empty-file-set edge case where --report emits []. |
| tests/test_sarif_output.py | Minor: adds a blank line between two existing tests. No functional change. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as cli._parse_run
    participant Run as pipeline.run / run_all
    participant Scan as _scan
    participant Group as _group_findings
    participant Blast as _blast_radius_payload
    participant Emit as _emit_json_payload

    CLI->>CLI: parse --report flag
    CLI->>CLI: "if report: args.json = True"
    CLI->>Run: "args (json=True, report=True)"

    Run->>Scan: _scan(source, files, ignores)
    Scan-->>Run: found_by_file

    alt "report=True"
        Run->>Blast: _blast_radius_payload(found_by_file)
        Blast->>Group: _group_findings(found_by_file)
        Group-->>Blast: groups keyed by finding.masked
        Blast-->>Run: blast_radius list
        Run->>Emit: "{findings: [...], blast_radius: [...]}"
    else "report=False"
        Run->>Emit: findings list (plain list)
    end

    Emit-->>Run: exit code
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat: add blast-radius report via --repo..."](https://github.com/ishannaik/agent-sweep/commit/cc9665bb7116c776ab44a8a5a8b08aef04e4fc62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45974046)</sub>

<!-- /greptile_comment -->