### PR TITLE
test: add curl auth regex backtracking coverage

### DIFF
--- a/tests/test_scan_performance.py
+++ b/tests/test_scan_performance.py
@@ -43,9 +43,12 @@ def test_no_catastrophic_scan_time(name):
 @pytest.mark.parametrize("name", list(CURL_AUTH_BOMBS))
 def test_curl_auth_rules_resist_adversarial_backtracking(name):
     t0 = time.perf_counter()
-    scan_text(CURL_AUTH_BOMBS[name])
+    findings = scan_text(CURL_AUTH_BOMBS[name])
     elapsed = time.perf_counter() - t0
 
+    assert not any(f.rule == name for f in findings), (
+        f"{name} produced a false-positive finding"
+    )
     assert elapsed < 1.0, f"{name} adversarial scan too slow: {elapsed:.3f}s"
 
 

--- a/tests/test_scan_performance.py
+++ b/tests/test_scan_performance.py
@@ -1,4 +1,5 @@
 """Pre-filter correctness + catastrophic-input timing for the full rule set."""
+
 from __future__ import annotations
 
 import sys
@@ -9,7 +10,6 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-from agentsweep import scanner  # noqa: E402
 from agentsweep.scanner import _PREFILTER, scan_text  # noqa: E402
 
 
@@ -22,12 +22,31 @@ BOMBS = {
     "hex-blob": "deadbeef" * 8000,
 }
 
+CURL_AUTH_BOMBS = {
+    "curl-auth-header": (
+        "curl " * 5000
+        + ("x" * 200 + ' --headeX "Authorization: Bearer abcdefgh" ') * 100
+    ),
+    "curl-auth-user": (
+        "curl " * 5000 + ("x" * 200 + " --useX username:password ") * 100
+    ),
+}
+
 
 @pytest.mark.parametrize("name", list(BOMBS))
 def test_no_catastrophic_scan_time(name):
     t0 = time.perf_counter()
     scan_text(BOMBS[name])
     assert time.perf_counter() - t0 < 1.0, f"{name} scan too slow"
+
+
+@pytest.mark.parametrize("name", list(CURL_AUTH_BOMBS))
+def test_curl_auth_rules_resist_adversarial_backtracking(name):
+    t0 = time.perf_counter()
+    scan_text(CURL_AUTH_BOMBS[name])
+    elapsed = time.perf_counter() - t0
+
+    assert elapsed < 1.0, f"{name} adversarial scan too slow: {elapsed:.3f}s"
 
 
 def test_full_scan_of_all_bombs_is_fast():
@@ -52,8 +71,9 @@ def test_prefilter_literals_are_truly_present_in_fixtures():
         if fixture is None:
             continue
         low = fixture.lower()
-        assert any(k in low for k in kws), \
+        assert any(k in low for k in kws), (
             f"{rule_id}: fixture lacks any prefilter literal {kws}"
+        )
 
 
 def test_prefilter_covers_anchored_and_context_rules():
@@ -65,7 +85,11 @@ def test_prefilter_covers_anchored_and_context_rules():
     assert _PREFILTER.get("gitlab-pat") == ("glpat-",)
     # Context rules keep their any-of provider keywords.
     assert set(_PREFILTER["jfrog-api-key"]) == {
-        "jfrog", "artifactory", "bintray", "xray"}
+        "jfrog",
+        "artifactory",
+        "bintray",
+        "xray",
+    }
     # Most of the 189 rules now have an anchor; the few without one (short or
     # non-literal leads) simply always run — still correct.
     assert len(_PREFILTER) > 150
@@ -101,6 +125,7 @@ def test_prefilter_backend_is_lossless_vs_running_all_rules():
 
 def test_prefilter_backend_named():
     from agentsweep.scanner import PREFILTER_BACKEND
+
     assert PREFILTER_BACKEND in ("aho-corasick", "substring")
 
 
@@ -108,9 +133,9 @@ def test_prefilter_does_not_change_findings():
     """Gating must be lossless: a string containing a context keyword still
     runs the rule exactly as before."""
     # snyk rule fires with the keyword present...
-    hit = ("snyk_token = "
-           "12345678-1234-1234-1234-123456789abc")
+    hit = "snyk_token = 12345678-1234-1234-1234-123456789abc"
     assert any(f.rule == "snyk" for f in scan_text(hit))
     # ...and a uuid with no provider keyword nearby does not.
-    assert not any(f.rule == "snyk"
-                   for f in scan_text("12345678-1234-1234-1234-123456789abc"))
+    assert not any(
+        f.rule == "snyk" for f in scan_text("12345678-1234-1234-1234-123456789abc")
+    )


### PR DESCRIPTION
Closes #141

## Summary

* add adversarial near-miss inputs for `curl-auth-header` and `curl-auth-user`
* verify both scans complete within the existing 1-second performance threshold
* confirm the inputs trigger the curl-prefiltered rules without producing false-positive findings

## Testing

* `python -m pytest -v` — 564 passed, 10 skipped
* `python -m ruff check tests/test_scan_performance.py`
* `python -m ruff format --check tests/test_scan_performance.py`
* `git diff --check`

## Notes

Repository-wide Ruff checks currently report unrelated pre-existing issues in other files, so lint and formatting validation were run against the modified test file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added performance coverage with an adversarial “curl auth” fixture set to stress rule matching against backtracking-heavy inputs.
  * Introduced a parametrized timing test that verifies each generated case completes scanning in under one second.
  * Ensured no false positives are reported for the corresponding rule name and preserved existing guarantees that prefiltering does not change detected findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->