### PR TITLE
perf: defer SOURCES and urllib.request imports off the -V path

### DIFF
--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -28,15 +28,20 @@ import argparse
 import json
 import sys
 import threading
-import urllib.request
 from pathlib import Path
 
 from . import __version__
-from .sources import SOURCES
 
 VERBS = {"scan", "fix", "undo", "purge"}
 
 _PYPI_URL = "https://pypi.org/pypi/agentsweep/json"
+
+
+def _sources() -> dict:
+    """Lazy accessor for the SOURCES registry (avoids import cost on -V)."""
+    from .sources import SOURCES
+
+    return SOURCES
 
 
 def check_for_update(timeout: int = 2) -> tuple[str | None, str | None]:
@@ -45,6 +50,8 @@ def check_for_update(timeout: int = 2) -> tuple[str | None, str | None]:
     Fetches PyPI metadata synchronously.  On any failure returns
     (None, error_string) so the caller can decide whether to surface it.
     """
+    import urllib.request
+
     try:
         with urllib.request.urlopen(_PYPI_URL, timeout=timeout) as resp:  # nosec B310 # _PYPI_URL is a hardcoded https:// constant, never user input
             data = json.loads(resp.read())
@@ -91,6 +98,8 @@ def _background_update_notice(args: argparse.Namespace) -> None:
     result: list[str | None] = [None]  # mutable box for thread result
 
     def _fetch() -> None:
+        import urllib.request
+
         try:
             with urllib.request.urlopen(_PYPI_URL, timeout=1.5) as resp:  # nosec B310 # _PYPI_URL is a hardcoded https:// constant, never user input
                 data = json.loads(resp.read())
@@ -252,7 +261,7 @@ def _route(argv: list[str]) -> tuple[str, list[str]]:
 def _add_common(ap: argparse.ArgumentParser) -> None:
     ap.add_argument(
         "--source",
-        choices=list(SOURCES),
+        choices=list(_sources()),
         default="claude-code",
         help="Which agent's history (default: claude-code).",
     )
@@ -270,7 +279,7 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
     # default when validating mutual exclusion with --all.
     ap.add_argument(
         "--source",
-        choices=list(SOURCES),
+        choices=list(_sources()),
         default=None,
         help="Which agent's history (default: claude-code).",
     )
@@ -476,7 +485,7 @@ def _parse_purge(rest: list[str]) -> argparse.Namespace:
 
 def source_completer(prefix: str, **kwargs) -> list[str]:
     """Dynamically complete --source values from the SOURCES registry."""
-    return [s for s in SOURCES if s.startswith(prefix)]
+    return [s for s in _sources() if s.startswith(prefix)]
 
 
 def rule_id_completer(prefix: str, **kwargs) -> list[str]:
@@ -513,7 +522,7 @@ def _get_completion_parser() -> argparse.ArgumentParser:
     scan_p = subparsers.add_parser("scan", description="Scan history files.")
     scan_source = scan_p.add_argument(
         "--source",
-        choices=list(SOURCES),
+        choices=list(_sources()),
         default=None,
         help="Which agent's history (default: claude-code).",
     )
@@ -562,7 +571,7 @@ def _get_completion_parser() -> argparse.ArgumentParser:
     fix_p = subparsers.add_parser("fix", description="Redact secrets in history.")
     fix_source = fix_p.add_argument(
         "--source",
-        choices=list(SOURCES),
+        choices=list(_sources()),
         default=None,
         help="Which agent's history (default: claude-code).",
     )
@@ -608,7 +617,7 @@ def _get_completion_parser() -> argparse.ArgumentParser:
     undo_p = subparsers.add_parser("undo", description="Restore backups.")
     undo_source = undo_p.add_argument(
         "--source",
-        choices=list(SOURCES),
+        choices=list(_sources()),
         default="claude-code",
         help="Which agent's history.",
     )
@@ -621,7 +630,7 @@ def _get_completion_parser() -> argparse.ArgumentParser:
     purge_p = subparsers.add_parser("purge", description="Delete backups.")
     purge_source = purge_p.add_argument(
         "--source",
-        choices=list(SOURCES),
+        choices=list(_sources()),
         default="claude-code",
         help="Which agent's history.",
     )


### PR DESCRIPTION
## Summary

Fixes #137

The `-V` / `--version` branch returns before any verb dispatch, but it still paid for two module-level imports it never uses:

- `from .sources import SOURCES` (~45 ms — drags in the sqlite helpers and the http stack)
- `import urllib.request` (~34 ms — only used by the update check)

Both are now lazy:

- `SOURCES` goes through a small `_sources()` accessor. The argparse `choices` lists and the shell completer call it on demand.
- `urllib.request` is imported inside `check_for_update()` and the background `_fetch()` closure — the only two call sites.

`rich` and `argcomplete` were already lazy on this path, so they are untouched.

## Verification

`python -X importtime` confirms neither `agentsweep.sources` nor `urllib.request` loads on `-V` anymore:

```
$ python -X importtime -c 'from agentsweep.cli import main; main(["-V"])' 2>&1 | grep -E 'agentsweep.sources|urllib.request'
(no output)
```

`-V` cold start measured at ~15–17 ms.

## Test plan

- [x] `agentsweep -V` still prints the version
- [x] `pytest tests/test_cli_gates.py tests/test_list_sources.py tests/test_explain.py` — 19 passed
- [x] `python -X importtime` confirms both imports are gone from the `-V` path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced startup overhead by loading agent sources and update-checking utilities only when needed.
* **Bug Fixes**
  * Improved command-line source selection and shell completion reliability.
  * Preserved background update checks while minimizing unnecessary startup work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR defers two module-level imports — `from .sources import SOURCES` and `import urllib.request` — off the `-V`/`--version` hot path, reducing cold-start latency from ~80 ms to ~15–17 ms.

- `SOURCES` is now accessed via a `_sources()` accessor that wraps a local `from .sources import SOURCES`; all six `choices=list(SOURCES)` call sites in the parser helpers are updated to call `_sources()` instead.
- `urllib.request` is imported inline inside `check_for_update()` and the `_fetch()` background-thread closure — the only two call sites — so it is no longer loaded on paths that never touch the network.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; the lazy-import pattern is correct and the -V early-return path is unambiguously free of both deferred imports.

The change is mechanically straightforward and the optimization goal is fully achieved. The only observations are cosmetic: _sources() is invoked four separate times inside _get_completion_parser() where a single local binding would suffice, and its return annotation uses the bare dict instead of the parameterized form.

**Files Needing Attention:** No files require special attention; src/agentsweep/cli.py is the only changed file and the logic is easy to follow.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/agentsweep/cli.py | Defers `from .sources import SOURCES` and `import urllib.request` to call-time via a `_sources()` accessor and inline imports; the `-V` early-return path is correctly unaffected. Minor: `_sources()` is invoked 4 times inside `_get_completion_parser()` and has an imprecise `dict` return annotation. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/agentsweep/cli.py`, line 521-525 ([link](https://github.com/ishannaik/agent-sweep/blob/09594af208871b5ed7c80813fe218488fd6bede1/src/agentsweep/cli.py#L521-L525)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `_sources()` is called four separate times inside `_get_completion_parser()`. Python's module cache means only the first call pays the import cost, but each subsequent call still re-executes `from .sources import SOURCES` (a dict lookup + attribute access). Hoisting one call to a local saves the redundant lookups and signals to readers that all four `choices` lists are identical slices of the same registry.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/agentsweep/cli.py
   Line: 521-525

   Comment:
   `_sources()` is called four separate times inside `_get_completion_parser()`. Python's module cache means only the first call pays the import cost, but each subsequent call still re-executes `from .sources import SOURCES` (a dict lookup + attribute access). Hoisting one call to a local saves the redundant lookups and signals to readers that all four `choices` lists are identical slices of the same registry.

   

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentsweep%2Fcli.py%0ALine%3A%20521-525%0A%0AComment%3A%0A%60_sources%28%29%60%20is%20called%20four%20separate%20times%20inside%20%60_get_completion_parser%28%29%60.%20Python's%20module%20cache%20means%20only%20the%20first%20call%20pays%20the%20import%20cost%2C%20but%20each%20subsequent%20call%20still%20re-executes%20%60from%20.sources%20import%20SOURCES%60%20%28a%20dict%20lookup%20%2B%20attribute%20access%29.%20Hoisting%20one%20call%20to%20a%20local%20saves%20the%20redundant%20lookups%20and%20signals%20to%20readers%20that%20all%20four%20%60choices%60%20lists%20are%20identical%20slices%20of%20the%20same%20registry.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20scan%0A%20%20%20%20_source_choices%20%3D%20list%28_sources%28%29%29%20%20%23%20load%20once%3B%20Python%20cache%20makes%20subsequent%20_sources%28%29%20calls%20free%20but%20this%20makes%20intent%20explicit%0A%20%20%20%20scan_p%20%3D%20subparsers.add_parser%28%22scan%22%2C%20description%3D%22Scan%20history%20files.%22%29%0A%20%20%20%20scan_source%20%3D%20scan_p.add_argument%28%0A%20%20%20%20%20%20%20%20%22--source%22%2C%0A%20%20%20%20%20%20%20%20choices%3D_source_choices%2C%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fagent-sweep&pr=164&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fagent-sweep%22%20on%20the%20existing%20branch%20%22perf%2F137-lazy-import-version%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2F137-lazy-import-version%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentsweep%2Fcli.py%0ALine%3A%20521-525%0A%0AComment%3A%0A%60_sources%28%29%60%20is%20called%20four%20separate%20times%20inside%20%60_get_completion_parser%28%29%60.%20Python's%20module%20cache%20means%20only%20the%20first%20call%20pays%20the%20import%20cost%2C%20but%20each%20subsequent%20call%20still%20re-executes%20%60from%20.sources%20import%20SOURCES%60%20%28a%20dict%20lookup%20%2B%20attribute%20access%29.%20Hoisting%20one%20call%20to%20a%20local%20saves%20the%20redundant%20lookups%20and%20signals%20to%20readers%20that%20all%20four%20%60choices%60%20lists%20are%20identical%20slices%20of%20the%20same%20registry.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20scan%0A%20%20%20%20_source_choices%20%3D%20list%28_sources%28%29%29%20%20%23%20load%20once%3B%20Python%20cache%20makes%20subsequent%20_sources%28%29%20calls%20free%20but%20this%20makes%20intent%20explicit%0A%20%20%20%20scan_p%20%3D%20subparsers.add_parser%28%22scan%22%2C%20description%3D%22Scan%20history%20files.%22%29%0A%20%20%20%20scan_source%20%3D%20scan_p.add_argument%28%0A%20%20%20%20%20%20%20%20%22--source%22%2C%0A%20%20%20%20%20%20%20%20choices%3D_source_choices%2C%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fagent-sweep&pr=164&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fagentsweep%2Fcli.py%0ALine%3A%20521-525%0A%0AComment%3A%0A%60_sources%28%29%60%20is%20called%20four%20separate%20times%20inside%20%60_get_completion_parser%28%29%60.%20Python's%20module%20cache%20means%20only%20the%20first%20call%20pays%20the%20import%20cost%2C%20but%20each%20subsequent%20call%20still%20re-executes%20%60from%20.sources%20import%20SOURCES%60%20%28a%20dict%20lookup%20%2B%20attribute%20access%29.%20Hoisting%20one%20call%20to%20a%20local%20saves%20the%20redundant%20lookups%20and%20signals%20to%20readers%20that%20all%20four%20%60choices%60%20lists%20are%20identical%20slices%20of%20the%20same%20registry.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20scan%0A%20%20%20%20_source_choices%20%3D%20list%28_sources%28%29%29%20%20%23%20load%20once%3B%20Python%20cache%20makes%20subsequent%20_sources%28%29%20calls%20free%20but%20this%20makes%20intent%20explicit%0A%20%20%20%20scan_p%20%3D%20subparsers.add_parser%28%22scan%22%2C%20description%3D%22Scan%20history%20files.%22%29%0A%20%20%20%20scan_source%20%3D%20scan_p.add_argument%28%0A%20%20%20%20%20%20%20%20%22--source%22%2C%0A%20%20%20%20%20%20%20%20choices%3D_source_choices%2C%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=164&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fagentsweep%2Fcli.py%3A521-525%0A%60_sources%28%29%60%20is%20called%20four%20separate%20times%20inside%20%60_get_completion_parser%28%29%60.%20Python's%20module%20cache%20means%20only%20the%20first%20call%20pays%20the%20import%20cost%2C%20but%20each%20subsequent%20call%20still%20re-executes%20%60from%20.sources%20import%20SOURCES%60%20%28a%20dict%20lookup%20%2B%20attribute%20access%29.%20Hoisting%20one%20call%20to%20a%20local%20saves%20the%20redundant%20lookups%20and%20signals%20to%20readers%20that%20all%20four%20%60choices%60%20lists%20are%20identical%20slices%20of%20the%20same%20registry.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20scan%0A%20%20%20%20_source_choices%20%3D%20list%28_sources%28%29%29%20%20%23%20load%20once%3B%20Python%20cache%20makes%20subsequent%20_sources%28%29%20calls%20free%20but%20this%20makes%20intent%20explicit%0A%20%20%20%20scan_p%20%3D%20subparsers.add_parser%28%22scan%22%2C%20description%3D%22Scan%20history%20files.%22%29%0A%20%20%20%20scan_source%20%3D%20scan_p.add_argument%28%0A%20%20%20%20%20%20%20%20%22--source%22%2C%0A%20%20%20%20%20%20%20%20choices%3D_source_choices%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Asrc%2Fagentsweep%2Fcli.py%3A40-44%0AThe%20return%20annotation%20%60dict%60%20is%20the%20bare%20built-in%20with%20no%20type%20parameters.%20The%20actual%20value%20is%20%60dict%5Bstr%2C%20type%5BSource%5D%5D%60%20%28as%20declared%20in%20%60sources%2F__init__.py%60%29.%20A%20more%20precise%20annotation%20makes%20callers%20and%20type-checkers%20aware%20of%20what%20keys%20and%20values%20to%20expect.%0A%0A%60%60%60suggestion%0Adef%20_sources%28%29%20-%3E%20%22dict%5Bstr%2C%20type%5D%22%3A%0A%20%20%20%20%22%22%22Lazy%20accessor%20for%20the%20SOURCES%20registry%20%28avoids%20import%20cost%20on%20-V%29.%22%22%22%0A%20%20%20%20from%20.sources%20import%20SOURCES%0A%0A%20%20%20%20return%20SOURCES%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fagent-sweep&pr=164&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fagent-sweep%22%20on%20the%20existing%20branch%20%22perf%2F137-lazy-import-version%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2F137-lazy-import-version%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fagentsweep%2Fcli.py%3A521-525%0A%60_sources%28%29%60%20is%20called%20four%20separate%20times%20inside%20%60_get_completion_parser%28%29%60.%20Python's%20module%20cache%20means%20only%20the%20first%20call%20pays%20the%20import%20cost%2C%20but%20each%20subsequent%20call%20still%20re-executes%20%60from%20.sources%20import%20SOURCES%60%20%28a%20dict%20lookup%20%2B%20attribute%20access%29.%20Hoisting%20one%20call%20to%20a%20local%20saves%20the%20redundant%20lookups%20and%20signals%20to%20readers%20that%20all%20four%20%60choices%60%20lists%20are%20identical%20slices%20of%20the%20same%20registry.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20scan%0A%20%20%20%20_source_choices%20%3D%20list%28_sources%28%29%29%20%20%23%20load%20once%3B%20Python%20cache%20makes%20subsequent%20_sources%28%29%20calls%20free%20but%20this%20makes%20intent%20explicit%0A%20%20%20%20scan_p%20%3D%20subparsers.add_parser%28%22scan%22%2C%20description%3D%22Scan%20history%20files.%22%29%0A%20%20%20%20scan_source%20%3D%20scan_p.add_argument%28%0A%20%20%20%20%20%20%20%20%22--source%22%2C%0A%20%20%20%20%20%20%20%20choices%3D_source_choices%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Asrc%2Fagentsweep%2Fcli.py%3A40-44%0AThe%20return%20annotation%20%60dict%60%20is%20the%20bare%20built-in%20with%20no%20type%20parameters.%20The%20actual%20value%20is%20%60dict%5Bstr%2C%20type%5BSource%5D%5D%60%20%28as%20declared%20in%20%60sources%2F__init__.py%60%29.%20A%20more%20precise%20annotation%20makes%20callers%20and%20type-checkers%20aware%20of%20what%20keys%20and%20values%20to%20expect.%0A%0A%60%60%60suggestion%0Adef%20_sources%28%29%20-%3E%20%22dict%5Bstr%2C%20type%5D%22%3A%0A%20%20%20%20%22%22%22Lazy%20accessor%20for%20the%20SOURCES%20registry%20%28avoids%20import%20cost%20on%20-V%29.%22%22%22%0A%20%20%20%20from%20.sources%20import%20SOURCES%0A%0A%20%20%20%20return%20SOURCES%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fagent-sweep&pr=164&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fagentsweep%2Fcli.py%3A521-525%0A%60_sources%28%29%60%20is%20called%20four%20separate%20times%20inside%20%60_get_completion_parser%28%29%60.%20Python's%20module%20cache%20means%20only%20the%20first%20call%20pays%20the%20import%20cost%2C%20but%20each%20subsequent%20call%20still%20re-executes%20%60from%20.sources%20import%20SOURCES%60%20%28a%20dict%20lookup%20%2B%20attribute%20access%29.%20Hoisting%20one%20call%20to%20a%20local%20saves%20the%20redundant%20lookups%20and%20signals%20to%20readers%20that%20all%20four%20%60choices%60%20lists%20are%20identical%20slices%20of%20the%20same%20registry.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20scan%0A%20%20%20%20_source_choices%20%3D%20list%28_sources%28%29%29%20%20%23%20load%20once%3B%20Python%20cache%20makes%20subsequent%20_sources%28%29%20calls%20free%20but%20this%20makes%20intent%20explicit%0A%20%20%20%20scan_p%20%3D%20subparsers.add_parser%28%22scan%22%2C%20description%3D%22Scan%20history%20files.%22%29%0A%20%20%20%20scan_source%20%3D%20scan_p.add_argument%28%0A%20%20%20%20%20%20%20%20%22--source%22%2C%0A%20%20%20%20%20%20%20%20choices%3D_source_choices%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Asrc%2Fagentsweep%2Fcli.py%3A40-44%0AThe%20return%20annotation%20%60dict%60%20is%20the%20bare%20built-in%20with%20no%20type%20parameters.%20The%20actual%20value%20is%20%60dict%5Bstr%2C%20type%5BSource%5D%5D%60%20%28as%20declared%20in%20%60sources%2F__init__.py%60%29.%20A%20more%20precise%20annotation%20makes%20callers%20and%20type-checkers%20aware%20of%20what%20keys%20and%20values%20to%20expect.%0A%0A%60%60%60suggestion%0Adef%20_sources%28%29%20-%3E%20%22dict%5Bstr%2C%20type%5D%22%3A%0A%20%20%20%20%22%22%22Lazy%20accessor%20for%20the%20SOURCES%20registry%20%28avoids%20import%20cost%20on%20-V%29.%22%22%22%0A%20%20%20%20from%20.sources%20import%20SOURCES%0A%0A%20%20%20%20return%20SOURCES%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=164&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/agentsweep/cli.py:521-525
`_sources()` is called four separate times inside `_get_completion_parser()`. Python's module cache means only the first call pays the import cost, but each subsequent call still re-executes `from .sources import SOURCES` (a dict lookup + attribute access). Hoisting one call to a local saves the redundant lookups and signals to readers that all four `choices` lists are identical slices of the same registry.

```suggestion
    # scan
    _source_choices = list(_sources())  # load once; Python cache makes subsequent _sources() calls free but this makes intent explicit
    scan_p = subparsers.add_parser("scan", description="Scan history files.")
    scan_source = scan_p.add_argument(
        "--source",
        choices=_source_choices,
```

### Issue 2
src/agentsweep/cli.py:40-44
The return annotation `dict` is the bare built-in with no type parameters. The actual value is `dict[str, type[Source]]` (as declared in `sources/__init__.py`). A more precise annotation makes callers and type-checkers aware of what keys and values to expect.

```suggestion
def _sources() -> "dict[str, type]":
    """Lazy accessor for the SOURCES registry (avoids import cost on -V)."""
    from .sources import SOURCES

    return SOURCES
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: defer SOURCES and urllib.request i..."](https://github.com/ishannaik/agent-sweep/commit/09594af208871b5ed7c80813fe218488fd6bede1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47840497)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->