### PR TITLE
feat: Add CLI rule filtering options

### DIFF
--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -262,6 +262,8 @@ def _add_common(ap: argparse.ArgumentParser) -> None:
 
 
 def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
+    from .scanner import DETECTOR_IDS, RULES
+
     ap = argparse.ArgumentParser(
         prog=f"agentsweep {verb}",
         description="Find and redact secrets in AI coding agent histories.",
@@ -323,6 +325,20 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
     ap.add_argument(
         "--no-ignore", action="store_true", help="Ignore any .agentsweepignore files."
     )
+    ap.add_argument(
+        "--exclude-rule",
+        action="append",
+        default=[],
+        metavar="RULE_ID",
+        help="Suppress findings from this rule id. Repeatable.",
+    )
+    ap.add_argument(
+        "--only-rule",
+        action="append",
+        default=[],
+        metavar="RULE_ID",
+        help="Keep only findings from this rule id. Repeatable.",
+    )
     # Redaction flags (used by `fix` / legacy --fix; harmless on `scan`).
     ap.add_argument(
         "--no-backup",
@@ -341,6 +357,20 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
     )
     args = ap.parse_args(rest)
     args.fix = verb == "fix"
+
+    if args.exclude_rule and args.only_rule:
+        ap.error("cannot use --exclude-rule with --only-rule")
+
+    all_rule_ids = {rule_id for rule_id, _display, _pattern in RULES} | set(DETECTOR_IDS)
+    unknown = sorted(
+        set(args.exclude_rule).union(args.only_rule).difference(all_rule_ids)
+    )
+    if unknown:
+        joined = ", ".join(unknown)
+        ap.error(f"unknown rule id(s): {joined} (see: agentsweep explain --list)")
+
+    args.exclude_rule = set(args.exclude_rule)
+    args.only_rule = set(args.only_rule)
 
     if args.format is not None:
         if args.json:
@@ -548,6 +578,24 @@ def _get_completion_parser() -> argparse.ArgumentParser:
     scan_p.add_argument(
         "--no-ignore", action="store_true", help="Ignore any .agentsweepignore files."
     )
+    _with_rule_id_completer(
+        scan_p.add_argument(
+            "--exclude-rule",
+            action="append",
+            default=[],
+            metavar="RULE_ID",
+            help="Suppress findings from this rule id. Repeatable.",
+        )
+    )
+    _with_rule_id_completer(
+        scan_p.add_argument(
+            "--only-rule",
+            action="append",
+            default=[],
+            metavar="RULE_ID",
+            help="Keep only findings from this rule id. Repeatable.",
+        )
+    )
     scan_p.add_argument(
         "--no-backup", action="store_true", help="Skip .bak file creation."
     )
@@ -593,6 +641,24 @@ def _get_completion_parser() -> argparse.ArgumentParser:
     )
     fix_p.add_argument(
         "--no-ignore", action="store_true", help="Ignore any .agentsweepignore files."
+    )
+    _with_rule_id_completer(
+        fix_p.add_argument(
+            "--exclude-rule",
+            action="append",
+            default=[],
+            metavar="RULE_ID",
+            help="Suppress findings from this rule id. Repeatable.",
+        )
+    )
+    _with_rule_id_completer(
+        fix_p.add_argument(
+            "--only-rule",
+            action="append",
+            default=[],
+            metavar="RULE_ID",
+            help="Keep only findings from this rule id. Repeatable.",
+        )
     )
     fix_p.add_argument(
         "--no-backup", action="store_true", help="Skip .bak file creation."

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -858,6 +858,8 @@ def _scan_file(
             finding.file = f
             finding.line = line_num
             finding.keypath = keypath
+            # --exclude-rule / --only-rule are CLI presentation filters, not
+            # ignore-file suppressions, so they do not increment `suppressed`.
             if finding.rule in exclude_rules:
                 continue
             if only_rules is not None and finding.rule not in only_rules:

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -104,8 +104,18 @@ def run(args, *, _findings_out: list | None = None,
     ignores = (ignore_mod.IgnoreSet() if _opt(args, "no_ignore")
                else ignore_mod.load([source.root, Path.cwd()]))
 
+    exclude_rules = set(_opt(args, "exclude_rule", set()))
+    only_rules = _opt(args, "only_rule", None)
+    only_rules = None if not only_rules else set(only_rules)
+
     if machine:
-        found_by_file, _, suppressed, truncated = _scan(source, files, ignores)
+        found_by_file, _, suppressed, truncated = _scan(
+            source,
+            files,
+            ignores,
+            exclude_rules=exclude_rules,
+            only_rules=only_rules,
+        )
         if truncated:
             print(f"warning: {len(truncated)} file(s) exceeded the scan budget "
                   f"and were truncated", file=sys.stderr)
@@ -126,7 +136,13 @@ def run(args, *, _findings_out: list | None = None,
     t0 = time.perf_counter()
     with ui.scan_progress(len(files)) as progress:
         found_by_file, strings_scanned, suppressed, truncated = _scan(
-            source, files, ignores, progress)
+            source,
+            files,
+            ignores,
+            progress,
+            exclude_rules=exclude_rules,
+            only_rules=only_rules,
+        )
     elapsed = time.perf_counter() - t0
 
     ui.stage(2, "ok", "SCAN", f"{len(files)} file(s)",
@@ -306,6 +322,9 @@ def run_all(args) -> int:
     report = getattr(args, "report", False)
     detected_only = bool(_opt(args, "detected", False))
     no_ignore = bool(_opt(args, "no_ignore", False))
+    exclude_rules = set(_opt(args, "exclude_rule", set()))
+    only_rules = _opt(args, "only_rule", None)
+    only_rules = None if not only_rules else set(only_rules)
 
     selected: list[tuple[str, Source]] = []
     experimental: list[str] = []
@@ -470,7 +489,11 @@ def run_all(args) -> int:
                     else ignore_mod.load([source.root, Path.cwd()])
                 )
                 found_by_file, strings_scanned, suppressed, truncated = _scan(
-                    source, files, ignores
+                    source,
+                    files,
+                    ignores,
+                    exclude_rules=exclude_rules,
+                    only_rules=only_rules,
                 )
                 return (
                     key, source, files, found_by_file,
@@ -521,7 +544,12 @@ def run_all(args) -> int:
                             progress.detection(rule_display, masked, location)
 
                 found_by_file, strings_scanned, suppressed, truncated = _scan(
-                    source, files, ignores, _LockedProgress()
+                    source,
+                    files,
+                    ignores,
+                    _LockedProgress(),
+                    exclude_rules=exclude_rules,
+                    only_rules=only_rules,
                 )
                 return (
                     key, source, files, found_by_file,
@@ -756,7 +784,15 @@ def _suggest_paths(missing: Path) -> list[str]:
     return difflib.get_close_matches(missing.name, siblings, n=3, cutoff=0.5)
 
 
-def _scan(source, files, ignores, progress=None):
+def _scan(
+    source,
+    files,
+    ignores,
+    progress=None,
+    *,
+    exclude_rules: set[str] | None = None,
+    only_rules: set[str] | None = None,
+):
     """Scan all files, wiring the progress bar + live detection feed when a
     progress object is supplied. (A multiprocessing path was evaluated and
     dropped — on Windows the spawn + per-worker regex recompile cost gave
@@ -771,8 +807,15 @@ def _scan(source, files, ignores, progress=None):
         if det is not None and fd.file is not None and fd.line is not None:
             det(fd.display, fd.masked, f"{ui.rel(fd.file, source.root)}:{fd.line}")
 
-    return _scan_all(source, files, ignores=ignores,
-                     on_file=_on_file, on_finding=_on_finding)
+    return _scan_all(
+        source,
+        files,
+        ignores=ignores,
+        on_file=_on_file,
+        on_finding=_on_finding,
+        exclude_rules=exclude_rules,
+        only_rules=only_rules,
+    )
 
 
 # A single history file rarely holds more than a few MB of actual conversation
@@ -788,6 +831,9 @@ def _scan_file(
     source: Source,
     f: Path,
     ignores,
+    *,
+    exclude_rules: set[str] | None = None,
+    only_rules: set[str] | None = None,
 ) -> tuple[Path, list[tuple[int, list, str, Finding]], int, int, bool]:
     """Scan a single file; safe to call from a thread pool worker.
 
@@ -797,6 +843,8 @@ def _scan_file(
     them on the main thread after each future completes, so Rich Live is never
     touched from a worker thread.
     """
+    exclude_rules = exclude_rules or set()
+
     items: list[tuple[int, list, str, Finding]] = []
     strings_scanned = 0
     suppressed = 0
@@ -810,6 +858,10 @@ def _scan_file(
             finding.file = f
             finding.line = line_num
             finding.keypath = keypath
+            if finding.rule in exclude_rules:
+                continue
+            if only_rules is not None and finding.rule not in only_rules:
+                continue
             if ignores:
                 fp = ignore_mod.fingerprint(relpath, line_num, finding.rule)
                 if ignores.matches(finding.rule, finding.value, fp):
@@ -835,6 +887,9 @@ def _scan_all(
     ignores=None,
     on_file=None,
     on_finding=None,
+    *,
+    exclude_rules: set[str] | None = None,
+    only_rules: set[str] | None = None,
 ) -> tuple[dict[Path, list[tuple[int, list, str, Finding]]], int, int, list[Path]]:
     out: dict[Path, list[tuple[int, list, str, Finding]]] = {}
     strings_scanned = 0
@@ -847,7 +902,13 @@ def _scan_all(
         for f in files:
             if on_file is not None:
                 on_file(f)
-            _, items, sc, sup, trunc = _scan_file(source, f, ignores)
+            _, items, sc, sup, trunc = _scan_file(
+                source,
+                f,
+                ignores,
+                exclude_rules=exclude_rules,
+                only_rules=only_rules,
+            )
             strings_scanned += sc
             suppressed += sup
             if trunc:
@@ -861,7 +922,14 @@ def _scan_all(
     workers = min(_SCAN_WORKERS, len(files))
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {
-            pool.submit(_scan_file, source, f, ignores): f
+            pool.submit(
+                _scan_file,
+                source,
+                f,
+                ignores,
+                exclude_rules=exclude_rules,
+                only_rules=only_rules,
+            ): f
             for f in files
         }
         for fut in as_completed(futures):

--- a/tests/test_rule_filter.py
+++ b/tests/test_rule_filter.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.cli import _get_completion_parser, main  # noqa: E402
+
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+GH_TOKEN = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+_SECRET_LINE = (
+    '{"type":"user","message":{"content":[{"type":"text",'
+    f'"text":"key={AWS_KEY} and token {GH_TOKEN}"' + '}]}}\n'
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
+def _mkroot(tmp_path: Path) -> Path:
+    root = tmp_path / "history"
+    root.mkdir(exist_ok=True)
+    (root / "session.jsonl").write_text(_SECRET_LINE, encoding="utf-8")
+    return root
+
+
+def _scan_json(root: Path, extra_args: list[str] | None = None, capsys=None):
+    code = main(["scan", "--root", str(root), "--json"] + (extra_args or []))
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    return code, payload, captured.err
+
+
+def test_exclude_rule_drops_matching_findings(tmp_path, capsys):
+    root = _mkroot(tmp_path)
+
+    code, payload, _err = _scan_json(
+        root,
+        extra_args=["--exclude-rule", "aws-access-key"],
+        capsys=capsys,
+    )
+
+    assert code == 1
+    assert {item["rule"] for item in payload} == {"github-pat"}
+
+
+def test_only_rule_keeps_only_named_rule(tmp_path, capsys):
+    root = _mkroot(tmp_path)
+
+    code, payload, _err = _scan_json(
+        root,
+        extra_args=["--only-rule", "aws-access-key"],
+        capsys=capsys,
+    )
+
+    assert code == 1
+    assert {item["rule"] for item in payload} == {"aws-access-key"}
+
+
+def test_unknown_rule_id_errors_out(tmp_path):
+    root = _mkroot(tmp_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["scan", "--root", str(root), "--json", "--only-rule", "not-a-rule"])
+
+    assert exc_info.value.code == 2
+
+
+def test_exclude_and_only_rule_are_mutually_exclusive(tmp_path):
+    root = _mkroot(tmp_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "scan",
+                "--root",
+                str(root),
+                "--json",
+                "--exclude-rule",
+                "aws-access-key",
+                "--only-rule",
+                "github-pat",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+
+def test_completion_parser_registers_rule_id_completer_for_filters():
+    parser = _get_completion_parser()
+    subparsers_action = next(
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+
+    for name in ("scan", "fix"):
+        subparser = subparsers_action.choices[name]
+        actions = {
+            option: action
+            for action in subparser._actions
+            for option in action.option_strings
+        }
+        assert getattr(actions["--exclude-rule"], "completer", None) is not None
+        assert getattr(actions["--only-rule"], "completer", None) is not None

--- a/tests/test_scan_all.py
+++ b/tests/test_scan_all.py
@@ -172,6 +172,26 @@ def test_scan_all_detected_includes_both_when_present(_isolate_env, capsys):
     assert sources >= {"claude-code", "codex"}
 
 
+def test_scan_all_exclude_rule_filters_aggregated_findings(_isolate_env, capsys):
+    _seed_claude(
+        _isolate_env,
+        content=(
+            '{"type":"user","message":{"content":[{"type":"text",'
+            f'"text":"key={AWS_KEY} and token {GH_TOKEN}"' + '}]}}\n'
+        ),
+    )
+
+    code, payload, _err = _scan_all_json(
+        extra=["--exclude-rule", "aws-access-key"],
+        capsys=capsys,
+    )
+
+    assert code == 1
+    assert payload
+    assert all(item["source"] == "claude-code" for item in payload)
+    assert {item["rule"] for item in payload} == {"github-pat"}
+
+
 # ---------------------------------------------------------------------------
 # (e) / (f) flag rejection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thanks for contributing to agentsweep! Fill in the sections below.
Keep PRs focused — one concern per PR (a CI fix and a feature should be
two PRs). See CONTRIBUTING.md for the project's conventions.
-->

## What & why

Adds repeatable `--exclude-rule` and `--only-rule` flags to `scan`/`fix` so a single run can suppress or isolate specific rule ids without requiring a `.agentsweepignore` file.

The filters are validated against known rule ids, wired into shell completion, threaded through the scan pipeline, and applied in `_scan_file()` alongside the existing `.agentsweepignore` check so both filtering mechanisms compose cleanly.

fixes: #120 

## Type of change

- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [x] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing

Added focused coverage in `tests/test_rule_filter.py` for:

- `--exclude-rule` filtering
- `--only-rule` filtering
- Unknown rule ID validation
- Mutual exclusion of `--exclude-rule` and `--only-rule`
- Shell completion wiring

```text
$ pytest tests/test_rule_filter.py
===================================================================== test session starts ======================================================================
platform win32 -- Python 3.13.3, pytest-9.1.1, pluggy-1.6.0
collected 5 items

tests/test_rule_filter.py .....                                                                                                                           [100%]

====================================================================== 5 passed in 0.62s =======================================================================
```

## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux and Windows, Python 3.11–3.13)
- [ ] `mypy src/` is clean — it runs on every matrix leg and is the most common reason a PR goes red
- [x] No new runtime dependency, or the PR explains why one is needed (the core install is deliberately three packages)
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [ ] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail)
- [ ] **New detection rule?** Added to `RULES` **and** `ROTATION_GUIDANCE` **and** a fixture/test, with every regex quantifier bounded (no unbounded `.*`), and the keyword pre-filter kept lossless
- [ ] **New source?** Registered in `SOURCES` with process markers, a menu entry, and a round-trip test (see CONTRIBUTING.md → "Adding a new source — checklist")
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths)
- [x] Did not re-introduce `force-include` in `pyproject.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-rule filtering for `scan` and `fix` with `--exclude-rule` (hide findings for selected rule IDs) and `--only-rule` (show findings for selected rule IDs only).
  * Enabled dynamic shell completion and rule ID validation for these options.
* **Bug Fixes**
  * Unknown rule IDs now produce a clear error.
  * `--exclude-rule` and `--only-rule` can’t be used together.
* **Tests**
  * Added coverage for CLI filtering, completion, and rule-scoped behavior in aggregated scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `--exclude-rule` and `--only-rule` CLI flags to the `scan` and `fix` subcommands, allowing users to suppress or isolate specific rule IDs in a single run without an `.agentsweepignore` file. Both flags are validated against known rule IDs, mutually exclusive at parse time, and threaded through the entire scan pipeline.

- **CLI layer** (`cli.py`): `_parse_run` validates rule IDs against `RULES | DETECTOR_IDS`, errors on unknown IDs or flag co-use, and converts lists to sets before dispatch; shell completion wired for both `scan` and `fix` subparsers.
- **Pipeline layer** (`pipeline.py`): Filters applied in `_scan_file` before the ignore-file check; both sequential and `ThreadPoolExecutor` paths pass the kwargs correctly.
- **Tests**: Five focused unit tests in `test_rule_filter.py`; `test_scan_all.py` gains a `--all`-path regression test closing the coverage gap from the prior review round.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — filters are applied consistently across all scan paths and validation is tight.

Clean additive feature with no existing behavior modified; all prior review concerns addressed.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentsweep/cli.py | Adds --exclude-rule and --only-rule flags with mutual-exclusion validation, unknown-rule-ID error reporting, and shell-completion wiring |
| src/agentsweep/pipeline.py | Threads exclude_rules/only_rules through all scan functions; both sequential and ThreadPoolExecutor paths are covered |
| tests/test_rule_filter.py | New test file covering all five key scenarios for the new flags |
| tests/test_scan_all.py | Adds --all path regression test for --exclude-rule, addressing prior review gap |

<sub>Reviews (2): Last reviewed commit: ["test: add run\_all coverage for rule filt..."](https://github.com/ishannaik/agent-sweep/commit/8bb213550822ddbe434ffac88c4025275e713b28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47398192)</sub>

<!-- /greptile_comment -->