### PR TITLE
perf: lazy-import rich and defer argcomplete on version check (#137)

### DIFF
--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -19,6 +19,7 @@ Usage shapes, all supported:
 
 Run logic lives in pipeline.py; interaction in menu.py.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -28,7 +29,7 @@ import threading
 import urllib.request
 from pathlib import Path
 
-from . import __version__, ui
+from . import __version__
 from .sources import SOURCES
 
 VERBS = {"scan", "fix", "undo", "purge"}
@@ -73,6 +74,7 @@ def _background_update_notice(args: argparse.Namespace) -> None:
     # Guard: skip in non-interactive / machine-readable contexts, or when the
     # user has explicitly opted out via env var (useful in CI / slow networks).
     import os
+
     try:
         if os.environ.get("AGENTSWEEP_NO_UPDATE"):
             return
@@ -104,11 +106,12 @@ def _background_update_notice(args: argparse.Namespace) -> None:
 
     latest = result[0]
     if latest is not None and _version_tuple(latest) > _version_tuple(__version__):
+        from . import ui
+
         # Route through the shared console so NO_COLOR / --no-color are honored
         # (a raw ANSI print would bypass apply_no_color entirely).
         ui.console.print(
-            f"  ★ agentsweep {latest} available"
-            f" — pip install --upgrade agentsweep",
+            f"  ★ agentsweep {latest} available — pip install --upgrade agentsweep",
             style="dim yellow",
         )
 
@@ -132,6 +135,8 @@ def _run_update_check() -> int:
 def _interactive() -> bool:
     """True when a human is at both ends (stdin tty + terminal stdout)."""
     try:
+        from . import ui
+
         return sys.stdin.isatty() and ui.console.is_terminal
     except Exception:
         return False
@@ -140,18 +145,6 @@ def _interactive() -> bool:
 def main(argv: list[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
-
-    # Honor NO_COLOR / --no-color before any styled output (menu, banner,
-    # update notice). The flag is parsed per-verb below; catch it here too so
-    # it applies to the interactive menu and the early --version/--update paths.
-    ui.apply_no_color(ui.resolve_no_color("--no-color" in argv))
-
-    try:
-        import argcomplete
-        completion_parser = _get_completion_parser()
-        argcomplete.autocomplete(completion_parser)
-    except ImportError:
-        pass
 
     if argv and argv[0] in ("-V", "--version"):
         print(f"agentsweep {__version__}")
@@ -162,13 +155,30 @@ def main(argv: list[str] | None = None) -> int:
 
     if argv and argv[0] == "list-sources":
         from .pipeline import list_sources
+
         return list_sources(_parse_list_sources(argv[1:]))
 
     if argv and argv[0] == "completion":
         return _run_completion(argv[1:])
 
+    # Honor NO_COLOR / --no-color before any styled output (menu, banner,
+    # update notice). The flag is parsed per-verb below; catch it here too so
+    # it applies to the interactive menu and the early --version/--update paths.
+    from . import ui
+
+    ui.apply_no_color(ui.resolve_no_color("--no-color" in argv))
+
+    try:
+        import argcomplete
+
+        completion_parser = _get_completion_parser()
+        argcomplete.autocomplete(completion_parser)
+    except ImportError:
+        pass
+
     if not argv and _interactive():
         from .menu import run_menu
+
         try:
             return run_menu()
         except KeyboardInterrupt:
@@ -180,10 +190,12 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if verb == "undo":
             from .pipeline import undo
+
             return undo(_parse_undo(rest))
 
         if verb == "purge":
             from .pipeline import purge
+
             return purge(_parse_purge(rest))
 
         args = _parse_run(verb, rest)
@@ -212,6 +224,8 @@ def main(argv: list[str] | None = None) -> int:
                 return fixed
         return code
     except KeyboardInterrupt:
+        from . import ui
+
         ui.shutdown_notice(during_fix=(verb == "fix"), plain=("--json" in rest))
         return 130
 
@@ -227,10 +241,15 @@ def _route(argv: list[str]) -> tuple[str, list[str]]:
 
 
 def _add_common(ap: argparse.ArgumentParser) -> None:
-    ap.add_argument("--source", choices=list(SOURCES), default="claude-code",
-                    help="Which agent's history (default: claude-code).")
-    ap.add_argument("--root", type=Path,
-                    help="Override the source's default root directory.")
+    ap.add_argument(
+        "--source",
+        choices=list(SOURCES),
+        default="claude-code",
+        help="Which agent's history (default: claude-code).",
+    )
+    ap.add_argument(
+        "--root", type=Path, help="Override the source's default root directory."
+    )
 
 
 def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
@@ -240,46 +259,78 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
     )
     # default=None so we can tell "user passed --source" from the implicit
     # default when validating mutual exclusion with --all.
-    ap.add_argument("--source", choices=list(SOURCES), default=None,
-                    help="Which agent's history (default: claude-code).")
-    ap.add_argument("--root", type=Path,
-                    help="Override the source's default root directory.")
-    ap.add_argument("--all", action="store_true",
-                    help="Every registered agent source: scan aggregates "
-                         "findings; fix redacts each source in turn, gated "
-                         "and confirmed separately.")
-    ap.add_argument("--detected", action="store_true",
-                    help="With --all, only scan sources whose history root "
-                         "exists on this machine (same signal as "
-                         "list-sources --detected).")
-    ap.add_argument("-o", "--output", type=Path,
-                    help="Write findings as JSON to this file instead of "
-                         "flooding the terminal.")
-    ap.add_argument("--json", action="store_true",
-                    help="Emit findings as JSON to stdout (no banner/styling).")
-    ap.add_argument("--no-color", action="store_true",
-                    help="Disable ANSI colors/styling in human output "
-                         "(also honored via the NO_COLOR env var).")
-    ap.add_argument("--format", choices=["sarif"],
-                    help="Emit findings in an interchange format instead of "
-                         "the default report: sarif = SARIF 2.1.0 for GitHub "
-                         "code scanning and SARIF viewers (scan only).")
-    ap.add_argument("--no-ignore", action="store_true",
-                    help="Ignore any .agentsweepignore files.")
+    ap.add_argument(
+        "--source",
+        choices=list(SOURCES),
+        default=None,
+        help="Which agent's history (default: claude-code).",
+    )
+    ap.add_argument(
+        "--root", type=Path, help="Override the source's default root directory."
+    )
+    ap.add_argument(
+        "--all",
+        action="store_true",
+        help="Every registered agent source: scan aggregates "
+        "findings; fix redacts each source in turn, gated "
+        "and confirmed separately.",
+    )
+    ap.add_argument(
+        "--detected",
+        action="store_true",
+        help="With --all, only scan sources whose history root "
+        "exists on this machine (same signal as "
+        "list-sources --detected).",
+    )
+    ap.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Write findings as JSON to this file instead of flooding the terminal.",
+    )
+    ap.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit findings as JSON to stdout (no banner/styling).",
+    )
+    ap.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI colors/styling in human output "
+        "(also honored via the NO_COLOR env var).",
+    )
+    ap.add_argument(
+        "--format",
+        choices=["sarif"],
+        help="Emit findings in an interchange format instead of "
+        "the default report: sarif = SARIF 2.1.0 for GitHub "
+        "code scanning and SARIF viewers (scan only).",
+    )
+    ap.add_argument(
+        "--no-ignore", action="store_true", help="Ignore any .agentsweepignore files."
+    )
     # Redaction flags (used by `fix` / legacy --fix; harmless on `scan`).
-    ap.add_argument("--no-backup", action="store_true",
-                    help="Skip .bak file creation (NOT recommended).")
-    ap.add_argument("--force", action="store_true",
-                    help="Bypass soft safety checks (mtime, running-process).")
-    ap.add_argument("--allow-production", action="store_true",
-                    help="Allow --fix against the default production root.")
+    ap.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Skip .bak file creation (NOT recommended).",
+    )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="Bypass soft safety checks (mtime, running-process).",
+    )
+    ap.add_argument(
+        "--allow-production",
+        action="store_true",
+        help="Allow --fix against the default production root.",
+    )
     args = ap.parse_args(rest)
-    args.fix = (verb == "fix")
+    args.fix = verb == "fix"
 
     if args.format is not None:
         if args.json:
-            ap.error("cannot use --json with --format sarif; pick one output "
-                     "format")
+            ap.error("cannot use --json with --format sarif; pick one output format")
         if args.fix:
             ap.error("--format is a scan output format; not valid with fix")
 
@@ -292,8 +343,9 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
         args.source = "claude-code"
     else:
         if args.detected:
-            ap.error("--detected requires --all "
-                     "(or use: agentsweep list-sources --detected)")
+            ap.error(
+                "--detected requires --all (or use: agentsweep list-sources --detected)"
+            )
         if args.source is None:
             args.source = "claude-code"
     return args
@@ -303,12 +355,16 @@ def _parse_list_sources(rest: list[str]) -> argparse.Namespace:
     ap = argparse.ArgumentParser(
         prog="agentsweep list-sources",
         description="List every supported agent source and whether its "
-                    "history root exists on this machine. Read-only.",
+        "history root exists on this machine. Read-only.",
     )
-    ap.add_argument("--json", action="store_true",
-                    help="Emit the source list as JSON to stdout.")
-    ap.add_argument("--detected", action="store_true",
-                    help="Show only sources whose history root exists here.")
+    ap.add_argument(
+        "--json", action="store_true", help="Emit the source list as JSON to stdout."
+    )
+    ap.add_argument(
+        "--detected",
+        action="store_true",
+        help="Show only sources whose history root exists here.",
+    )
     return ap.parse_args(rest)
 
 
@@ -325,14 +381,16 @@ def _parse_purge(rest: list[str]) -> argparse.Namespace:
     ap = argparse.ArgumentParser(
         prog="agentsweep purge",
         description="Delete *.bak backups once the leaked keys are rotated. "
-                    "The backups hold the pre-redaction originals, so this "
-                    "is permanent — `agentsweep undo` stops working for "
-                    "them.",
+        "The backups hold the pre-redaction originals, so this "
+        "is permanent — `agentsweep undo` stops working for "
+        "them.",
     )
     _add_common(ap)
-    ap.add_argument("--yes", action="store_true",
-                    help="Skip the confirmation prompt (required when not "
-                         "running on a terminal).")
+    ap.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt (required when not running on a terminal).",
+    )
     return ap.parse_args(rest)
 
 
@@ -358,60 +416,145 @@ def _get_completion_parser() -> argparse.ArgumentParser:
 
     # scan
     scan_p = subparsers.add_parser("scan", description="Scan history files.")
-    scan_source = scan_p.add_argument("--source", choices=list(SOURCES), default=None,
-                                      help="Which agent's history (default: claude-code).")
+    scan_source = scan_p.add_argument(
+        "--source",
+        choices=list(SOURCES),
+        default=None,
+        help="Which agent's history (default: claude-code).",
+    )
     _with_source_completer(scan_source)
-    scan_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
-    scan_p.add_argument("--all", action="store_true", help="Scan every registered agent source.")
-    scan_p.add_argument("--detected", action="store_true", help="Only scan sources whose history root exists.")
-    scan_p.add_argument("-o", "--output", type=Path, help="Write findings as JSON to this file.")
-    scan_p.add_argument("--json", action="store_true", help="Emit findings as JSON to stdout.")
-    scan_p.add_argument("--no-color", action="store_true", help="Disable ANSI colors/styling in human output.")
-    scan_p.add_argument("--no-ignore", action="store_true", help="Ignore any .agentsweepignore files.")
-    scan_p.add_argument("--no-backup", action="store_true", help="Skip .bak file creation.")
+    scan_p.add_argument(
+        "--root", type=Path, help="Override the source's default root directory."
+    )
+    scan_p.add_argument(
+        "--all", action="store_true", help="Scan every registered agent source."
+    )
+    scan_p.add_argument(
+        "--detected",
+        action="store_true",
+        help="Only scan sources whose history root exists.",
+    )
+    scan_p.add_argument(
+        "-o", "--output", type=Path, help="Write findings as JSON to this file."
+    )
+    scan_p.add_argument(
+        "--json", action="store_true", help="Emit findings as JSON to stdout."
+    )
+    scan_p.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI colors/styling in human output.",
+    )
+    scan_p.add_argument(
+        "--no-ignore", action="store_true", help="Ignore any .agentsweepignore files."
+    )
+    scan_p.add_argument(
+        "--no-backup", action="store_true", help="Skip .bak file creation."
+    )
     scan_p.add_argument("--force", action="store_true", help="Bypass safety checks.")
-    scan_p.add_argument("--allow-production", action="store_true", help="Allow against default production root.")
+    scan_p.add_argument(
+        "--allow-production",
+        action="store_true",
+        help="Allow against default production root.",
+    )
 
     # fix
     fix_p = subparsers.add_parser("fix", description="Redact secrets in history.")
-    fix_source = fix_p.add_argument("--source", choices=list(SOURCES), default=None,
-                                     help="Which agent's history (default: claude-code).")
+    fix_source = fix_p.add_argument(
+        "--source",
+        choices=list(SOURCES),
+        default=None,
+        help="Which agent's history (default: claude-code).",
+    )
     _with_source_completer(fix_source)
-    fix_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
-    fix_p.add_argument("--all", action="store_true", help="Redact every agent source with findings, one at a time.")
-    fix_p.add_argument("--detected", action="store_true", help="With --all, only sources whose history root exists.")
-    fix_p.add_argument("-o", "--output", type=Path, help="Write findings as JSON to this file.")
-    fix_p.add_argument("--json", action="store_true", help="Emit findings as JSON to stdout.")
-    fix_p.add_argument("--no-color", action="store_true", help="Disable ANSI colors/styling in human output.")
-    fix_p.add_argument("--no-ignore", action="store_true", help="Ignore any .agentsweepignore files.")
-    fix_p.add_argument("--no-backup", action="store_true", help="Skip .bak file creation.")
+    fix_p.add_argument(
+        "--root", type=Path, help="Override the source's default root directory."
+    )
+    fix_p.add_argument(
+        "--all",
+        action="store_true",
+        help="Redact every agent source with findings, one at a time.",
+    )
+    fix_p.add_argument(
+        "--detected",
+        action="store_true",
+        help="With --all, only sources whose history root exists.",
+    )
+    fix_p.add_argument(
+        "-o", "--output", type=Path, help="Write findings as JSON to this file."
+    )
+    fix_p.add_argument(
+        "--json", action="store_true", help="Emit findings as JSON to stdout."
+    )
+    fix_p.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI colors/styling in human output.",
+    )
+    fix_p.add_argument(
+        "--no-ignore", action="store_true", help="Ignore any .agentsweepignore files."
+    )
+    fix_p.add_argument(
+        "--no-backup", action="store_true", help="Skip .bak file creation."
+    )
     fix_p.add_argument("--force", action="store_true", help="Bypass safety checks.")
-    fix_p.add_argument("--allow-production", action="store_true", help="Allow against default production root.")
+    fix_p.add_argument(
+        "--allow-production",
+        action="store_true",
+        help="Allow against default production root.",
+    )
 
     # undo
     undo_p = subparsers.add_parser("undo", description="Restore backups.")
-    undo_source = undo_p.add_argument("--source", choices=list(SOURCES), default="claude-code",
-                                       help="Which agent's history.")
+    undo_source = undo_p.add_argument(
+        "--source",
+        choices=list(SOURCES),
+        default="claude-code",
+        help="Which agent's history.",
+    )
     _with_source_completer(undo_source)
-    undo_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
+    undo_p.add_argument(
+        "--root", type=Path, help="Override the source's default root directory."
+    )
 
     # purge
     purge_p = subparsers.add_parser("purge", description="Delete backups.")
-    purge_source = purge_p.add_argument("--source", choices=list(SOURCES), default="claude-code",
-                                          help="Which agent's history.")
+    purge_source = purge_p.add_argument(
+        "--source",
+        choices=list(SOURCES),
+        default="claude-code",
+        help="Which agent's history.",
+    )
     _with_source_completer(purge_source)
-    purge_p.add_argument("--root", type=Path, help="Override the source's default root directory.")
-    purge_p.add_argument("--yes", action="store_true", help="Skip the confirmation prompt.")
+    purge_p.add_argument(
+        "--root", type=Path, help="Override the source's default root directory."
+    )
+    purge_p.add_argument(
+        "--yes", action="store_true", help="Skip the confirmation prompt."
+    )
 
     # list-sources
-    ls_p = subparsers.add_parser("list-sources", description="List supported agent sources.")
-    ls_p.add_argument("--json", action="store_true", help="Emit the source list as JSON to stdout.")
-    ls_p.add_argument("--detected", action="store_true", help="Show only sources whose history root exists.")
+    ls_p = subparsers.add_parser(
+        "list-sources", description="List supported agent sources."
+    )
+    ls_p.add_argument(
+        "--json", action="store_true", help="Emit the source list as JSON to stdout."
+    )
+    ls_p.add_argument(
+        "--detected",
+        action="store_true",
+        help="Show only sources whose history root exists.",
+    )
 
     # completion
-    comp_p = subparsers.add_parser("completion", description="Generate shell completion scripts.")
-    comp_p.add_argument("shell", choices=["bash", "zsh", "fish", "powershell"],
-                        help="The shell to generate completions for.")
+    comp_p = subparsers.add_parser(
+        "completion", description="Generate shell completion scripts."
+    )
+    comp_p.add_argument(
+        "shell",
+        choices=["bash", "zsh", "fish", "powershell"],
+        help="The shell to generate completions for.",
+    )
 
     return ap
 
@@ -421,8 +564,11 @@ def _parse_completion(rest: list[str]) -> argparse.Namespace:
         prog="agentsweep completion",
         description="Generate shell completion scripts for agentsweep.",
     )
-    ap.add_argument("shell", choices=["bash", "zsh", "fish", "powershell"],
-                    help="The shell to generate completions for.")
+    ap.add_argument(
+        "shell",
+        choices=["bash", "zsh", "fish", "powershell"],
+        help="The shell to generate completions for.",
+    )
     return ap.parse_args(rest)
 
 

--- a/tests/test_ui_output.py
+++ b/tests/test_ui_output.py
@@ -1,5 +1,6 @@
-﻿"""Contract tests for the pipeline UI: --json purity, exit codes, masking,
+"""Contract tests for the pipeline UI: --json purity, exit codes, masking,
 gate rendering, redact rows, and encoding degradation."""
+
 from __future__ import annotations
 
 import argparse
@@ -51,6 +52,7 @@ def _mkroot(tmp_path: Path, content: str = FIXTURE_LINE) -> Path:
 
 # ---------------------------------------------------------------- json mode
 
+
 def test_json_mode_is_machine_clean(tmp_path, capsys):
     root = _mkroot(tmp_path)
     code = main(["--root", str(root), "--json"])
@@ -96,6 +98,7 @@ def test_json_with_fix_is_scan_only(tmp_path, capsys):
 
 
 # ---------------------------------------------------------------- scan mode
+
 
 def test_scan_exit_codes(tmp_path, capsys):
     dirty = _mkroot(tmp_path)
@@ -147,8 +150,10 @@ def test_bracketed_path_segments_survive_rendering(tmp_path, capsys):
 
 # ----------------------------------------------------------------- gates
 
+
 def test_production_gate_blocks_and_still_shows_rotation(
-        tmp_path, _isolated_home, capsys):
+    tmp_path, _isolated_home, capsys
+):
     fake_root = _isolated_home / ".claude" / "projects"
     fake_root.mkdir(parents=True)
     (fake_root / "session.jsonl").write_text(FIXTURE_LINE, encoding="utf-8")
@@ -166,8 +171,9 @@ def test_production_gate_blocks_and_still_shows_rotation(
 
 def test_active_session_gate_blocks(tmp_path, monkeypatch, capsys):
     root = _mkroot(tmp_path)
-    monkeypatch.setattr(pipeline, "is_agent_running",
-                        lambda markers: (True, "claude.exe"))
+    monkeypatch.setattr(
+        pipeline, "is_agent_running", lambda markers: (True, "claude.exe")
+    )
 
     code = main(["--root", str(root), "--fix"])
     captured = capsys.readouterr()
@@ -181,8 +187,9 @@ def test_active_session_gate_blocks(tmp_path, monkeypatch, capsys):
 
 def test_force_overrides_active_session_gate(tmp_path, monkeypatch, capsys):
     root = _mkroot(tmp_path)
-    monkeypatch.setattr(pipeline, "is_agent_running",
-                        lambda markers: (True, "claude.exe"))
+    monkeypatch.setattr(
+        pipeline, "is_agent_running", lambda markers: (True, "claude.exe")
+    )
 
     code = main(["--root", str(root), "--fix", "--force"])
     captured = capsys.readouterr()
@@ -193,6 +200,7 @@ def test_force_overrides_active_session_gate(tmp_path, monkeypatch, capsys):
 
 
 # ----------------------------------------------------------------- redact
+
 
 def test_fix_redacts_end_to_end_with_force(tmp_path, _no_claude, capsys):
     root = _mkroot(tmp_path)
@@ -206,8 +214,7 @@ def test_fix_redacts_end_to_end_with_force(tmp_path, _no_claude, capsys):
     assert (root / "session.jsonl.bak").exists()
 
 
-def test_fix_write_error_shows_fail_row_and_exits_2(
-        tmp_path, _no_claude, capsys):
+def test_fix_write_error_shows_fail_row_and_exits_2(tmp_path, _no_claude, capsys):
     root = _mkroot(tmp_path)
     # Pre-existing .bak makes safe_write refuse — exercises the FAIL row.
     (root / "session.jsonl.bak").write_text("old", encoding="utf-8")
@@ -234,7 +241,8 @@ def test_fix_no_backup(tmp_path, _no_claude, capsys):
 
 
 def test_fix_writes_audit_log_in_isolated_home(
-        tmp_path, _isolated_home, _no_claude, capsys):
+    tmp_path, _isolated_home, _no_claude, capsys
+):
     root = _mkroot(tmp_path)
     code = main(["--root", str(root), "--fix", "--force"])
 
@@ -246,6 +254,7 @@ def test_fix_writes_audit_log_in_isolated_home(
 
 
 # --------------------------------------------------------- path forgiveness
+
 
 def test_root_not_found_exits_2_with_suggestion(tmp_path, capsys):
     (tmp_path / "history").mkdir()
@@ -268,15 +277,20 @@ def test_root_not_found_json_keeps_stdout_parseable(tmp_path, capsys):
 
 # --------------------------------------------------------------- no color
 
+
 def _force_color(monkeypatch):
     """Make the shared consoles emit color as if on a terminal.
 
     capsys stdout is not a tty, so rich stays plain by default — force a color
     system on so a no-color regression would actually show escapes to catch.
     """
-    monkeypatch.setattr(ui.console, "_color_system", ui.console._color_system
-                        or __import__("rich.color", fromlist=["ColorSystem"])
-                        .ColorSystem.TRUECOLOR, raising=False)
+    monkeypatch.setattr(
+        ui.console,
+        "_color_system",
+        ui.console._color_system
+        or __import__("rich.color", fromlist=["ColorSystem"]).ColorSystem.TRUECOLOR,
+        raising=False,
+    )
 
 
 def test_resolve_no_color_reads_env_and_flag(monkeypatch):
@@ -307,7 +321,7 @@ def test_no_color_env_suppresses_ansi(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
 
     assert code == 1
-    assert "AGENTSWEEP" in out          # human report still rendered
+    assert "AGENTSWEEP" in out  # human report still rendered
     assert not ANSI_ESCAPE.search(out)  # ...just without escapes
 
 
@@ -363,9 +377,7 @@ def test_update_notice_respects_no_color(monkeypatch, capsys):
     monkeypatch.delenv("AGENTSWEEP_NO_UPDATE", raising=False)
     ui.apply_no_color(True)
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
-    monkeypatch.setattr(
-        urllib.request, "urlopen", lambda *a, **k: _FakeResp()
-    )
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _FakeResp())
 
     args = argparse.Namespace(json=False)
     cli._background_update_notice(args)
@@ -376,6 +388,7 @@ def test_update_notice_respects_no_color(monkeypatch, capsys):
 
 
 # ----------------------------------------------------------------- menu
+
 
 def _feed_menu(monkeypatch, answers: list[str]):
     monkeypatch.setattr(cli, "_interactive", lambda: True)
@@ -406,8 +419,10 @@ def test_menu_scan_action_then_quit(monkeypatch, _isolated_home, capsys):
     # (e.g. APPDATA/Cursor, APPDATA/Windsurf) that are not isolated by tmp_path.
     import sys as _sys
     from agentsweep import menu as _menu
+
     def _fast_scan_all():
         print("No history files found for any source.", file=_sys.stderr)
+
     monkeypatch.setattr(_menu, "_scan_all_sources", _fast_scan_all)
     _feed_menu(monkeypatch, ["1", "", "q"])
     assert main([]) == 0
@@ -416,15 +431,15 @@ def test_menu_scan_action_then_quit(monkeypatch, _isolated_home, capsys):
 
 
 def test_menu_folder_typo_then_retry_shows_count(
-        tmp_path, monkeypatch, _isolated_home, capsys):
+    tmp_path, monkeypatch, _isolated_home, capsys
+):
     good = tmp_path / "history"
     good.mkdir()
     (good / "s.jsonl").write_text(FIXTURE_LINE, encoding="utf-8")
 
     # 2 → typo (suggestion shown) → corrected path (count shown, scan runs)
     # → Enter skips the post-scan redaction offer → Enter → q quit.
-    _feed_menu(monkeypatch, ["2", str(tmp_path / "histori"), str(good), "", "",
-                             "q"])
+    _feed_menu(monkeypatch, ["2", str(tmp_path / "histori"), str(good), "", "", "q"])
     assert main([]) == 0
     captured = capsys.readouterr()
 
@@ -435,12 +450,14 @@ def test_menu_folder_typo_then_retry_shows_count(
 
 
 def test_menu_empty_folder_offers_scan_anyway(
-        tmp_path, monkeypatch, _isolated_home, capsys):
+    tmp_path, monkeypatch, _isolated_home, capsys
+):
     empty = tmp_path / "empty"
     empty.mkdir()
     # decline the scan-anyway offer twice more → _ask_folder gives up → menu → quit
-    _feed_menu(monkeypatch, ["2", str(empty), "n", str(empty), "n", str(empty),
-                             "n", "", "q"])
+    _feed_menu(
+        monkeypatch, ["2", str(empty), "n", str(empty), "n", str(empty), "n", "", "q"]
+    )
     assert main([]) == 0
     out = capsys.readouterr().out
     assert "found 0 .jsonl file(s)" in out
@@ -454,7 +471,8 @@ def test_menu_invalid_choice_reprompts(monkeypatch, _isolated_home, capsys):
 
 
 def test_menu_redact_requires_typed_confirmation(
-        monkeypatch, _isolated_home, _no_claude, capsys):
+    monkeypatch, _isolated_home, _no_claude, capsys
+):
     fake_root = _isolated_home / ".claude" / "projects"
     fake_root.mkdir(parents=True)
     session = fake_root / "session.jsonl"
@@ -468,7 +486,8 @@ def test_menu_redact_requires_typed_confirmation(
 
 
 def test_menu_redact_confirmed_writes_and_undo_restores(
-        monkeypatch, _isolated_home, _no_claude, capsys):
+    monkeypatch, _isolated_home, _no_claude, capsys
+):
     fake_root = _isolated_home / ".claude" / "projects"
     fake_root.mkdir(parents=True)
     session = fake_root / "session.jsonl"
@@ -486,6 +505,7 @@ def test_menu_redact_confirmed_writes_and_undo_restores(
 
 
 # ----------------------------------------------------- post-scan redaction offer
+
 
 def test_post_scan_offer_declined_keeps_exit_1(tmp_path, monkeypatch, capsys):
     root = _mkroot(tmp_path)
@@ -505,8 +525,7 @@ def test_post_scan_offer_declined_keeps_exit_1(tmp_path, monkeypatch, capsys):
     assert AWS_KEY in (root / "session.jsonl").read_text(encoding="utf-8")
 
 
-def test_post_scan_offer_accepted_redacts(
-        tmp_path, monkeypatch, _no_claude, capsys):
+def test_post_scan_offer_accepted_redacts(tmp_path, monkeypatch, _no_claude, capsys):
     root = _mkroot(tmp_path)
     monkeypatch.setattr(cli, "_interactive", lambda: True)
     # Fresh file trips the mtime gate, so the guided --force retry kicks in.
@@ -533,6 +552,7 @@ def test_json_mode_never_prompts(tmp_path, monkeypatch, capsys):
 
 # ------------------------------------------------------- graceful shutdown
 
+
 def _raise_interrupt(*args, **kwargs):
     raise KeyboardInterrupt
 
@@ -549,7 +569,8 @@ def test_ctrl_c_mid_scan_exits_130_no_traceback(tmp_path, monkeypatch, capsys):
 
 
 def test_ctrl_c_during_fix_reassures_about_backups(
-        tmp_path, monkeypatch, _no_claude, capsys):
+    tmp_path, monkeypatch, _no_claude, capsys
+):
     root = _mkroot(tmp_path)
     monkeypatch.setattr(pipeline, "_redact_all", _raise_interrupt)
     code = main(["--root", str(root), "--fix", "--force"])
@@ -571,8 +592,7 @@ def test_ctrl_c_json_mode_keeps_stdout_clean(tmp_path, monkeypatch, capsys):
     assert "interrupted" in captured.err
 
 
-def test_ctrl_c_at_menu_prompt_exits_gracefully(
-        monkeypatch, _isolated_home, capsys):
+def test_ctrl_c_at_menu_prompt_exits_gracefully(monkeypatch, _isolated_home, capsys):
     monkeypatch.setattr(cli, "_interactive", lambda: True)
     monkeypatch.setattr("builtins.input", _raise_interrupt)
     assert main([]) == 0
@@ -581,8 +601,10 @@ def test_ctrl_c_at_menu_prompt_exits_gracefully(
 
 # ------------------------------------------------------- encoding fallback
 
+
 def _console_with_encoding(encoding: str):
     from rich.console import Console
+
     stream = io.TextIOWrapper(io.BytesIO(), encoding=encoding)
     # legacy_windows=False isolates the stream-encoding probe: on Windows,
     # rich marks any non-terminal stream legacy, which forces ASCII anyway.
@@ -593,6 +615,7 @@ def test_ascii_fallback_on_cp1252_stream():
     c = _console_with_encoding("cp1252")
     assert ui._icons(c) == ui._ICONS_ASCII
     from rich import box
+
     assert ui._box(c, box.DOUBLE) is box.ASCII
 
 
@@ -623,10 +646,13 @@ def test_custom_folder_scan_wires_progress(tmp_path, monkeypatch, capsys):
     class _TrackingProgress:
         def __enter__(self):
             return self
+
         def __exit__(self, *exc):
             return False
+
         def advance(self, current: str) -> None:
             advanced.append(current)
+
         def detection(self, *a) -> None:
             pass
 
@@ -643,3 +669,27 @@ def test_safe_escapes_unencodable_path_chars():
     # ✓ (U+2713) cannot encode to cp1252; printing it raw would crash.
     assert "\\u2713" in ui._safe(c, "C:\\Users\\dev\\✓project\\s.jsonl")
     assert ui._safe(c, "plain") == "plain"
+
+
+def test_lazy_imports_for_version_and_update():
+    """Ensure -V/--version and --update checks do not eager-load rich/argcomplete."""
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    src_path = str(Path(__file__).resolve().parent.parent / "src")
+
+    for flag in ("-V", "--version", "--update"):
+        code = f"""
+import sys
+sys.path.insert(0, {repr(src_path)})
+import agentsweep.cli
+code = agentsweep.cli.main([{repr(flag)}])
+sys.exit(code or (1 if "rich" in sys.modules or "argcomplete" in sys.modules else 0))
+"""
+        res = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        assert res.returncode == 0, (
+            f"Lazy import failed for {flag}: {res.stderr}\\n{res.stdout}"
+        )

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -11,6 +11,7 @@ Covers:
   (f) undo INTERACTIVE path: y/n via monkeypatched isatty + is_terminal
   (g) unknown verb-ish first arg (starts with --) routes to scan/fix correctly
 """
+
 from __future__ import annotations
 
 import argparse
@@ -70,12 +71,14 @@ def _seed_root(base: Path, content: str = _LINE, *, age_seconds: int = 3700) -> 
 # ---------------------------------------------------------------------------
 def _no_claude(monkeypatch):
     import agentsweep.pipeline as _pipeline
+
     monkeypatch.setattr(_pipeline, "is_agent_running", lambda markers: (False, ""))
 
 
 # ===========================================================================
 # (a) --version / -V
 # ===========================================================================
+
 
 def test_version_flag_prints_and_exits(capsys):
     code = main(["--version"])
@@ -107,6 +110,7 @@ def test_version_does_not_scan(tmp_path, capsys):
 # (b) "scan --root R" == legacy "--root R"  (findings / exit 1)
 # ===========================================================================
 
+
 def test_scan_verb_and_legacy_are_equivalent(tmp_path, monkeypatch, capsys):
     root = _seed_root(tmp_path)
 
@@ -120,6 +124,7 @@ def test_scan_verb_and_legacy_are_equivalent(tmp_path, monkeypatch, capsys):
     assert code_verb == 1
     # Both JSON outputs should contain the same secret rule hit.
     import json
+
     findings_legacy = json.loads(out_legacy)
     findings_verb = json.loads(out_verb)
     assert len(findings_legacy) == len(findings_verb)
@@ -131,6 +136,7 @@ def test_scan_verb_exits_1_with_findings(tmp_path, capsys):
     code = main(["scan", "--root", str(root), "--json"])
     assert code == 1
     import json
+
     findings = json.loads(capsys.readouterr().out)
     assert any(f["rule"] for f in findings)
 
@@ -150,6 +156,7 @@ def test_scan_verb_exits_0_on_clean_root(tmp_path, capsys):
 # (c) Legacy "--root R --fix --force" still redacts (back-compat alias)
 # ===========================================================================
 
+
 def test_legacy_fix_force_redacts(tmp_path, monkeypatch, capsys):
     _no_claude(monkeypatch)
     root = _seed_root(tmp_path)
@@ -164,6 +171,7 @@ def test_legacy_fix_force_redacts(tmp_path, monkeypatch, capsys):
 # ===========================================================================
 # (d) "fix" non-interactive with --force redacts
 # ===========================================================================
+
 
 def test_fix_verb_noninteractive_redacts(tmp_path, monkeypatch, capsys):
     """Non-interactive fix (capsys = non-tty): --force bypasses mtime/process gates."""
@@ -190,6 +198,7 @@ def test_fix_verb_creates_bak(tmp_path, monkeypatch, capsys):
 # (e) undo --root R
 # ===========================================================================
 
+
 def test_undo_restores_bak_noninteractively(tmp_path, monkeypatch, capsys):
     """Non-interactive undo (capsys = non-tty) should restore without prompting."""
     _no_claude(monkeypatch)
@@ -201,8 +210,10 @@ def test_undo_restores_bak_noninteractively(tmp_path, monkeypatch, capsys):
     bak = root / "session.jsonl.bak"
     bak.write_text(original_content, encoding="utf-8")
     # Simulate redacted main file.
-    session.write_text(original_content.replace(AWS_KEY, "[REDACTED:aws-access-key-id]"),
-                       encoding="utf-8")
+    session.write_text(
+        original_content.replace(AWS_KEY, "[REDACTED:aws-access-key-id]"),
+        encoding="utf-8",
+    )
 
     # Ensure non-interactive: sys.stdin.isatty() returns False under pytest capsys.
     code = main(["undo", "--root", str(root)])
@@ -242,10 +253,12 @@ def test_undo_restore_failure_exits_2(tmp_path, monkeypatch, capsys):
 
     # Patch os.replace to always raise OSError.
     import agentsweep.pipeline as _pipeline
+
     real_os_replace = _pipeline.os.replace if hasattr(_pipeline, "os") else None
 
     # Patch within the undo function's imported os module.
     import os as _os_mod
+
     original_replace = _os_mod.replace
 
     def _fail_replace(src, dst):
@@ -261,13 +274,20 @@ def test_undo_restore_failure_exits_2(tmp_path, monkeypatch, capsys):
 # (f) undo INTERACTIVE path: confirm (y) and cancel (n)
 # ===========================================================================
 
+
 def _make_terminal_console():
     """Return a simple namespace that looks like a terminal console to pipeline.undo."""
+
     class _FakeConsole:
         is_terminal = True
+
         # Rich Console methods used by ui — no-op stubs.
-        def print(self, *a, **kw): pass
-        def rule(self, *a, **kw): pass
+        def print(self, *a, **kw):
+            pass
+
+        def rule(self, *a, **kw):
+            pass
+
     return _FakeConsole()
 
 
@@ -279,8 +299,10 @@ def test_undo_interactive_y_restores(tmp_path, monkeypatch, capsys):
 
     bak = root / "session.jsonl.bak"
     bak.write_text(original_content, encoding="utf-8")
-    session.write_text(original_content.replace(AWS_KEY, "[REDACTED:aws-access-key-id]"),
-                       encoding="utf-8")
+    session.write_text(
+        original_content.replace(AWS_KEY, "[REDACTED:aws-access-key-id]"),
+        encoding="utf-8",
+    )
 
     # Make the undo function think it's interactive by:
     # 1. making sys.stdin.isatty() return True
@@ -288,6 +310,7 @@ def test_undo_interactive_y_restores(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     import agentsweep.ui as _ui
     import agentsweep.pipeline as _pipeline
+
     fake_console = _make_terminal_console()
     monkeypatch.setattr(_ui, "console", fake_console)
     monkeypatch.setattr(_pipeline, "ui", _ui)
@@ -317,6 +340,7 @@ def test_undo_interactive_n_cancels(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     import agentsweep.ui as _ui
     import agentsweep.pipeline as _pipeline
+
     fake_console = _make_terminal_console()
     monkeypatch.setattr(_ui, "console", fake_console)
     monkeypatch.setattr(_pipeline, "ui", _ui)
@@ -344,6 +368,7 @@ def test_undo_interactive_eof_cancels_gracefully(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     import agentsweep.ui as _ui
     import agentsweep.pipeline as _pipeline
+
     fake_console = _make_terminal_console()
     monkeypatch.setattr(_ui, "console", fake_console)
     monkeypatch.setattr(_pipeline, "ui", _ui)
@@ -363,6 +388,7 @@ def test_undo_interactive_eof_cancels_gracefully(tmp_path, monkeypatch, capsys):
 # (g) Unknown verb-ish first arg (starts with --) routes to scan/fix correctly
 # ===========================================================================
 
+
 def test_double_dash_arg_routes_to_scan(tmp_path, capsys):
     """An arg starting with -- that is not a verb is routed to scan."""
     root = _seed_root(tmp_path)
@@ -370,6 +396,7 @@ def test_double_dash_arg_routes_to_scan(tmp_path, capsys):
     code = main(["--root", str(root), "--json"])
     assert code == 1  # findings found → scan exit 1
     import json
+
     out = capsys.readouterr().out
     findings = json.loads(out)
     assert len(findings) > 0
@@ -398,6 +425,7 @@ def test_source_flag_still_works_with_verb(tmp_path, capsys):
 # Additional edge cases
 # ===========================================================================
 
+
 def test_undo_multiple_bak_files(tmp_path, monkeypatch, capsys):
     """undo with multiple .bak files restores all of them."""
     _no_claude(monkeypatch)
@@ -424,7 +452,9 @@ def test_undo_multiple_bak_files(tmp_path, monkeypatch, capsys):
     assert not (subdir / "other.jsonl.bak").exists()
 
 
-def test_fix_verb_noninteractive_no_allow_production_blocks(tmp_path, monkeypatch, capsys):
+def test_fix_verb_noninteractive_no_allow_production_blocks(
+    tmp_path, monkeypatch, capsys
+):
     """Non-interactive fix without --allow-production on default root is blocked (exit 2)."""
     _no_claude(monkeypatch)
     fake_home = tmp_path / "home"
@@ -440,7 +470,9 @@ def test_fix_verb_noninteractive_no_allow_production_blocks(tmp_path, monkeypatc
     code = main(["fix", "--force"])  # no --allow-production
     captured = capsys.readouterr()
     assert code == 2
-    assert "default production root" in captured.err or "allow-production" in captured.err
+    assert (
+        "default production root" in captured.err or "allow-production" in captured.err
+    )
     # Nothing redacted.
     assert AWS_KEY in session.read_text(encoding="utf-8")
 
@@ -448,6 +480,7 @@ def test_fix_verb_noninteractive_no_allow_production_blocks(tmp_path, monkeypatc
 def test_scan_json_flag_produces_parseable_output(tmp_path, capsys):
     """scan --json should produce parseable JSON with fingerprint field."""
     import json
+
     root = _seed_root(tmp_path)
     code = main(["scan", "--root", str(root), "--json"])
     assert code == 1
@@ -494,6 +527,8 @@ def test_completion_powershell(capsys):
 def test_completion_rejects_unknown_shell():
     with pytest.raises(SystemExit):
         main(["completion", "tcsh"])
+
+
 def test_completion_missing_argcomplete_exits_2(monkeypatch, capsys):
     fake_argcomplete = types.ModuleType("argcomplete")
     setattr(fake_argcomplete, "autocomplete", lambda parser: None)
@@ -518,7 +553,7 @@ def test_completion_setup_does_not_swallow_parser_errors(monkeypatch):
     monkeypatch.setattr(cli, "_get_completion_parser", _fail_parser)
 
     with pytest.raises(RuntimeError, match="broken completion parser"):
-        main(["--version"])
+        main(["scan"])
 
 
 def test_fix_completion_matches_the_cli_contract():
@@ -532,9 +567,7 @@ def test_fix_completion_matches_the_cli_contract():
     )
     fix_parser = subparsers_action.choices["fix"]
     fix_options = {
-        option
-        for action in fix_parser._actions
-        for option in action.option_strings
+        option for action in fix_parser._actions for option in action.option_strings
     }
 
     # #53's contract: completions advertise exactly what fix accepts. fix --all
@@ -545,6 +578,7 @@ def test_fix_completion_matches_the_cli_contract():
 
 def test_source_completer_matches():
     from agentsweep.cli import source_completer
+
     res = source_completer("clau")
     assert "claude-code" in res
     res_all = source_completer("")


### PR DESCRIPTION
This PR addresses issue #137: "perf: lazy-import rich/argcomplete for faster --version / -V cold start".

### Changes:
- **`src/agentsweep/cli.py`**:
  - Removed top-level import of the `ui` module (which eagerly imports `rich`).
  - Moved early `-V` / `--version` and `--update` argument checks to the very beginning of the `main()` entrypoint function.
  - Deferred the import of `ui` and the setup of `argcomplete` until after these version/update checks are completed.
  - Lazy-imported `ui` inside functions/paths that require styled terminal output (e.g., `_background_update_notice`, `_interactive`, and the main scanning flow).
- **`tests/test_ui_output.py`**:
  - Added a new cross-platform unit test (`test_lazy_imports_for_version_and_update`) that uses a clean Python subprocess to verify that `rich` and `argcomplete` are not loaded into `sys.modules` when running version and update checks.
- **`tests/test_verbs.py`**:
  - Updated `test_completion_setup_does_not_swallow_parser_errors` to run on `main(["scan"])` instead of `main(["--version"])` because the version subcommand now intentionally skips the autocomplete parser setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of version, update, completion, and other early command-line operations.
  * Reduced unnecessary loading of optional interface components for simple commands.
  * Preserved existing command options, validation, undo behavior, and completion handling.

* **Tests**
  * Added coverage to verify lightweight startup behavior for version and update commands.
  * Expanded coverage for interactive undo and command error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR defers the import of `rich` (via the `ui` package) and `argcomplete` until after the early-exit checks for `-V`/`--version` and `--update`, eliminating those modules from the cold-start path. The test suite is updated to verify the lazy-import contract with a subprocess check, and `test_completion_setup_does_not_swallow_parser_errors` is corrected to use `main([\"scan\"])` since `--version` now exits before argcomplete is configured.

- `cli.py`: `from . import ui` and the `argcomplete` block are relocated after the `--version`, `--update`, `list-sources`, and `completion` early exits — but only the first two were the intended targets; `list-sources` is now left without an `apply_no_color()` call even though `pipeline.list_sources()` uses `ui.banner()` and `ui.sources_table()` for styled output.
- `test_ui_output.py`: Adds `test_lazy_imports_for_version_and_update`, which spawns clean subprocesses to assert `rich` and `argcomplete` are absent from `sys.modules`; the `--update` iteration makes a live PyPI network request that can stall for up to 2 s in offline environments.
- `tests/test_verbs.py`: Cosmetic reformatting plus the one functional fix to the argcomplete-error-propagation test.
</details>

<h3>Confidence Score: 3/5</h3>

The version/update cold-start optimisation is correct, but the refactoring unintentionally breaks NO_COLOR support for agentsweep list-sources.

Moving apply_no_color() past the list-sources early exit means that pipeline.list_sources() — which calls ui.banner(), ui.warn_line(), and ui.sources_table() — now runs without the ANSI-stripping the NO_COLOR env var is supposed to trigger. This was working before the refactoring and is a broken user-visible contract.

src/agentsweep/cli.py — specifically the placement of apply_no_color() relative to the list-sources early-exit block.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentsweep/cli.py | Lazy-imports `ui` and `argcomplete` to speed up `-V`/`--version` cold start; inadvertently skips `apply_no_color()` for the `list-sources` path, breaking `NO_COLOR` env-var support for that subcommand. |
| tests/test_ui_output.py | Adds `test_lazy_imports_for_version_and_update` subprocess test and reformats existing tests; the `--update` iteration triggers a real PyPI network call that can add up to 2 s latency in offline CI. |
| tests/test_verbs.py | Updates `test_completion_setup_does_not_swallow_parser_errors` to use `main(["scan"])` instead of `main(["--version"])`, correctly reflecting that version now exits before argcomplete setup; also reformats tests. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[main argv] --> B{version flag?}
    B -->|yes| C[print version, return 0, no rich or argcomplete loaded]
    B -->|no| D{--update?}
    D -->|yes| E[_run_update_check, return 0, no rich or argcomplete loaded]
    D -->|no| F{list-sources?}
    F -->|yes| G[pipeline.list_sources uses ui.console NO apply_no_color called]
    F -->|no| H{completion?}
    H -->|yes| I[_run_completion, return]
    H -->|no| J[import ui, apply_no_color, setup argcomplete]
    J --> K{no argv and interactive?}
    K -->|yes| L[run_menu]
    K -->|no| M[route verb rest]
    M --> N[scan or fix or undo or purge]
    N -->|KeyboardInterrupt| O[lazy import ui, shutdown_notice]
    style G fill:#ffcccc
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fagentsweep%2Fcli.py%3A156-159%0A**NO_COLOR%20not%20applied%20on%20the%20%60list-sources%60%20path**%0A%0A%60list_sources%28%29%60%20in%20%60pipeline.py%60%20calls%20%60ui.banner%28%29%60%2C%20%60ui.warn_line%28%29%60%2C%20and%20%60ui.sources_table%28%29%60%20%E2%80%94%20all%20styled%20rich%20output.%20Before%20this%20PR%2C%20%60ui.apply_no_color%28%29%60%20was%20called%20at%20the%20top%20of%20%60main%28%29%60%20before%20the%20%60list-sources%60%20early%20exit%2C%20so%20%60NO_COLOR%3D1%20agentsweep%20list-sources%60%20correctly%20suppressed%20ANSI%20bold%2Fdim%20sequences.%20After%20this%20refactoring%2C%20%60list-sources%60%20exits%20before%20%60apply_no_color%28%29%60%20is%20ever%20called%2C%20so%20the%20%60NO_COLOR%60%20env-var%20convention%20is%20skipped%20entirely%20for%20this%20path.%20In%20practice%2C%20%60NO_COLOR%3D1%20agentsweep%20list-sources%60%20will%20emit%20bold%2Fdim%20escape%20sequences%20that%20it%20previously%20suppressed.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fagentsweep%2Fcli.py%3A164-167%0AThe%20comment%20says%20%60apply_no_color%60%20%22applies%20to%20%E2%80%A6%20the%20early%20--version%2F--update%20paths%2C%22%20but%20those%20paths%20now%20exit%20before%20this%20code%20is%20reached.%20The%20comment%20is%20misleading%20and%20should%20be%20updated%20to%20reflect%20what%20this%20block%20actually%20covers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20Honor%20NO_COLOR%20%2F%20--no-color%20before%20any%20styled%20output%20%28menu%2C%20banner%2C%0A%20%20%20%20%23%20update%20notice%29.%20The%20flag%20is%20parsed%20per-verb%20below%3B%20catch%20it%20here%20too%20so%0A%20%20%20%20%23%20it%20applies%20to%20the%20interactive%20menu%20and%20all%20remaining%20code%20paths.%0A%20%20%20%20from%20.%20import%20ui%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Ftest_ui_output.py%3A682-695%0A**%60--update%60%20case%20makes%20a%20live%20network%20request**%0A%0AThe%20loop%20includes%20%60%22--update%22%60%20as%20one%20of%20the%20tested%20flags.%20%60main%28%5B%22--update%22%5D%29%60%20calls%20%60_run_update_check%28%29%60%20%E2%86%92%20%60check_for_update%28timeout%3D2%29%60%20which%20opens%20a%20real%20HTTPS%20connection%20to%20PyPI.%20In%20an%20offline%20CI%20environment%20this%20hangs%20for%20the%20full%202-second%20timeout%20before%20returning%20gracefully.%20The%20test%20itself%20passes%20either%20way%20%28the%20import%20check%20is%20the%20only%20assertion%29%2C%20but%20it%20silently%20adds%20up%20to%202%20seconds%20of%20latency%20and%20could%20behave%20unpredictably%20on%20flaky%20networks.%20Consider%20monkeypatching%20%60urllib.request.urlopen%60%20in%20the%20subprocess%20code%20string%2C%20or%20splitting%20the%20%60--update%60%20case%20into%20its%20own%20test%20that%20mocks%20the%20network%20call.%0A%0A&repo=ishannaik%2Fagent-sweep&pr=157&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fagent-sweep%22%20on%20the%20existing%20branch%20%22perf-lazy-imports-137%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf-lazy-imports-137%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fagentsweep%2Fcli.py%3A156-159%0A**NO_COLOR%20not%20applied%20on%20the%20%60list-sources%60%20path**%0A%0A%60list_sources%28%29%60%20in%20%60pipeline.py%60%20calls%20%60ui.banner%28%29%60%2C%20%60ui.warn_line%28%29%60%2C%20and%20%60ui.sources_table%28%29%60%20%E2%80%94%20all%20styled%20rich%20output.%20Before%20this%20PR%2C%20%60ui.apply_no_color%28%29%60%20was%20called%20at%20the%20top%20of%20%60main%28%29%60%20before%20the%20%60list-sources%60%20early%20exit%2C%20so%20%60NO_COLOR%3D1%20agentsweep%20list-sources%60%20correctly%20suppressed%20ANSI%20bold%2Fdim%20sequences.%20After%20this%20refactoring%2C%20%60list-sources%60%20exits%20before%20%60apply_no_color%28%29%60%20is%20ever%20called%2C%20so%20the%20%60NO_COLOR%60%20env-var%20convention%20is%20skipped%20entirely%20for%20this%20path.%20In%20practice%2C%20%60NO_COLOR%3D1%20agentsweep%20list-sources%60%20will%20emit%20bold%2Fdim%20escape%20sequences%20that%20it%20previously%20suppressed.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fagentsweep%2Fcli.py%3A164-167%0AThe%20comment%20says%20%60apply_no_color%60%20%22applies%20to%20%E2%80%A6%20the%20early%20--version%2F--update%20paths%2C%22%20but%20those%20paths%20now%20exit%20before%20this%20code%20is%20reached.%20The%20comment%20is%20misleading%20and%20should%20be%20updated%20to%20reflect%20what%20this%20block%20actually%20covers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20Honor%20NO_COLOR%20%2F%20--no-color%20before%20any%20styled%20output%20%28menu%2C%20banner%2C%0A%20%20%20%20%23%20update%20notice%29.%20The%20flag%20is%20parsed%20per-verb%20below%3B%20catch%20it%20here%20too%20so%0A%20%20%20%20%23%20it%20applies%20to%20the%20interactive%20menu%20and%20all%20remaining%20code%20paths.%0A%20%20%20%20from%20.%20import%20ui%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Ftest_ui_output.py%3A682-695%0A**%60--update%60%20case%20makes%20a%20live%20network%20request**%0A%0AThe%20loop%20includes%20%60%22--update%22%60%20as%20one%20of%20the%20tested%20flags.%20%60main%28%5B%22--update%22%5D%29%60%20calls%20%60_run_update_check%28%29%60%20%E2%86%92%20%60check_for_update%28timeout%3D2%29%60%20which%20opens%20a%20real%20HTTPS%20connection%20to%20PyPI.%20In%20an%20offline%20CI%20environment%20this%20hangs%20for%20the%20full%202-second%20timeout%20before%20returning%20gracefully.%20The%20test%20itself%20passes%20either%20way%20%28the%20import%20check%20is%20the%20only%20assertion%29%2C%20but%20it%20silently%20adds%20up%20to%202%20seconds%20of%20latency%20and%20could%20behave%20unpredictably%20on%20flaky%20networks.%20Consider%20monkeypatching%20%60urllib.request.urlopen%60%20in%20the%20subprocess%20code%20string%2C%20or%20splitting%20the%20%60--update%60%20case%20into%20its%20own%20test%20that%20mocks%20the%20network%20call.%0A%0A&repo=ishannaik%2Fagent-sweep&pr=157&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fagentsweep%2Fcli.py%3A156-159%0A**NO_COLOR%20not%20applied%20on%20the%20%60list-sources%60%20path**%0A%0A%60list_sources%28%29%60%20in%20%60pipeline.py%60%20calls%20%60ui.banner%28%29%60%2C%20%60ui.warn_line%28%29%60%2C%20and%20%60ui.sources_table%28%29%60%20%E2%80%94%20all%20styled%20rich%20output.%20Before%20this%20PR%2C%20%60ui.apply_no_color%28%29%60%20was%20called%20at%20the%20top%20of%20%60main%28%29%60%20before%20the%20%60list-sources%60%20early%20exit%2C%20so%20%60NO_COLOR%3D1%20agentsweep%20list-sources%60%20correctly%20suppressed%20ANSI%20bold%2Fdim%20sequences.%20After%20this%20refactoring%2C%20%60list-sources%60%20exits%20before%20%60apply_no_color%28%29%60%20is%20ever%20called%2C%20so%20the%20%60NO_COLOR%60%20env-var%20convention%20is%20skipped%20entirely%20for%20this%20path.%20In%20practice%2C%20%60NO_COLOR%3D1%20agentsweep%20list-sources%60%20will%20emit%20bold%2Fdim%20escape%20sequences%20that%20it%20previously%20suppressed.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fagentsweep%2Fcli.py%3A164-167%0AThe%20comment%20says%20%60apply_no_color%60%20%22applies%20to%20%E2%80%A6%20the%20early%20--version%2F--update%20paths%2C%22%20but%20those%20paths%20now%20exit%20before%20this%20code%20is%20reached.%20The%20comment%20is%20misleading%20and%20should%20be%20updated%20to%20reflect%20what%20this%20block%20actually%20covers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20Honor%20NO_COLOR%20%2F%20--no-color%20before%20any%20styled%20output%20%28menu%2C%20banner%2C%0A%20%20%20%20%23%20update%20notice%29.%20The%20flag%20is%20parsed%20per-verb%20below%3B%20catch%20it%20here%20too%20so%0A%20%20%20%20%23%20it%20applies%20to%20the%20interactive%20menu%20and%20all%20remaining%20code%20paths.%0A%20%20%20%20from%20.%20import%20ui%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Ftest_ui_output.py%3A682-695%0A**%60--update%60%20case%20makes%20a%20live%20network%20request**%0A%0AThe%20loop%20includes%20%60%22--update%22%60%20as%20one%20of%20the%20tested%20flags.%20%60main%28%5B%22--update%22%5D%29%60%20calls%20%60_run_update_check%28%29%60%20%E2%86%92%20%60check_for_update%28timeout%3D2%29%60%20which%20opens%20a%20real%20HTTPS%20connection%20to%20PyPI.%20In%20an%20offline%20CI%20environment%20this%20hangs%20for%20the%20full%202-second%20timeout%20before%20returning%20gracefully.%20The%20test%20itself%20passes%20either%20way%20%28the%20import%20check%20is%20the%20only%20assertion%29%2C%20but%20it%20silently%20adds%20up%20to%202%20seconds%20of%20latency%20and%20could%20behave%20unpredictably%20on%20flaky%20networks.%20Consider%20monkeypatching%20%60urllib.request.urlopen%60%20in%20the%20subprocess%20code%20string%2C%20or%20splitting%20the%20%60--update%60%20case%20into%20its%20own%20test%20that%20mocks%20the%20network%20call.%0A%0A&pr=157&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/agentsweep/cli.py:156-159
**NO_COLOR not applied on the `list-sources` path**

`list_sources()` in `pipeline.py` calls `ui.banner()`, `ui.warn_line()`, and `ui.sources_table()` — all styled rich output. Before this PR, `ui.apply_no_color()` was called at the top of `main()` before the `list-sources` early exit, so `NO_COLOR=1 agentsweep list-sources` correctly suppressed ANSI bold/dim sequences. After this refactoring, `list-sources` exits before `apply_no_color()` is ever called, so the `NO_COLOR` env-var convention is skipped entirely for this path. In practice, `NO_COLOR=1 agentsweep list-sources` will emit bold/dim escape sequences that it previously suppressed.

### Issue 2 of 3
src/agentsweep/cli.py:164-167
The comment says `apply_no_color` "applies to … the early --version/--update paths," but those paths now exit before this code is reached. The comment is misleading and should be updated to reflect what this block actually covers.

```suggestion
    # Honor NO_COLOR / --no-color before any styled output (menu, banner,
    # update notice). The flag is parsed per-verb below; catch it here too so
    # it applies to the interactive menu and all remaining code paths.
    from . import ui
```

### Issue 3 of 3
tests/test_ui_output.py:682-695
**`--update` case makes a live network request**

The loop includes `"--update"` as one of the tested flags. `main(["--update"])` calls `_run_update_check()` → `check_for_update(timeout=2)` which opens a real HTTPS connection to PyPI. In an offline CI environment this hangs for the full 2-second timeout before returning gracefully. The test itself passes either way (the import check is the only assertion), but it silently adds up to 2 seconds of latency and could behave unpredictably on flaky networks. Consider monkeypatching `urllib.request.urlopen` in the subprocess code string, or splitting the `--update` case into its own test that mocks the network call.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: lazy-import rich and defer argcomp..."](https://github.com/ishannaik/agent-sweep/commit/0ecd6ee63850d14679dc198f89d6c52bad65e6df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46252787)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->