### PR TITLE
tests: add .agentsweepignore edge-case coverage

### DIFF
--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -546,3 +546,163 @@ class TestVerbDispatch:
         out = capsys.readouterr().out
         assert code == 0
         assert json.loads(out) == []
+# ===========================================================================
+# Issue #134: edge-case coverage for add_line ambiguity, comments/blanks,
+# and root+cwd merge behavior with overlapping/conflicting entries.
+# ===========================================================================
+
+class TestAmbiguousLiteralLooksLikeFingerprint:
+    """A literal value shaped like <text>:<digits>:<text> is currently
+    parsed as a fingerprint, not a literal — because add_line only checks
+    that the middle segment is numeric, not that the last segment is a
+    known rule id. These tests document/lock in that current behavior.
+    """
+
+    def test_ambiguous_literal_is_classified_as_fingerprint(self):
+        ig = IgnoreSet()
+        ig.add_line("foo:123:bar")
+        assert "foo:123:bar" in ig.fingerprints
+        assert "foo:123:bar" not in ig.values
+
+    def test_ambiguous_literal_does_not_suppress_by_value(self):
+        # If a real secret's value happens to literally read "foo:123:bar",
+        # writing it verbatim into .agentsweepignore will NOT suppress a
+        # finding via value-matching, because it landed in `fingerprints`
+        # instead of `values`.
+        ig = IgnoreSet()
+        ig.add_line("foo:123:bar")
+        assert not ig.matches("some-rule", "foo:123:bar", "unrelated.jsonl:1:some-rule")
+
+    def test_ambiguous_literal_suppresses_only_as_a_literal_fingerprint_match(self):
+        # It DOES suppress a finding whose own fingerprint happens to equal
+        # "foo:123:bar" (path=foo, line=123, rule=bar) — even though "bar"
+        # is never validated against known rule ids.
+        ig = IgnoreSet()
+        ig.add_line("foo:123:bar")
+        assert ig.matches("bar", "irrelevant-secret-value", "foo:123:bar")
+
+    def test_non_digit_middle_segment_is_treated_as_literal_value(self):
+        # Contrast case: when the middle segment isn't numeric, it is NOT
+        # mistaken for a fingerprint and correctly falls through to values.
+        ig = IgnoreSet()
+        ig.add_line("foo:abc:bar")
+        assert "foo:abc:bar" in ig.values
+        assert "foo:abc:bar" not in ig.fingerprints
+
+
+class TestCommentAndBlankLineEdgeCases:
+    """Additional edge cases for comment/blank-line handling in add_line."""
+
+    def test_line_with_only_hash_is_a_comment(self):
+        ig = IgnoreSet()
+        ig.add_line("#")
+        assert not ig
+
+    def test_tab_only_line_is_treated_as_blank(self):
+        ig = IgnoreSet()
+        ig.add_line("\t\t")
+        assert not ig
+
+    def test_hash_not_at_start_is_not_a_comment(self):
+        # Only a line whose *stripped* form starts with '#' is skipped —
+        # a literal value that merely contains '#' partway through is not.
+        ig = IgnoreSet()
+        ig.add_line("some#value")
+        assert "some#value" in ig.values
+
+    def test_rule_line_has_no_inline_comment_support(self):
+        # Everything after 'rule:' up to end of line becomes the rule id,
+        # comment-and-all — there's no '#' stripping mid-line.
+        ig = IgnoreSet()
+        ig.add_line("rule:aws-access-key # trailing note")
+        assert "aws-access-key # trailing note" in ig.rules
+
+    def test_load_skips_interspersed_comments_and_blanks(self, tmp_path):
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / IGNORE_FILENAME).write_text(
+            "# header comment\n"
+            "rule:aws-access-key\n"
+            "\n"
+            "   \n"
+            "# mid comment\n"
+            "rule:github-pat\n",
+            encoding="utf-8",
+        )
+        ig = load([root])
+        assert ig.rules == {"aws-access-key", "github-pat"}
+
+
+class TestMergeConflictingEntries:
+    """Merging root + cwd .agentsweepignore when entries overlap or
+    ostensibly conflict. Since IgnoreSet stores rules/fingerprints/values
+    as sets, "conflicting" entries simply union — there is no precedence
+    or override semantics between root and cwd.
+    """
+
+    def test_same_rule_in_both_files_dedupes_naturally(self, tmp_path):
+        root = tmp_path / "root"
+        cwd = tmp_path / "cwd"
+        root.mkdir()
+        cwd.mkdir()
+        (root / IGNORE_FILENAME).write_text("rule:aws-access-key\n", encoding="utf-8")
+        (cwd / IGNORE_FILENAME).write_text("rule:aws-access-key\n", encoding="utf-8")
+
+        ig = load([root, cwd])
+        assert ig.rules == {"aws-access-key"}
+        assert len(ig.sources) == 2  # both files still counted as sources
+
+    def test_root_rule_and_cwd_fingerprint_for_same_rule_both_apply(self, tmp_path):
+        # root broadly suppresses a whole rule; cwd narrowly suppresses one
+        # fingerprint of that same rule. Both merge in — the narrower entry
+        # is redundant but harmless, not a conflict.
+        root = tmp_path / "root"
+        cwd = tmp_path / "cwd"
+        root.mkdir()
+        cwd.mkdir()
+        (root / IGNORE_FILENAME).write_text("rule:aws-access-key\n", encoding="utf-8")
+        (cwd / IGNORE_FILENAME).write_text(
+            "session.jsonl:1:aws-access-key\n", encoding="utf-8"
+        )
+
+        ig = load([root, cwd])
+        assert "aws-access-key" in ig.rules
+        assert "session.jsonl:1:aws-access-key" in ig.fingerprints
+        assert ig.matches("aws-access-key", "anything", "other.jsonl:9:aws-access-key")
+
+    def test_root_and_cwd_disagree_on_literal_value_both_suppressed(self, tmp_path):
+        # root ignores one literal secret value, cwd ignores a different one
+        # for the same rule — both end up suppressed since merging unions
+        # rather than replaces.
+        root = tmp_path / "root"
+        cwd = tmp_path / "cwd"
+        root.mkdir()
+        cwd.mkdir()
+        (root / IGNORE_FILENAME).write_text(f"{AWS_KEY}\n", encoding="utf-8")
+        other_key = "AKIAOTHER12345678901"
+        (cwd / IGNORE_FILENAME).write_text(f"{other_key}\n", encoding="utf-8")
+
+        ig = load([root, cwd])
+        assert AWS_KEY in ig.values
+        assert other_key in ig.values
+
+    def test_end_to_end_root_and_cwd_conflicting_entries_merge(
+            self, tmp_path, monkeypatch, capsys):
+        """End-to-end: root ignores by rule, cwd ignores the same finding
+        again by fingerprint. Result should still just suppress it once,
+        not double-count or error."""
+        root = _mkroot(tmp_path, _AWS_ONLY_LINE)
+        cwd = tmp_path / "workdir"
+        cwd.mkdir()
+
+        code0, payload0, _ = _scan_json(root, capsys=capsys)
+        assert code0 == 1
+        aws_fp = payload0[0]["fingerprint"]
+
+        (root / IGNORE_FILENAME).write_text("rule:aws-access-key\n", encoding="utf-8")
+        (cwd / IGNORE_FILENAME).write_text(aws_fp + "\n", encoding="utf-8")
+
+        monkeypatch.chdir(cwd)
+        code, payload, err = _scan_json(root, capsys=capsys)
+        assert code == 0
+        assert payload == []


### PR DESCRIPTION
## What & why
Adds test coverage for issue #134's `.agentsweepignore` edge cases in `IgnoreSet.add_line` and `load()`: the parsing ambiguity for literal values shaped like `<text>:<digits>:<text>`, comment/blank-line edge cases, and merge behavior across scan-root and cwd `.agentsweepignore` files with overlapping/conflicting entries.

Closes #134

- Document current `add_line` behavior for a literal value shaped like `<text>:<digits>:<text>` — it's classified as a fingerprint (not a literal) since `add_line` only checks that the middle segment is numeric, without validating the last segment against known rule ids.
- Additional comment/blank-line edge cases: hash-only lines, tab-only blanks, mid-line `#` not treated as a comment, no inline-comment support on `rule:` lines.
- Merge behavior for root + cwd `.agentsweepignore` with overlapping and conflicting entries: same rule in both files dedupes via set union, a broad `rule:` in one file and a narrow fingerprint in the other both apply, differing literal values are both retained, and an end-to-end scan confirms overlapping suppression doesn't double count or error.

## Type of change
- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [ ] Feature / enhancement
- [x] Refactor / docs / chore

## Testing
Ran the full `test_ignore.py` suite locally, all passing (60 tests, including the 13 new ones added here):
============================================================================================== 60 passed in 0.63s ==============================================================================================

## Checklist
- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13)
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [ ] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail) — N/A, no redaction/write-path code touched
- [ ] **New detection rule?** — N/A, no new rule added
- [ ] **New source?** — N/A, no new source added
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths) — N/A, no CLI/output code touched; existing `_scan_json` tests confirm output stays clean
- [x] Did not re-introduce `force-include` in `pyproject.toml` — true, `pyproject.toml` untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for `.agentsweepignore` handling.
  * Verified correct classification and exact matching of fingerprint entries.
  * Added edge-case coverage for comments, blank lines, and rule parsing.
  * Confirmed ignore entries merge correctly across scan root and current directory without duplicate suppressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds 13 new unit and integration tests for `.agentsweepignore` edge cases introduced in issue #134, covering `IgnoreSet.add_line` parsing ambiguity, comment/blank-line handling, and root+cwd merge behavior — all in `tests/test_ignore.py` with no production code changes.

- **Ambiguity documentation** (`TestAmbiguousLiteralLooksLikeFingerprint`): Locks in the current behavior where a value shaped like `<text>:<digits>:<text>` is silently classified as a fingerprint rather than a literal.
- **Comment/blank-line edge cases** (`TestCommentAndBlankLineEdgeCases`): Covers hash-only lines, tab-only blanks, mid-line `#` not treated as a comment, and the absence of inline-comment stripping on `rule:` lines.
- **Merge behavior** (`TestMergeConflictingEntries`): Verifies that same-rule deduplication, overlapping rule+fingerprint entries, and differing literal values all union correctly across root and cwd ignore files.
</details>

<h3>Confidence Score: 4/5</h3>

Test-only change with no production code modifications; all new assertions accurately reflect the existing implementation.

The new tests are logically sound and align with the actual IgnoreSet implementation. Minor gaps: missing blank lines, an underdocumented silent no-op behavior on rule lines with trailing comments, and one end-to-end test whose docstring claims no double-counting but omits the assertion to enforce it.

tests/test_ignore.py — the test_end_to_end_root_and_cwd_conflicting_entries_merge test and the inline-comment behavior test both deserve a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/test_ignore.py | Adds 13 new tests across three classes covering add_line parsing ambiguity, comment/blank-line edge cases, and root+cwd merge behavior; test logic is accurate against the implementation, with one test that understates its coverage of the no-double-count guarantee and a missing blank line before the new section. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["add_line(raw)"] --> B["strip()"]
    B --> C{empty or starts with '#'?}
    C -->|yes| D["skip (comment/blank)"]
    C -->|no| E{starts with 'rule:'?}
    E -->|yes| F["rules.add(id)"]
    E -->|no| G["rsplit(':', 2)"]
    G --> H{3 parts AND middle is digit?}
    H -->|yes| I["fingerprints.add(line)"]
    H -->|no| J["values.add(line)"]

    subgraph "Ambiguity zone (Issue #134)"
      K["'foo:123:bar' to fingerprints (even if 'bar' is not a rule id)"]
      L["'rule:aws-key # comment' to rules (whole string, never matches)"]
    end

    I -.-> K
    F -.-> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["add_line(raw)"] --> B["strip()"]
    B --> C{empty or starts with '#'?}
    C -->|yes| D["skip (comment/blank)"]
    C -->|no| E{starts with 'rule:'?}
    E -->|yes| F["rules.add(id)"]
    E -->|no| G["rsplit(':', 2)"]
    G --> H{3 parts AND middle is digit?}
    H -->|yes| I["fingerprints.add(line)"]
    H -->|no| J["values.add(line)"]

    subgraph "Ambiguity zone (Issue #134)"
      K["'foo:123:bar' to fingerprints (even if 'bar' is not a rule id)"]
      L["'rule:aws-key # comment' to rules (whole string, never matches)"]
    end

    I -.-> K
    F -.-> L
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atests%2Ftest_ignore.py%3A689-708%0A**%60test_end_to_end_root_and_cwd_conflicting_entries_merge%60%20doesn't%20verify%20the%20%22not%20double-count%22%20claim**%0A%0AThe%20docstring%20explicitly%20says%20*%22Result%20should%20still%20just%20suppress%20it%20once%2C%20not%20double-count%20or%20error%22*%2C%20but%20only%20%60code%20%3D%3D%200%60%20and%20%60payload%20%3D%3D%20%5B%5D%60%20are%20asserted.%20If%20the%20scan%20were%20ever%20to%20report%20%60%222%20suppressed%22%60%20for%20a%20single%20finding%20%28e.g.%2C%20counting%20both%20the%20rule%20match%20and%20the%20fingerprint%20match%29%2C%20this%20test%20would%20still%20pass.%20Adding%20%60assert%20%221%22%20in%20err%20and%20%22suppressed%22%20in%20err%60%20would%20actually%20enforce%20the%20stated%20contract.%0A%0A%23%23%23%20Issue%202%20of%203%0Atests%2Ftest_ignore.py%3A613-618%0A**Locking%20in%20a%20silent%20no-op%20behavior%20without%20a%20broader%20warning**%0A%0A%60test_rule_line_has_no_inline_comment_support%60%20correctly%20documents%20that%20%60rule%3Aaws-access-key%20%23%20trailing%20note%60%20stores%20the%20full%20string%20including%20the%20comment%20as%20the%20rule%20ID%2C%20so%20it%20never%20matches%20any%20real%20finding.%20A%20user%20who%20writes%20%60rule%3Aaws-access-key%20%20%23%20temp%20ignore%60%20expecting%20suppression%20will%20get%20none%20with%20no%20error.%20Consider%20adding%20a%20comment%20cross-referencing%20the%20known%20ambiguity%20so%20a%20future%20reader%20doesn't%20treat%20this%20as%20by-design.%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Ftest_ignore.py%3A548-552%0APEP%208%20requires%20two%20blank%20lines%20between%20top-level%20definitions.%20There%20are%20none%20between%20the%20closing%20line%20of%20%60TestVerbDispatch%60%20and%20the%20new%20section%20comment%2C%20which%20also%20means%20there%20is%20effectively%20only%20one%20blank%20line%20before%20%60class%20TestAmbiguousLiteralLooksLikeFingerprint%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert%20json.loads%28out%29%20%3D%3D%20%5B%5D%0A%0A%23%20%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%0A%23%20Issue%20%23134%3A%20edge-case%20coverage%20for%20add_line%20ambiguity%2C%20comments%2Fblanks%2C%0A%23%20and%20root%2Bcwd%20merge%20behavior%20with%20overlapping%2Fconflicting%20entries.%0A%23%20%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%0A%60%60%60%0A%0A&repo=ishannaik%2Fagent-sweep&pr=148&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fagent-sweep%22%20on%20the%20existing%20branch%20%22tests%2Fagentsweepignore-edge-cases%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22tests%2Fagentsweepignore-edge-cases%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atests%2Ftest_ignore.py%3A689-708%0A**%60test_end_to_end_root_and_cwd_conflicting_entries_merge%60%20doesn't%20verify%20the%20%22not%20double-count%22%20claim**%0A%0AThe%20docstring%20explicitly%20says%20*%22Result%20should%20still%20just%20suppress%20it%20once%2C%20not%20double-count%20or%20error%22*%2C%20but%20only%20%60code%20%3D%3D%200%60%20and%20%60payload%20%3D%3D%20%5B%5D%60%20are%20asserted.%20If%20the%20scan%20were%20ever%20to%20report%20%60%222%20suppressed%22%60%20for%20a%20single%20finding%20%28e.g.%2C%20counting%20both%20the%20rule%20match%20and%20the%20fingerprint%20match%29%2C%20this%20test%20would%20still%20pass.%20Adding%20%60assert%20%221%22%20in%20err%20and%20%22suppressed%22%20in%20err%60%20would%20actually%20enforce%20the%20stated%20contract.%0A%0A%23%23%23%20Issue%202%20of%203%0Atests%2Ftest_ignore.py%3A613-618%0A**Locking%20in%20a%20silent%20no-op%20behavior%20without%20a%20broader%20warning**%0A%0A%60test_rule_line_has_no_inline_comment_support%60%20correctly%20documents%20that%20%60rule%3Aaws-access-key%20%23%20trailing%20note%60%20stores%20the%20full%20string%20including%20the%20comment%20as%20the%20rule%20ID%2C%20so%20it%20never%20matches%20any%20real%20finding.%20A%20user%20who%20writes%20%60rule%3Aaws-access-key%20%20%23%20temp%20ignore%60%20expecting%20suppression%20will%20get%20none%20with%20no%20error.%20Consider%20adding%20a%20comment%20cross-referencing%20the%20known%20ambiguity%20so%20a%20future%20reader%20doesn't%20treat%20this%20as%20by-design.%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Ftest_ignore.py%3A548-552%0APEP%208%20requires%20two%20blank%20lines%20between%20top-level%20definitions.%20There%20are%20none%20between%20the%20closing%20line%20of%20%60TestVerbDispatch%60%20and%20the%20new%20section%20comment%2C%20which%20also%20means%20there%20is%20effectively%20only%20one%20blank%20line%20before%20%60class%20TestAmbiguousLiteralLooksLikeFingerprint%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert%20json.loads%28out%29%20%3D%3D%20%5B%5D%0A%0A%23%20%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%0A%23%20Issue%20%23134%3A%20edge-case%20coverage%20for%20add_line%20ambiguity%2C%20comments%2Fblanks%2C%0A%23%20and%20root%2Bcwd%20merge%20behavior%20with%20overlapping%2Fconflicting%20entries.%0A%23%20%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%0A%60%60%60%0A%0A&repo=ishannaik%2Fagent-sweep&pr=148&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atests%2Ftest_ignore.py%3A689-708%0A**%60test_end_to_end_root_and_cwd_conflicting_entries_merge%60%20doesn't%20verify%20the%20%22not%20double-count%22%20claim**%0A%0AThe%20docstring%20explicitly%20says%20*%22Result%20should%20still%20just%20suppress%20it%20once%2C%20not%20double-count%20or%20error%22*%2C%20but%20only%20%60code%20%3D%3D%200%60%20and%20%60payload%20%3D%3D%20%5B%5D%60%20are%20asserted.%20If%20the%20scan%20were%20ever%20to%20report%20%60%222%20suppressed%22%60%20for%20a%20single%20finding%20%28e.g.%2C%20counting%20both%20the%20rule%20match%20and%20the%20fingerprint%20match%29%2C%20this%20test%20would%20still%20pass.%20Adding%20%60assert%20%221%22%20in%20err%20and%20%22suppressed%22%20in%20err%60%20would%20actually%20enforce%20the%20stated%20contract.%0A%0A%23%23%23%20Issue%202%20of%203%0Atests%2Ftest_ignore.py%3A613-618%0A**Locking%20in%20a%20silent%20no-op%20behavior%20without%20a%20broader%20warning**%0A%0A%60test_rule_line_has_no_inline_comment_support%60%20correctly%20documents%20that%20%60rule%3Aaws-access-key%20%23%20trailing%20note%60%20stores%20the%20full%20string%20including%20the%20comment%20as%20the%20rule%20ID%2C%20so%20it%20never%20matches%20any%20real%20finding.%20A%20user%20who%20writes%20%60rule%3Aaws-access-key%20%20%23%20temp%20ignore%60%20expecting%20suppression%20will%20get%20none%20with%20no%20error.%20Consider%20adding%20a%20comment%20cross-referencing%20the%20known%20ambiguity%20so%20a%20future%20reader%20doesn't%20treat%20this%20as%20by-design.%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Ftest_ignore.py%3A548-552%0APEP%208%20requires%20two%20blank%20lines%20between%20top-level%20definitions.%20There%20are%20none%20between%20the%20closing%20line%20of%20%60TestVerbDispatch%60%20and%20the%20new%20section%20comment%2C%20which%20also%20means%20there%20is%20effectively%20only%20one%20blank%20line%20before%20%60class%20TestAmbiguousLiteralLooksLikeFingerprint%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20assert%20json.loads%28out%29%20%3D%3D%20%5B%5D%0A%0A%23%20%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%0A%23%20Issue%20%23134%3A%20edge-case%20coverage%20for%20add_line%20ambiguity%2C%20comments%2Fblanks%2C%0A%23%20and%20root%2Bcwd%20merge%20behavior%20with%20overlapping%2Fconflicting%20entries.%0A%23%20%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%0A%60%60%60%0A%0A&pr=148&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
tests/test_ignore.py:689-708
**`test_end_to_end_root_and_cwd_conflicting_entries_merge` doesn't verify the "not double-count" claim**

The docstring explicitly says *"Result should still just suppress it once, not double-count or error"*, but only `code == 0` and `payload == []` are asserted. If the scan were ever to report `"2 suppressed"` for a single finding (e.g., counting both the rule match and the fingerprint match), this test would still pass. Adding `assert "1" in err and "suppressed" in err` would actually enforce the stated contract.

### Issue 2 of 3
tests/test_ignore.py:613-618
**Locking in a silent no-op behavior without a broader warning**

`test_rule_line_has_no_inline_comment_support` correctly documents that `rule:aws-access-key # trailing note` stores the full string including the comment as the rule ID, so it never matches any real finding. A user who writes `rule:aws-access-key  # temp ignore` expecting suppression will get none with no error. Consider adding a comment cross-referencing the known ambiguity so a future reader doesn't treat this as by-design.

### Issue 3 of 3
tests/test_ignore.py:548-552
PEP 8 requires two blank lines between top-level definitions. There are none between the closing line of `TestVerbDispatch` and the new section comment, which also means there is effectively only one blank line before `class TestAmbiguousLiteralLooksLikeFingerprint`.

```suggestion
        assert json.loads(out) == []

# ===========================================================================
# Issue #134: edge-case coverage for add_line ambiguity, comments/blanks,
# and root+cwd merge behavior with overlapping/conflicting entries.
# ===========================================================================
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["tests: add .agentsweepignore edge-case c..."](https://github.com/ishannaik/agent-sweep/commit/f64fa5429fba3e17fe3351614a41fd24a3289591) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46021726)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->