### PR TITLE
Add glob pattern support for .agentsweepignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,11 +428,12 @@ The patterns: AWS access keys, GitHub tokens (PAT/OAuth/App/fine-grained), Strip
 A false positive you already understand should not keep showing up. Put an
 `.agentsweepignore` file in the **scan root** or your **current working
 directory** (both are read; entries merge). Each non-comment line is one of
-three forms:
+four forms:
 
 | Form | What it suppresses |
 | --- | --- |
 | `rule:<rule-id>` | Every finding from that rule |
+| `path:<pattern>` | Every finding whose relative file path matches the pattern |
 | `<relpath>:<line>:<rule>` | One exact finding — the fingerprint agentsweep prints next to each hit |
 | a bare literal | Any finding whose secret value matches |
 
@@ -443,9 +444,15 @@ Example:
 AKIAIOSFODNN7EXAMPLE
 # ignore the whole slack-webhook rule
 rule:slack-webhook
+# ignore findings in nested fixture directories
+path:*/fixtures/*
 # one exact false positive in a fixture
 tests/fixtures/claude/sample.jsonl:42:aws-access-key-id
 ```
+
+Path entries use Python `fnmatch` semantics, where `*` matches across `/` and
+`**` has no special recursive meaning. For example, use `path:*/fixtures/*`
+rather than `path:**/fixtures/**`.
 
 Copy-paste path: run a scan, copy the fingerprint printed beside the false
 positive, paste it into `.agentsweepignore`, re-scan — it will be gone. Use

--- a/src/agentsweep/ignore.py
+++ b/src/agentsweep/ignore.py
@@ -4,8 +4,12 @@ Looked up in the scan root and the current directory. Each non-comment
 line is one of:
 
     rule:<rule-id>            ignore every finding from that rule
+    path:<pattern>            ignore findings whose relative path matches
     <relpath>:<line>:<rule>   ignore one exact finding (a "fingerprint")
     <literal>                 ignore any finding whose secret value matches
+
+Path entries use fnmatch patterns, where * can match across path separators
+and ** has no special recursive meaning. For example: path:*/fixtures/*
 
 Fingerprints are what agentsweep prints next to each finding, so the
 copy-paste path is: see a false positive, paste its fingerprint into

--- a/src/agentsweep/ignore.py
+++ b/src/agentsweep/ignore.py
@@ -13,6 +13,7 @@ copy-paste path is: see a false positive, paste its fingerprint into
 """
 from __future__ import annotations
 
+import fnmatch
 from pathlib import Path
 
 IGNORE_FILENAME = ".agentsweepignore"
@@ -27,14 +28,20 @@ class IgnoreSet:
         self.rules: set[str] = set()
         self.fingerprints: set[str] = set()
         self.values: set[str] = set()
+        self.globs: list[str] = []
         self.sources: list[Path] = []
 
     def __bool__(self) -> bool:
-        return bool(self.rules or self.fingerprints or self.values)
+        return bool(self.rules or self.fingerprints or self.values or self.globs)
 
     def add_line(self, raw: str) -> None:
         line = raw.strip()
         if not line or line.startswith("#"):
+            return
+        if line.startswith("path:"):
+            glob = line[len("path:"):].strip()
+            if glob:
+                self.globs.append(glob)
             return
         if line.startswith("rule:"):
             self.rules.add(line[len("rule:"):].strip())
@@ -47,10 +54,12 @@ class IgnoreSet:
         else:
             self.values.add(line)
 
-    def matches(self, rule: str, value: str, fp: str) -> bool:
+    def matches(self, rule: str, value: str, fp: str, relpath: str = "") -> bool:
         return (rule in self.rules
                 or fp in self.fingerprints
-                or value in self.values)
+                or value in self.values
+                or any(fnmatch.fnmatch(relpath, glob) for glob in self.globs)
+                )
 
 
 def load(roots: list[Path]) -> IgnoreSet:

--- a/src/agentsweep/ignore.py
+++ b/src/agentsweep/ignore.py
@@ -32,7 +32,7 @@ class IgnoreSet:
         self.rules: set[str] = set()
         self.fingerprints: set[str] = set()
         self.values: set[str] = set()
-        self.globs: list[str] = []
+        self.globs: set[str] = set()
         self.sources: list[Path] = []
 
     def __bool__(self) -> bool:
@@ -42,27 +42,34 @@ class IgnoreSet:
         line = raw.strip()
         if not line or line.startswith("#"):
             return
-        if line.startswith("path:"):
-            glob = line[len("path:"):].strip()
-            if glob:
-                self.globs.append(glob)
-            return
+
         if line.startswith("rule:"):
             self.rules.add(line[len("rule:"):].strip())
             return
+
         # A fingerprint is "<path>:<line>:<rule>" — last segment a rule id,
         # second-to-last an integer line number. Anything else is a literal.
         parts = line.rsplit(":", 2)
         if len(parts) == 3 and parts[1].isdigit():
             self.fingerprints.add(line)
-        else:
-            self.values.add(line)
+            return
 
+        if line.startswith("path:"):
+            glob = line[len("path:"):].strip()
+            if glob:
+                self.globs.add(glob)
+            return
+
+        self.values.add(line)
+        
     def matches(self, rule: str, value: str, fp: str, relpath: str = "") -> bool:
         return (rule in self.rules
                 or fp in self.fingerprints
                 or value in self.values
-                or any(fnmatch.fnmatch(relpath, glob) for glob in self.globs)
+                or any(
+                    fnmatch.fnmatch(relpath.replace("\\", "/"), glob)
+                    for glob in self.globs
+                )
                 )
 
 

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -949,7 +949,7 @@ def _scan_file(
                 continue
             if ignores:
                 fp = ignore_mod.fingerprint(relpath, line_num, finding.rule)
-                if ignores.matches(finding.rule, finding.value, fp):
+                if ignores.matches(finding.rule, finding.value, fp, relpath):
                     suppressed += 1
                     continue
             items.append((line_num, keypath, value, finding))

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -107,8 +107,8 @@ class TestIgnoreSetAddLine:
         
     def test_path_prefix_goes_to_globs(self):
         ig = IgnoreSet()
-        ig.add_line("path:**/fixtures/**")
-        assert "**/fixtures/**" in ig.globs
+        ig.add_line("path:*/fixtures/*")
+        assert "*/fixtures/*" in ig.globs
         assert not ig.rules
         assert not ig.fingerprints
         assert not ig.values
@@ -189,12 +189,23 @@ class TestIgnoreSetMatches:
 
     def test_path_glob_matches_relpath(self):
         ig = IgnoreSet()
-        ig.add_line("path:**/fixtures/**")
+        ig.add_line("path:*/fixtures/*")
         assert ig.matches(
             "aws-access-key",
             AWS_KEY,
             "tests/fixtures/sample.jsonl:1:aws-access-key",
             "tests/fixtures/sample.jsonl",
+        )
+        
+    def test_path_glob_does_not_match_other_paths(self):
+        ig = IgnoreSet()
+        ig.add_line("path:*/fixtures/*")
+
+        assert not ig.matches(
+            "aws-access-key",
+            AWS_KEY,
+            "tests/other/sample.jsonl:1:aws-access-key",
+            "tests/other/sample.jsonl",
         )
     
     def test_no_match_returns_false(self):
@@ -328,6 +339,36 @@ class TestFingerprintSuppression:
         assert "1" in err2 and "suppressed" in err2
 
 
+class TestPathGlobSuppression:
+    """path:<pattern> suppresses findings based on their relative file path."""
+
+    def test_path_glob_suppresses_matching_file(self, tmp_path, capsys):
+        root = _mkroot(tmp_path, _AWS_ONLY_LINE)
+        (root / IGNORE_FILENAME).write_text(
+            "path:*.jsonl\n",
+            encoding="utf-8",
+        )
+
+        code, payload, err = _scan_json(root, capsys=capsys)
+
+        assert code == 0
+        assert payload == []
+        assert "1" in err and "suppressed" in err
+
+    def test_path_glob_does_not_suppress_non_matching_file(self, tmp_path, capsys):
+        root = _mkroot(tmp_path, _AWS_ONLY_LINE)
+        (root / IGNORE_FILENAME).write_text(
+            "path:*.txt\n",
+            encoding="utf-8",
+        )
+
+        code, payload, err = _scan_json(root, capsys=capsys)
+
+        assert code == 1
+        assert any(f["rule"] == "aws-access-key" for f in payload)
+        assert "suppressed" not in err
+        
+        
 class TestLiteralValueSuppression:
     """A bare literal value line suppresses any finding whose secret matches."""
 

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -104,6 +104,14 @@ class TestIgnoreSetAddLine:
         ig = IgnoreSet()
         ig.add_line("rule: aws-access-key ")
         assert "aws-access-key" in ig.rules
+        
+    def test_path_prefix_goes_to_globs(self):
+        ig = IgnoreSet()
+        ig.add_line("path:**/fixtures/**")
+        assert "**/fixtures/**" in ig.globs
+        assert not ig.rules
+        assert not ig.fingerprints
+        assert not ig.values
 
     def test_fingerprint_pattern_goes_to_fingerprints(self):
         ig = IgnoreSet()
@@ -179,6 +187,16 @@ class TestIgnoreSetMatches:
         # does NOT match a different secret value
         assert not ig.matches("aws-access-key", "AKIAOTHER12345678901", "f:1:aws-access-key")
 
+    def test_path_glob_matches_relpath(self):
+        ig = IgnoreSet()
+        ig.add_line("path:**/fixtures/**")
+        assert ig.matches(
+            "aws-access-key",
+            AWS_KEY,
+            "tests/fixtures/sample.jsonl:1:aws-access-key",
+            "tests/fixtures/sample.jsonl",
+        )
+    
     def test_no_match_returns_false(self):
         ig = IgnoreSet()
         ig.add_line("rule:aws-access-key")

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -157,6 +157,20 @@ class TestIgnoreSetAddLine:
         ig = IgnoreSet()
         ig.add_line(AWS_KEY)
         assert ig
+        
+    def test_bool_true_when_has_glob(self):
+        ig = IgnoreSet()
+        ig.add_line("path:*/fixtures/*")
+        assert ig
+        
+    def test_file_named_path_is_classified_as_fingerprint(self):
+        ig = IgnoreSet()
+        ig.add_line("path:1:aws-access-key")
+
+        assert "path:1:aws-access-key" in ig.fingerprints
+        assert not ig.globs
+        assert not ig.rules
+        assert not ig.values
 
 
 class TestIgnoreSetMatches:
@@ -195,6 +209,17 @@ class TestIgnoreSetMatches:
             AWS_KEY,
             "tests/fixtures/sample.jsonl:1:aws-access-key",
             "tests/fixtures/sample.jsonl",
+        )
+        
+    def test_path_glob_matches_windows_separators(self):
+        ig = IgnoreSet()
+        ig.add_line("path:*/fixtures/*")
+
+        assert ig.matches(
+            "aws-access-key",
+            AWS_KEY,
+            r"tests\fixtures\sample.jsonl:1:aws-access-key",
+            r"tests\fixtures\sample.jsonl",
         )
         
     def test_path_glob_does_not_match_other_paths(self):


### PR DESCRIPTION
<!--
Thanks for contributing to agentsweep! Fill in the sections below.
Keep PRs focused — one concern per PR (a CI fix and a feature should be
two PRs). See CONTRIBUTING.md for the project's conventions.
-->

## What & why

<!-- One or two sentences: what this changes and why. Link any issue, e.g. "Closes #12". -->
This PR adds glob pattern support for `.agentsweepignore` using `path:` entries.

It allows findings to be ignored based on relative file paths in addition to existing rule, fingerprint, and value matching.

Closes #125

## Type of change

- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [x] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing

<!-- How did you verify this? Paste the relevant `pytest` summary. -->

```
uv run pytest tests/test_ignore.py -v
62 passed

uv run pytest
608 passed
```

## Checklist

- [ ] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13)
- [ ] `mypy src/` is clean — it runs on every matrix leg and is the most common reason a PR goes red
- [x] No new runtime dependency, or the PR explains why one is needed (the core install is deliberately three packages)
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [x] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail)
- [ ] **New detection rule?** Added to `RULES` **and** `ROTATION_GUIDANCE` **and** a fixture/test, with every regex quantifier bounded (no unbounded `.*`), and the keyword pre-filter kept lossless
- [ ] **New source?** Registered in `SOURCES` with process markers, a menu entry, and a round-trip test (see CONTRIBUTING.md → "Adding a new source — checklist")
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths)
- [x] Did not re-introduce `force-include` in `pyproject.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `path:<pattern>` entries in `.agentsweepignore`.
  * Path-based rules can suppress findings in matching relative file paths.
  * Suppression results now report the number of findings ignored by matching paths.
  * Supports path matching across common path separator formats.

* **Documentation**
  * Added guidance and examples for path glob patterns, including matching behavior.

* **Tests**
  * Added coverage for matching and non-matching path-based ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `path:<pattern>` as a fourth entry format in `.agentsweepignore`, enabling users to suppress findings across entire sets of files using `fnmatch` glob patterns. The implementation correctly handles Windows path separator normalization and deduplicates patterns via a `set`.

- **`ignore.py`**: Adds a `globs: set[str]` field, parses `path:` entries in `add_line`, and applies them via `fnmatch.fnmatch` in `matches`, with `replace("\\", "/")` for Windows compat.
- **`pipeline.py`**: Threads the pre-computed `relpath` into `ignores.matches()` at the single call site.
- **`tests/test_ignore.py`**: Adds unit tests for classification, boolean truthiness, Windows separators, negative-match assertions, and two end-to-end integration tests in `TestPathGlobSuppression`.
</details>

<h3>Confidence Score: 4/5</h3>

- Safe to merge with a small follow-up fix for the fingerprint/glob ordering edge case.
- All previously-identified gaps (Windows normalization, set vs list, bool coverage, negative-match tests, end-to-end integration test) have been resolved. One remaining issue: the fingerprint heuristic fires before the `path:` prefix check, so a glob like `path:2023:logs` is silently added to `fingerprints` instead of `globs`, making the new feature non-functional for that pattern class. The fix is a reordering of two `if` blocks in `add_line`.
- `src/agentsweep/ignore.py` — the ordering of the fingerprint heuristic vs the `path:` prefix check in `add_line`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentsweep/ignore.py | Core feature implementation: adds `globs` set, parses `path:` entries, applies fnmatch matching with Windows normalization. The fingerprint check runs before the `path:` check, so `path:<digit>:<anything>` is misclassified as a fingerprint, but this edge case is explicitly tested and accepted by the author. |
| src/agentsweep/pipeline.py | Minimal one-line change to thread `relpath` into `ignores.matches()`. Correct and safe — `relpath` is already computed above the loop. |
| tests/test_ignore.py | Good coverage added: classification, bool truthiness, Windows separator test, negative-match assertion, and two end-to-end integration tests in TestPathGlobSuppression. |
| README.md | Documents the new `path:` entry type with accurate fnmatch semantics, a practical example, and a clarifying note about `**` not being recursive. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["add_line(raw)"] --> B{starts with rule:?}
    B -- Yes --> C[rules.add]
    B -- No --> D{3-part fingerprint?\nrsplit colon 2, middle is digit}
    D -- Yes --> E[fingerprints.add]
    D -- No --> F{starts with path:?}
    F -- Yes --> G{glob empty?}
    G -- No --> H[globs.add]
    G -- Yes --> I[silently skip]
    F -- No --> J[values.add]

    K["matches(rule, value, fp, relpath)"] --> L{rule in rules?}
    L -- Yes --> M[return True]
    L -- No --> N{fp in fingerprints?}
    N -- Yes --> M
    N -- No --> O{value in values?}
    O -- Yes --> M
    O -- No --> P{"any fnmatch(relpath.replace('\\\\','/'), glob)\nfor glob in globs"}
    P -- Yes --> M
    P -- No --> Q[return False]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fagentsweep%2Fignore.py%3A52-61%0A**%60path%3A%60%20check%20silently%20loses%20when%20glob%20starts%20with%20%60%3Cdigit%3E%3A%3Ctoken%3E%60**%0A%0AThe%20fingerprint%20heuristic%20%28%60rsplit%28%22%3A%22%2C%202%29%60%20%2B%20%60parts%5B1%5D.isdigit%28%29%60%29%20runs%20before%20the%20%60path%3A%60%20prefix%20check%2C%20so%20a%20line%20like%20%60path%3A2023%3Alogs%60%20is%20parsed%20as%20three%20parts%20%60%5B%22path%22%2C%20%222023%22%2C%20%22logs%22%5D%60%2C%20%60%222023%22.isdigit%28%29%60%20is%20True%2C%20and%20the%20entry%20lands%20in%20%60fingerprints%60%20instead%20of%20%60globs%60.%20The%20user's%20glob%20pattern%20is%20silently%20discarded.%20This%20affects%20any%20pattern%20where%20the%20first%20segment%20of%20the%20glob%20%28before%20the%20first%20%60%3A%60%29%20is%20a%20pure%20integer%20%E2%80%94%20e.g.%2C%20%60path%3A1%3A*%60%20or%20%60path%3A2024%3Aarchive%60.%20Moving%20the%20%60path%3A%60%20check%20above%20the%20fingerprint%20block%20removes%20the%20ambiguity%2C%20at%20the%20cost%20that%20a%20pre-existing%20fingerprint%20for%20a%20file%20literally%20named%20%60path%60%20%28i.e.%2C%20%60path%3A1%3Asome-rule%60%29%20would%20now%20be%20treated%20as%20a%20glob%3B%20that%20trade-off%20is%20almost%20certainly%20correct%20since%20%60path%60%20as%20a%20bare%20filename%20is%20far%20less%20common%20than%20explicit%20%60path%3A%60%20glob%20entries.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fagent-sweep&pr=163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fagent-sweep%22%20on%20the%20existing%20branch%20%22add-glob-pattern-support%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22add-glob-pattern-support%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fagentsweep%2Fignore.py%3A52-61%0A**%60path%3A%60%20check%20silently%20loses%20when%20glob%20starts%20with%20%60%3Cdigit%3E%3A%3Ctoken%3E%60**%0A%0AThe%20fingerprint%20heuristic%20%28%60rsplit%28%22%3A%22%2C%202%29%60%20%2B%20%60parts%5B1%5D.isdigit%28%29%60%29%20runs%20before%20the%20%60path%3A%60%20prefix%20check%2C%20so%20a%20line%20like%20%60path%3A2023%3Alogs%60%20is%20parsed%20as%20three%20parts%20%60%5B%22path%22%2C%20%222023%22%2C%20%22logs%22%5D%60%2C%20%60%222023%22.isdigit%28%29%60%20is%20True%2C%20and%20the%20entry%20lands%20in%20%60fingerprints%60%20instead%20of%20%60globs%60.%20The%20user's%20glob%20pattern%20is%20silently%20discarded.%20This%20affects%20any%20pattern%20where%20the%20first%20segment%20of%20the%20glob%20%28before%20the%20first%20%60%3A%60%29%20is%20a%20pure%20integer%20%E2%80%94%20e.g.%2C%20%60path%3A1%3A*%60%20or%20%60path%3A2024%3Aarchive%60.%20Moving%20the%20%60path%3A%60%20check%20above%20the%20fingerprint%20block%20removes%20the%20ambiguity%2C%20at%20the%20cost%20that%20a%20pre-existing%20fingerprint%20for%20a%20file%20literally%20named%20%60path%60%20%28i.e.%2C%20%60path%3A1%3Asome-rule%60%29%20would%20now%20be%20treated%20as%20a%20glob%3B%20that%20trade-off%20is%20almost%20certainly%20correct%20since%20%60path%60%20as%20a%20bare%20filename%20is%20far%20less%20common%20than%20explicit%20%60path%3A%60%20glob%20entries.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fagent-sweep&pr=163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fagentsweep%2Fignore.py%3A52-61%0A**%60path%3A%60%20check%20silently%20loses%20when%20glob%20starts%20with%20%60%3Cdigit%3E%3A%3Ctoken%3E%60**%0A%0AThe%20fingerprint%20heuristic%20%28%60rsplit%28%22%3A%22%2C%202%29%60%20%2B%20%60parts%5B1%5D.isdigit%28%29%60%29%20runs%20before%20the%20%60path%3A%60%20prefix%20check%2C%20so%20a%20line%20like%20%60path%3A2023%3Alogs%60%20is%20parsed%20as%20three%20parts%20%60%5B%22path%22%2C%20%222023%22%2C%20%22logs%22%5D%60%2C%20%60%222023%22.isdigit%28%29%60%20is%20True%2C%20and%20the%20entry%20lands%20in%20%60fingerprints%60%20instead%20of%20%60globs%60.%20The%20user's%20glob%20pattern%20is%20silently%20discarded.%20This%20affects%20any%20pattern%20where%20the%20first%20segment%20of%20the%20glob%20%28before%20the%20first%20%60%3A%60%29%20is%20a%20pure%20integer%20%E2%80%94%20e.g.%2C%20%60path%3A1%3A*%60%20or%20%60path%3A2024%3Aarchive%60.%20Moving%20the%20%60path%3A%60%20check%20above%20the%20fingerprint%20block%20removes%20the%20ambiguity%2C%20at%20the%20cost%20that%20a%20pre-existing%20fingerprint%20for%20a%20file%20literally%20named%20%60path%60%20%28i.e.%2C%20%60path%3A1%3Asome-rule%60%29%20would%20now%20be%20treated%20as%20a%20glob%3B%20that%20trade-off%20is%20almost%20certainly%20correct%20since%20%60path%60%20as%20a%20bare%20filename%20is%20far%20less%20common%20than%20explicit%20%60path%3A%60%20glob%20entries.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/agentsweep/ignore.py:52-61
**`path:` check silently loses when glob starts with `<digit>:<token>`**

The fingerprint heuristic (`rsplit(":", 2)` + `parts[1].isdigit()`) runs before the `path:` prefix check, so a line like `path:2023:logs` is parsed as three parts `["path", "2023", "logs"]`, `"2023".isdigit()` is True, and the entry lands in `fingerprints` instead of `globs`. The user's glob pattern is silently discarded. This affects any pattern where the first segment of the glob (before the first `:`) is a pure integer — e.g., `path:1:*` or `path:2024:archive`. Moving the `path:` check above the fingerprint block removes the ambiguity, at the cost that a pre-existing fingerprint for a file literally named `path` (i.e., `path:1:some-rule`) would now be treated as a glob; that trade-off is almost certainly correct since `path` as a bare filename is far less common than explicit `path:` glob entries.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Address review feedback for path ignore ..."](https://github.com/ishannaik/agent-sweep/commit/30c975b650b90006aa4a33bb966647b616426eff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47617691)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->