### PR TITLE
docs: add CHANGELOG.md, backfilled from git tag history (fixes #131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,141 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `CLAUDE_CONFIG_DIR` support so Claude Code profiles outside the default
+  `~/.claude` (e.g. `~/.claude-personal`) can be scanned (#63)
+- SARIF 2.1.0 output (`--format sarif`) for GitHub code scanning and other
+  SARIF viewers (#58)
+- `fix --all`: guided multi-source redaction (#59)
+- Dockerfile and container usage docs (#27, #62)
+- Crush (Charm) agent source (#57)
+- Google OAuth client secret and service-account key detectors (#104)
+- Additional LLM-provider secret detectors (#109)
+- Pre-commit hook (`.pre-commit-hooks.yaml`) (#75)
+- Warning for leftover `.bak` files that still hold secrets (#74)
+- `--no-color` flag; also honors the `NO_COLOR` env var (#78, #97, #101)
+- Bash/zsh/fish and PowerShell shell completions (#31, #56)
+- Man page for the `agentsweep` command (#105)
+- `pytest-benchmark` harness for scan hot paths (#94)
+
+### Fixed
+- CRLF line endings are now preserved through redaction rewrites (#54)
+- Shell-completion command contract (#53)
+
+### Changed
+- `scan --all` parallelized across sources for faster multi-source runs
+  (#92, #103)
+
+### CI / Infra
+- mypy static type checking (#89)
+- Enforced test-coverage threshold (#96)
+- CodeQL, Dependabot, and SHA-pinned Actions for supply-chain hardening
+- macOS and ARM Linux added to the test matrix
+- `deptry` + `vulture` dead-code/dependency checks (#87, #108)
+- Bandit SAST job, all findings triaged (#106)
+
+## [0.1.9] - 2026-06-13
+### Fixed
+- Idempotent redaction retries; stop offering `--force` when it can't help
+
+## [0.1.8] - 2026-06-13
+### Added
+- In-app contribution nudges
+
+### Changed
+- BIP-39 wordlist stored as a compact joined string
+
+## [0.1.7] - 2026-06-13
+### Added
+- 13 more agent sources (29 total)
+- Experimental-source flag for sources whose history path/format is
+  inferred rather than verified against a real install
+
+## [0.1.6] - 2026-06-13
+### Added
+- Discord bot token detector (id.timestamp.hmac base64url) (#8)
+- Discord webhook URL detector
+- Kilo Code, Roo Code, and Open Interpreter sources
+- "All sources" option in the interactive scan picker
+- `purge` verb for stale `.bak` backups; new backups created `0600` (#7)
+- `uv.lock` for reproducible dev installs
+- Pull-request and issue templates (#11)
+
+### Fixed
+- TUI arrow keys misread as quit on Unix terminals (#5)
+- `--fix` now works for markdown and whole-file JSON histories, fail-closed
+  (#3)
+- Windows CI: pty/termios imports moved inside Unix-only functions (#9)
+- `os.read` buffer tightened from 16 to 6 bytes in `_read_key_unix`
+
+### Changed
+- Menu elif-ladders collapsed into dispatch tables; redact rendering
+  deduplicated (#10)
+
+## [0.1.5] - 2026-06-12
+### Added
+- OpenClaw, Hermes, and Goose agent sources
+- Mermaid pipeline diagram in README (5-stage flow, scan vs. fix paths)
+
+### Fixed
+- SQLite sources now back up before mutating, via the `sqlite3.backup()` API
+
+### Changed
+- Sources modularized into the `sources/` package
+
+## [0.1.4] - 2026-06-12
+### Fixed
+- Skip a redundant double-scan on REDACT
+
+### Changed
+- TUI polish; 7-option menu
+
+## [0.1.3] - 2026-06-12
+### Added
+- Interactive TUI picker
+- Parallel file scanning
+- 10 total agent sources
+
+## [0.1.2] - 2026-06-12
+### Added
+- Codex, OpenCode, Cursor, Windsurf, Aider, Cline, Gemini CLI,
+  Continue (VS Code), and GitHub Copilot Chat agent sources
+- `python -m agentsweep` support via `__main__.py`
+- Preflight checks for a running agent process
+- Background update-check on TTY launches, with `--update` flag
+- PyPI publish workflow triggered on version tags
+
+### Fixed
+- Discovery spinner now shows while walking large folders
+- Removed `force-include` from `pyproject.toml` — it was breaking editable
+  installs
+
+## [0.1.1]
+### Added
+- `asweep` short alias for the `agentsweep` command
+
+## [0.1.0] - Initial release
+### Added
+- Core scan/redact pipeline for Claude Code history
+- Interactive menu mode with confirmation and undo
+- 131 initial secret-pattern detectors, later expanded to 189
+- Keyword pre-filter for faster scanning
+- `pip install` / `uvx` packaging and CI
+
+[Unreleased]: https://github.com/Ishannaik/agent-sweep/compare/v0.1.9...HEAD
+[0.1.9]: https://github.com/Ishannaik/agent-sweep/compare/v0.1.8...v0.1.9
+[0.1.8]: https://github.com/Ishannaik/agent-sweep/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.com/Ishannaik/agent-sweep/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/Ishannaik/agent-sweep/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/Ishannaik/agent-sweep/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/Ishannaik/agent-sweep/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/Ishannaik/agent-sweep/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/Ishannaik/agent-sweep/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/Ishannaik/agent-sweep/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/Ishannaik/agent-sweep/releases/tag/v0.1.0

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,21 +13,26 @@
 
 Full documentation: https://docs.pypi.org/trusted-publishers/
 
-No API token or secret is required — PyPI authenticates via OIDC from the workflow.
+No API token or secret is required - PyPI authenticates via OIDC from the workflow.
 
 ## Per-release steps
 
-1. Bump the version in two places:
-   - `pyproject.toml` — the `version = "X.Y.Z"` field
-   - `src/agentsweep/__init__.py` — the `__version__ = "X.Y.Z"` string
+1. Move the `## [Unreleased]` entries in `CHANGELOG.md` under a new
+   `## [X.Y.Z] - YYYY-MM-DD` heading, and add the compare link at the
+   bottom of the file (`[X.Y.Z]: .../compare/vPREV...vX.Y.Z`). Leave a
+   fresh empty `## [Unreleased]` section above it for the next release.
 
-2. Commit the version bump:
+2. Bump the version in two places:
+   - `pyproject.toml` - the `version = "X.Y.Z"` field
+   - `src/agentsweep/__init__.py` - the `__version__ = "X.Y.Z"` string
+
+3. Commit the version bump and changelog together:
    ```
-   git add pyproject.toml src/agentsweep/__init__.py
+   git add pyproject.toml src/agentsweep/__init__.py CHANGELOG.md
    git commit -m "chore: bump version to X.Y.Z"
    ```
 
-3. Tag and push:
+4. Tag and push:
    ```
    git tag vX.Y.Z
    git push origin main --tags


### PR DESCRIPTION
## What & why
Adds CHANGELOG.md in Keep a Changelog format, backfilled from actual git
tag history (v0.1.0 through v0.1.9, plus an Unreleased section for
everything merged since v0.1.9). Also updates docs/RELEASING.md's
per-release checklist to include moving Unreleased entries under the new
version heading, alongside the existing version-bump/tag/push steps.

Fixes #131

## Type of change
- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [ ] Feature / enhancement
- [x] Refactor / docs / chore

## Testing
N/A — docs-only change, no code touched, nothing to run pytest against.

## Checklist
- [ ] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13) — N/A, no Python code changed
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [ ] Redaction / write-path changes preserve the corruption-prevention invariants — N/A, no redaction/write-path code touched
- [ ] **New detection rule?** — N/A, no rule changes in this PR
- [ ] **New source?** — N/A, no source changes in this PR
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths) — unaffected, docs-only
- [x] Did not re-introduce `force-include` in `pyproject.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive Keep-a-Changelog history covering current and previous releases.
  - Documented upcoming features, fixes, behavioral changes, and CI/security updates.
  - Added release comparison links for easier navigation between versions.
  - Updated release instructions to include preparing, versioning, and committing changelog updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces `CHANGELOG.md` in Keep a Changelog format, backfilled from git tag history (v0.1.0–v0.1.9) with an Unreleased section, and updates `docs/RELEASING.md` to include a CHANGELOG maintenance step in the per-release checklist.

- `CHANGELOG.md` is added as a new file with version entries for all ten releases and an Unreleased section; two entries deviate from the spec: `[0.1.1]` is missing its release date, and `[0.1.0]` uses the text "Initial release" instead of a `YYYY-MM-DD` date.
- `docs/RELEASING.md` gains a new step 1 that instructs contributors to move Unreleased entries under a versioned heading before bumping; the git commit message template in step 3 does not yet reflect that `CHANGELOG.md` is now part of the commit.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — docs-only change with no impact on code or CI.

Two entries in the new CHANGELOG.md don't conform to the Keep a Changelog date format: [0.1.1] has no date at all, and [0.1.0] carries the text "Initial release" instead of a YYYY-MM-DD value. These are cosmetic issues that won't break anything at runtime, but they should be fixed before the file is used as the canonical changelog source.

CHANGELOG.md — the two oldest version entries need proper ISO 8601 dates before tools or linters are pointed at this file.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | New file — backfilled Keep a Changelog entries for v0.1.0–v0.1.9 plus an Unreleased section; two format violations: [0.1.1] has no release date, and [0.1.0] uses prose ("Initial release") instead of a YYYY-MM-DD date; the CI/Infra subsection is non-standard per spec. |
| docs/RELEASING.md | Per-release checklist updated to add a CHANGELOG.md step before version bump; steps renumbered correctly; minor: suggested commit message doesn't mention the changelog update. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Work on feature/fix] --> B[Merge PR to main]
    B --> C[Add entry to Unreleased section in CHANGELOG.md]
    C --> D{Ready to release?}
    D -- No --> B
    D -- Yes --> E["Step 1: Move Unreleased entries to ## [X.Y.Z] - YYYY-MM-DD"]
    E --> F["Add compare link at bottom of CHANGELOG.md"]
    F --> G["Leave fresh empty ## [Unreleased] section"]
    G --> H["Step 2: Bump version in pyproject.toml and __init__.py"]
    H --> I["Step 3: git add pyproject.toml __init__.py CHANGELOG.md && git commit"]
    I --> J["Step 4: git tag vX.Y.Z && git push origin main --tags"]
    J --> K["release.yml triggered → build sdist/wheel → publish to PyPI"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0ACHANGELOG.md%3A119-120%0AMissing%20release%20date%20for%20%60%5B0.1.1%5D%60.%20Keep%20a%20Changelog%20requires%20every%20version%20heading%20to%20carry%20an%20ISO%208601%20date%20%28%60YYYY-MM-DD%60%29%3B%20without%20it%2C%20tools%20that%20parse%20the%20changelog%20%28e.g.%20%60git-cliff%60%2C%20%60release-drafter%60%2C%20changelog%20linters%29%20will%20treat%20this%20entry%20as%20undated%20or%20fail%20to%20parse%20it%20entirely.%20Since%20%60v0.1.1%60%20is%20between%20%60v0.1.0%60%20and%20%60v0.1.2%60%20%282026-06-12%29%2C%20its%20tag%20date%20should%20be%20available%20via%20%60git%20log%20--tags%60.%0A%0A%60%60%60suggestion%0A%23%23%20%5B0.1.1%5D%20-%20YYYY-MM-DD%0A%23%23%23%20Added%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0ACHANGELOG.md%3A123%0A%60-%20Initial%20release%60%20is%20not%20a%20valid%20date%20field.%20Keep%20a%20Changelog%20specifies%20the%20version%20header%20format%20as%20%60%23%23%20%5BX.Y.Z%5D%20-%20YYYY-MM-DD%60%3B%20the%20text%20after%20the%20dash%20must%20be%20an%20ISO%208601%20date.%20Using%20prose%20here%20breaks%20changelog%20parsers%20and%20is%20inconsistent%20with%20every%20other%20entry.%20The%20actual%20release%20date%20can%20be%20retrieved%20with%20%60git%20log%20-1%20--format%3D%25as%20v0.1.0%60.%0A%0A%60%60%60suggestion%0A%23%23%20%5B0.1.0%5D%20-%20YYYY-MM-DD%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0ACHANGELOG.md%3A35-41%0ANon-standard%20subsection%20heading%20%60%23%23%23%20CI%20%2F%20Infra%60.%20The%20Keep%20a%20Changelog%20spec%20defines%20exactly%20six%20permitted%20subsection%20types%3A%20%60Added%60%2C%20%60Changed%60%2C%20%60Deprecated%60%2C%20%60Removed%60%2C%20%60Fixed%60%2C%20and%20%60Security%60.%20A%20custom%20heading%20won't%20break%20rendering%20but%20will%20be%20silently%20skipped%20or%20flagged%20by%20strict%20changelog%20parsers.%20Consider%20folding%20these%20entries%20under%20%60%23%23%23%20Changed%60%20%28infrastructure%20changes%29%20or%20%60%23%23%23%20Added%60%20where%20appropriate%2C%20to%20stay%20within%20the%20spec%20the%20file's%20own%20preamble%20cites.%0A%0A%23%23%23%20Issue%204%20of%204%0Adocs%2FRELEASING.md%3A29-33%0ACommit%20message%20doesn't%20reflect%20the%20changelog%20update.%20Step%203%20now%20stages%20%60CHANGELOG.md%60%20alongside%20the%20version%20files%2C%20but%20the%20suggested%20commit%20message%20%60%22chore%3A%20bump%20version%20to%20X.Y.Z%22%60%20doesn't%20mention%20it.%20Consumers%20scanning%20the%20git%20log%20for%20the%20changelog%20update%20won't%20find%20it.%20A%20message%20like%20%60%22chore%3A%20bump%20version%20to%20X.Y.Z%20and%20update%20CHANGELOG%22%60%20would%20make%20the%20intent%20self-documenting.%0A%0A&repo=ishannaik%2Fagent-sweep&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fagent-sweep%22%20on%20the%20existing%20branch%20%22docs%2Fchangelog%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fchangelog%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0ACHANGELOG.md%3A119-120%0AMissing%20release%20date%20for%20%60%5B0.1.1%5D%60.%20Keep%20a%20Changelog%20requires%20every%20version%20heading%20to%20carry%20an%20ISO%208601%20date%20%28%60YYYY-MM-DD%60%29%3B%20without%20it%2C%20tools%20that%20parse%20the%20changelog%20%28e.g.%20%60git-cliff%60%2C%20%60release-drafter%60%2C%20changelog%20linters%29%20will%20treat%20this%20entry%20as%20undated%20or%20fail%20to%20parse%20it%20entirely.%20Since%20%60v0.1.1%60%20is%20between%20%60v0.1.0%60%20and%20%60v0.1.2%60%20%282026-06-12%29%2C%20its%20tag%20date%20should%20be%20available%20via%20%60git%20log%20--tags%60.%0A%0A%60%60%60suggestion%0A%23%23%20%5B0.1.1%5D%20-%20YYYY-MM-DD%0A%23%23%23%20Added%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0ACHANGELOG.md%3A123%0A%60-%20Initial%20release%60%20is%20not%20a%20valid%20date%20field.%20Keep%20a%20Changelog%20specifies%20the%20version%20header%20format%20as%20%60%23%23%20%5BX.Y.Z%5D%20-%20YYYY-MM-DD%60%3B%20the%20text%20after%20the%20dash%20must%20be%20an%20ISO%208601%20date.%20Using%20prose%20here%20breaks%20changelog%20parsers%20and%20is%20inconsistent%20with%20every%20other%20entry.%20The%20actual%20release%20date%20can%20be%20retrieved%20with%20%60git%20log%20-1%20--format%3D%25as%20v0.1.0%60.%0A%0A%60%60%60suggestion%0A%23%23%20%5B0.1.0%5D%20-%20YYYY-MM-DD%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0ACHANGELOG.md%3A35-41%0ANon-standard%20subsection%20heading%20%60%23%23%23%20CI%20%2F%20Infra%60.%20The%20Keep%20a%20Changelog%20spec%20defines%20exactly%20six%20permitted%20subsection%20types%3A%20%60Added%60%2C%20%60Changed%60%2C%20%60Deprecated%60%2C%20%60Removed%60%2C%20%60Fixed%60%2C%20and%20%60Security%60.%20A%20custom%20heading%20won't%20break%20rendering%20but%20will%20be%20silently%20skipped%20or%20flagged%20by%20strict%20changelog%20parsers.%20Consider%20folding%20these%20entries%20under%20%60%23%23%23%20Changed%60%20%28infrastructure%20changes%29%20or%20%60%23%23%23%20Added%60%20where%20appropriate%2C%20to%20stay%20within%20the%20spec%20the%20file's%20own%20preamble%20cites.%0A%0A%23%23%23%20Issue%204%20of%204%0Adocs%2FRELEASING.md%3A29-33%0ACommit%20message%20doesn't%20reflect%20the%20changelog%20update.%20Step%203%20now%20stages%20%60CHANGELOG.md%60%20alongside%20the%20version%20files%2C%20but%20the%20suggested%20commit%20message%20%60%22chore%3A%20bump%20version%20to%20X.Y.Z%22%60%20doesn't%20mention%20it.%20Consumers%20scanning%20the%20git%20log%20for%20the%20changelog%20update%20won't%20find%20it.%20A%20message%20like%20%60%22chore%3A%20bump%20version%20to%20X.Y.Z%20and%20update%20CHANGELOG%22%60%20would%20make%20the%20intent%20self-documenting.%0A%0A&repo=ishannaik%2Fagent-sweep&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0ACHANGELOG.md%3A119-120%0AMissing%20release%20date%20for%20%60%5B0.1.1%5D%60.%20Keep%20a%20Changelog%20requires%20every%20version%20heading%20to%20carry%20an%20ISO%208601%20date%20%28%60YYYY-MM-DD%60%29%3B%20without%20it%2C%20tools%20that%20parse%20the%20changelog%20%28e.g.%20%60git-cliff%60%2C%20%60release-drafter%60%2C%20changelog%20linters%29%20will%20treat%20this%20entry%20as%20undated%20or%20fail%20to%20parse%20it%20entirely.%20Since%20%60v0.1.1%60%20is%20between%20%60v0.1.0%60%20and%20%60v0.1.2%60%20%282026-06-12%29%2C%20its%20tag%20date%20should%20be%20available%20via%20%60git%20log%20--tags%60.%0A%0A%60%60%60suggestion%0A%23%23%20%5B0.1.1%5D%20-%20YYYY-MM-DD%0A%23%23%23%20Added%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0ACHANGELOG.md%3A123%0A%60-%20Initial%20release%60%20is%20not%20a%20valid%20date%20field.%20Keep%20a%20Changelog%20specifies%20the%20version%20header%20format%20as%20%60%23%23%20%5BX.Y.Z%5D%20-%20YYYY-MM-DD%60%3B%20the%20text%20after%20the%20dash%20must%20be%20an%20ISO%208601%20date.%20Using%20prose%20here%20breaks%20changelog%20parsers%20and%20is%20inconsistent%20with%20every%20other%20entry.%20The%20actual%20release%20date%20can%20be%20retrieved%20with%20%60git%20log%20-1%20--format%3D%25as%20v0.1.0%60.%0A%0A%60%60%60suggestion%0A%23%23%20%5B0.1.0%5D%20-%20YYYY-MM-DD%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0ACHANGELOG.md%3A35-41%0ANon-standard%20subsection%20heading%20%60%23%23%23%20CI%20%2F%20Infra%60.%20The%20Keep%20a%20Changelog%20spec%20defines%20exactly%20six%20permitted%20subsection%20types%3A%20%60Added%60%2C%20%60Changed%60%2C%20%60Deprecated%60%2C%20%60Removed%60%2C%20%60Fixed%60%2C%20and%20%60Security%60.%20A%20custom%20heading%20won't%20break%20rendering%20but%20will%20be%20silently%20skipped%20or%20flagged%20by%20strict%20changelog%20parsers.%20Consider%20folding%20these%20entries%20under%20%60%23%23%23%20Changed%60%20%28infrastructure%20changes%29%20or%20%60%23%23%23%20Added%60%20where%20appropriate%2C%20to%20stay%20within%20the%20spec%20the%20file's%20own%20preamble%20cites.%0A%0A%23%23%23%20Issue%204%20of%204%0Adocs%2FRELEASING.md%3A29-33%0ACommit%20message%20doesn't%20reflect%20the%20changelog%20update.%20Step%203%20now%20stages%20%60CHANGELOG.md%60%20alongside%20the%20version%20files%2C%20but%20the%20suggested%20commit%20message%20%60%22chore%3A%20bump%20version%20to%20X.Y.Z%22%60%20doesn't%20mention%20it.%20Consumers%20scanning%20the%20git%20log%20for%20the%20changelog%20update%20won't%20find%20it.%20A%20message%20like%20%60%22chore%3A%20bump%20version%20to%20X.Y.Z%20and%20update%20CHANGELOG%22%60%20would%20make%20the%20intent%20self-documenting.%0A%0A&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
CHANGELOG.md:119-120
Missing release date for `[0.1.1]`. Keep a Changelog requires every version heading to carry an ISO 8601 date (`YYYY-MM-DD`); without it, tools that parse the changelog (e.g. `git-cliff`, `release-drafter`, changelog linters) will treat this entry as undated or fail to parse it entirely. Since `v0.1.1` is between `v0.1.0` and `v0.1.2` (2026-06-12), its tag date should be available via `git log --tags`.

```suggestion
## [0.1.1] - YYYY-MM-DD
### Added
```

### Issue 2 of 4
CHANGELOG.md:123
`- Initial release` is not a valid date field. Keep a Changelog specifies the version header format as `## [X.Y.Z] - YYYY-MM-DD`; the text after the dash must be an ISO 8601 date. Using prose here breaks changelog parsers and is inconsistent with every other entry. The actual release date can be retrieved with `git log -1 --format=%as v0.1.0`.

```suggestion
## [0.1.0] - YYYY-MM-DD
```

### Issue 3 of 4
CHANGELOG.md:35-41
Non-standard subsection heading `### CI / Infra`. The Keep a Changelog spec defines exactly six permitted subsection types: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, and `Security`. A custom heading won't break rendering but will be silently skipped or flagged by strict changelog parsers. Consider folding these entries under `### Changed` (infrastructure changes) or `### Added` where appropriate, to stay within the spec the file's own preamble cites.

### Issue 4 of 4
docs/RELEASING.md:29-33
Commit message doesn't reflect the changelog update. Step 3 now stages `CHANGELOG.md` alongside the version files, but the suggested commit message `"chore: bump version to X.Y.Z"` doesn't mention it. Consumers scanning the git log for the changelog update won't find it. A message like `"chore: bump version to X.Y.Z and update CHANGELOG"` would make the intent self-documenting.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add CHANGELOG.md, backfilled from ..."](https://github.com/ishannaik/agent-sweep/commit/235304c9d3c70378225115ce464afa6de993915f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46541920)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->