### PR TITLE
enhancement: adding Redact Parameter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,11 @@ agentsweep fix --allow-production --no-backup
 # Bypass soft safety checks: mtime gate (files modified <60 s ago) and running-process gate
 agentsweep fix --allow-production --force
 
+# Customize the redaction placeholder (default: [REDACTED:{rule}]); {rule} is
+# optional. Rejected up front if it contains a path separator or a control
+# character, or if {rule} substitution would fail.
+agentsweep fix --allow-production --redact-with "***{rule}***"
+
 # Combine: non-interactive JSON-mode redaction against a custom root
 agentsweep fix --root ~/history-copy --json
 ```

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -68,6 +68,32 @@ def _version_tuple(v: str) -> tuple[int, ...]:
         return (0,)
 
 
+def _validate_redact_template(value: str) -> str:
+    """Reject a --redact-with template that would corrupt the written file
+    or crash mid-redaction, before any scanning starts.
+
+    {rule} is optional (the default template uses it, but a fixed string
+    like "[SECRET]" is valid too); anything else in braces is not, since
+    str.format() would raise on it deep inside the write path instead of
+    here at parse time.
+    """
+    if "/" in value or "\\" in value:
+        raise argparse.ArgumentTypeError(
+            "--redact-with must not contain path separators (/ or \\)"
+        )
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in value):
+        raise argparse.ArgumentTypeError(
+            "--redact-with must not contain control characters"
+        )
+    try:
+        value.format(rule="x")
+    except (KeyError, IndexError, ValueError) as e:
+        raise argparse.ArgumentTypeError(
+            f"--redact-with has an invalid {{placeholder}}: {e}"
+        ) from e
+    return value
+
+
 def _background_update_notice(args: argparse.Namespace) -> None:
     """Fire a background update check and print a notice before first output.
 
@@ -364,6 +390,14 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Allow --fix against the default production root.",
     )
+    ap.add_argument(
+        "--redact-with",
+        type=_validate_redact_template,
+        default=None,
+        metavar="TEMPLATE",
+        help="Custom placeholder for redacted secrets, e.g. '[SECRET]'. "
+        "{rule} is substituted if present. Default: [REDACTED:{rule}]",
+    )
     args = ap.parse_args(rest)
     args.fix = verb == "fix"
 
@@ -614,6 +648,14 @@ def _get_completion_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Allow against default production root.",
     )
+    scan_p.add_argument(
+        "--redact-with",
+        type=_validate_redact_template,
+        default=None,
+        metavar="TEMPLATE",
+        help="Custom placeholder for redacted secrets, e.g. '[SECRET]'. "
+        "{rule} is substituted if present. Default: [REDACTED:{rule}]",
+    )
 
     # fix
     fix_p = subparsers.add_parser("fix", description="Redact secrets in history.")
@@ -677,6 +719,14 @@ def _get_completion_parser() -> argparse.ArgumentParser:
         "--allow-production",
         action="store_true",
         help="Allow against default production root.",
+    )
+    fix_p.add_argument(
+        "--redact-with",
+        type=_validate_redact_template,
+        default=None,
+        metavar="TEMPLATE",
+        help="Custom placeholder for redacted secrets, e.g. '[SECRET]'. "
+        "{rule} is substituted if present. Default: [REDACTED:{rule}]",
     )
 
     # undo

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -92,9 +92,20 @@ def _validate_redact_template(value: str) -> str:
         raise argparse.ArgumentTypeError(
             "--redact-with must not contain path separators (/ or \\)"
         )
-    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in value):
+    # U+0085 (NEL), U+2028 (LINE SEPARATOR), and U+2029 (PARAGRAPH SEPARATOR)
+    # are >= 0x20 so the control-character check above doesn't catch them,
+    # but str.splitlines() treats all three as line breaks and
+    # json.dumps(..., ensure_ascii=False) writes them through raw — one of
+    # these in the template silently turns one JSON value into two lines,
+    # which fails safe_write's post-write line-count validation and aborts
+    # the redaction after the secret has already been found (but not fixed).
+    _EXTRA_LINE_BREAK_CODEPOINTS = (0x85, 0x2028, 0x2029)
+    if any(
+        ord(c) < 0x20 or ord(c) == 0x7F or ord(c) in _EXTRA_LINE_BREAK_CODEPOINTS
+        for c in value
+    ):
         raise argparse.ArgumentTypeError(
-            "--redact-with must not contain control characters"
+            "--redact-with must not contain control or line-breaking characters"
         )
     try:
         fields = list(string.Formatter().parse(value))

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import string
 import sys
 import threading
 from pathlib import Path
@@ -73,10 +74,20 @@ def _validate_redact_template(value: str) -> str:
     or crash mid-redaction, before any scanning starts.
 
     {rule} is optional (the default template uses it, but a fixed string
-    like "[SECRET]" is valid too); anything else in braces is not, since
-    str.format() would raise on it deep inside the write path instead of
-    here at parse time.
+    like "[SECRET]" is valid too). Anything else in braces is not: this
+    parses the template the same way str.format() would (string.Formatter,
+    not a regex) but only allows an exact, bare "rule" field — no
+    conversion (!r), no format spec (:>10), no attribute/index access
+    (.foo, [0]) — since those can raise mid-format (e.g. AttributeError,
+    which plain str.format(rule="x") probing wouldn't always catch: "x"
+    happens to have most of str's own attributes).
     """
+    if not value:
+        # An empty template silently no-ops via `redact_with or REDACT_TEMPLATE`
+        # in pipeline.py, but even if it didn't: an empty replacement erases
+        # all trace that a secret was ever there, defeating the point of a
+        # redaction tool (no marker means no signal anything was scrubbed).
+        raise argparse.ArgumentTypeError("--redact-with must not be empty")
     if "/" in value or "\\" in value:
         raise argparse.ArgumentTypeError(
             "--redact-with must not contain path separators (/ or \\)"
@@ -86,11 +97,19 @@ def _validate_redact_template(value: str) -> str:
             "--redact-with must not contain control characters"
         )
     try:
-        value.format(rule="x")
-    except (KeyError, IndexError, ValueError) as e:
+        fields = list(string.Formatter().parse(value))
+    except ValueError as e:
         raise argparse.ArgumentTypeError(
             f"--redact-with has an invalid {{placeholder}}: {e}"
         ) from e
+    for _literal, field_name, format_spec, conversion in fields:
+        if field_name is None:
+            continue
+        if field_name != "rule" or format_spec or conversion is not None:
+            raise argparse.ArgumentTypeError(
+                "--redact-with only supports a bare {rule} placeholder "
+                "(no conversion, format spec, attribute, or index access)"
+            )
     return value
 
 

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -193,6 +193,7 @@ def run(args, *, _findings_out: list | None = None,
         found_by_file=found_by_file,
         backup=not args.no_backup,
         force=args.force,
+        template=_opt(args, "redact_with", None) or REDACT_TEMPLATE,
     )
     if _force_recoverable_out is not None:
         _force_recoverable_out.append(recoverable)
@@ -250,6 +251,7 @@ def redact_findings(args, source: Source, found_by_file: dict, *,
         found_by_file=found_by_file,
         backup=not args.no_backup,
         force=args.force,
+        template=_opt(args, "redact_with", None) or REDACT_TEMPLATE,
     )
     if _force_recoverable_out is not None:
         _force_recoverable_out.append(recoverable)
@@ -749,6 +751,7 @@ def _fix_all_sources(args, dirty: list[tuple[str, Source, dict]]) -> int:
             found_by_file=found_by_file,
             backup=not args.no_backup,
             force=args.force,
+            template=_opt(args, "redact_with", None) or REDACT_TEMPLATE,
         )
         for status, path_display, note in rows:
             ui.redact_row(status, f"{key}: {path_display}", note)
@@ -1411,6 +1414,7 @@ def _redact_all(
     found_by_file: dict,
     backup: bool,
     force: bool,
+    template: str = REDACT_TEMPLATE,
 ) -> tuple[list[tuple[str, str, str]], int, bool]:
     """Apply redactions, returning (rows, error_count, force_recoverable).
 
@@ -1433,7 +1437,7 @@ def _redact_all(
             recoverable = recoverable or e.force_recoverable
             continue
 
-        redactions = _build_redactions(items)
+        redactions = _build_redactions(items, template)
         try:
             new_content = source.apply_redactions(path, redactions)
             record = safe_write(path, new_content, backup=backup,
@@ -1494,7 +1498,10 @@ def _preflight_gates(source: Source, source_cls: type[Source],
     return None, False
 
 
-def _build_redactions(items: list[tuple[int, list, str, Finding]]) -> list[tuple[int, list, str]]:
+def _build_redactions(
+    items: list[tuple[int, list, str, Finding]],
+    template: str = REDACT_TEMPLATE,
+) -> list[tuple[int, list, str]]:
     # Group findings by the (line, keypath) pair so multiple secrets inside one
     # string are applied in a single rewrite.
     by_loc: dict[tuple[int, tuple], tuple[str, list[Finding]]] = {}
@@ -1510,6 +1517,6 @@ def _build_redactions(items: list[tuple[int, list, str, Finding]]) -> list[tuple
         # Replace right-to-left so earlier spans' offsets stay valid.
         for fd in sorted(findings, key=lambda x: x.span[0], reverse=True):
             start, end = fd.span
-            new_val = new_val[:start] + REDACT_TEMPLATE.format(rule=fd.rule) + new_val[end:]
+            new_val = new_val[:start] + template.format(rule=fd.rule) + new_val[end:]
         redactions.append((line_num, list(kp_tuple), new_val))
     return redactions

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -234,6 +234,17 @@ def test_fix_verb_redact_with_no_placeholder(tmp_path, monkeypatch, capsys):
     "secrets\\{rule}",     # path separator (backslash)
     "{unknown_field}",     # placeholder str.format() can't resolve
     "unbalanced{",         # malformed brace
+    "{rule.foo}",          # attribute access -- naive value.format(rule="x")
+                           # probing wouldn't catch this ("x" has no .foo,
+                           # but a real rule id wouldn't either, and the
+                           # AttributeError would go uncaught mid-parse)
+    "{rule.upper}",        # attribute access on a method that DOES exist on
+                           # str -- would silently pass a naive probe
+    "{rule!r}",            # conversion
+    "{rule:>10}",          # format spec
+    "{0}",                 # positional, not the named "rule" field
+    "",                    # empty -- would silently no-op via `x or default`
+                           # in pipeline.py instead of erasing the secret
 ])
 def test_fix_verb_rejects_broken_redact_template(tmp_path, monkeypatch, bad_template):
     _no_claude(monkeypatch)

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -245,10 +245,18 @@ def test_fix_verb_redact_with_no_placeholder(tmp_path, monkeypatch, capsys):
     "{0}",                 # positional, not the named "rule" field
     "",                    # empty -- would silently no-op via `x or default`
                            # in pipeline.py instead of erasing the secret
+    chr(0x85),             # U+0085 NEL -- >= 0x20 so the plain control-char
+                           # check wouldn't catch it, but str.splitlines()
+                           # treats it as a line break and would corrupt a
+                           # JSON/JSONL write mid-redaction
+    chr(0x2028),           # U+2028 LINE SEPARATOR -- same class of bug
+    chr(0x2029),           # U+2029 PARAGRAPH SEPARATOR -- same class of bug
 ])
 def test_fix_verb_rejects_broken_redact_template(tmp_path, monkeypatch, bad_template):
     _no_claude(monkeypatch)
     root = _seed_root(tmp_path)
+    session = root / "session.jsonl"
+    original_content = session.read_text(encoding="utf-8")
     try:
         main([
             "fix", "--root", str(root), "--force", "--allow-production",
@@ -259,6 +267,12 @@ def test_fix_verb_rejects_broken_redact_template(tmp_path, monkeypatch, bad_temp
         raised = True
         assert e.code == 2
     assert raised, f"expected argparse error exit 2 for {bad_template!r}"
+    # The whole point of rejecting before scanning is that nothing gets
+    # written: the secret must still be on disk, untouched, and no .bak
+    # should exist (safe_write must never have run).
+    assert session.read_text(encoding="utf-8") == original_content
+    assert AWS_KEY in session.read_text(encoding="utf-8")
+    assert not (root / "session.jsonl.bak").exists()
 
 
 # ===========================================================================

--- a/tests/test_verbs.py
+++ b/tests/test_verbs.py
@@ -194,6 +194,62 @@ def test_fix_verb_creates_bak(tmp_path, monkeypatch, capsys):
     assert (root / "session.jsonl.bak").exists()
 
 
+def test_fix_verb_redact_with_custom_template(tmp_path, monkeypatch, capsys):
+    """--redact-with substitutes {rule}; post-write validation still passes."""
+    _no_claude(monkeypatch)
+    root = _seed_root(tmp_path)
+    session = root / "session.jsonl"
+
+    code = main([
+        "fix", "--root", str(root), "--force", "--allow-production",
+        "--redact-with", "<<HIDDEN:{rule}>>",
+    ])
+    assert code == 0
+    content = session.read_text(encoding="utf-8")
+    assert AWS_KEY not in content
+    assert "<<HIDDEN:aws-access-key>>" in content
+    # post-write validation (JSON re-parse, line count) is the real backstop;
+    # a .bak proves safe_write's validate-then-commit path completed.
+    assert (root / "session.jsonl.bak").exists()
+
+
+def test_fix_verb_redact_with_no_placeholder(tmp_path, monkeypatch, capsys):
+    """{rule} is optional -- a template with no placeholder is valid too."""
+    _no_claude(monkeypatch)
+    root = _seed_root(tmp_path)
+    session = root / "session.jsonl"
+
+    code = main([
+        "fix", "--root", str(root), "--force", "--allow-production",
+        "--redact-with", "[SECRET]",
+    ])
+    assert code == 0
+    content = session.read_text(encoding="utf-8")
+    assert AWS_KEY not in content
+    assert "[SECRET]" in content
+
+
+@pytest.mark.parametrize("bad_template", [
+    "../{rule}",           # path separator
+    "secrets\\{rule}",     # path separator (backslash)
+    "{unknown_field}",     # placeholder str.format() can't resolve
+    "unbalanced{",         # malformed brace
+])
+def test_fix_verb_rejects_broken_redact_template(tmp_path, monkeypatch, bad_template):
+    _no_claude(monkeypatch)
+    root = _seed_root(tmp_path)
+    try:
+        main([
+            "fix", "--root", str(root), "--force", "--allow-production",
+            "--redact-with", bad_template,
+        ])
+        raised = False
+    except SystemExit as e:
+        raised = True
+        assert e.code == 2
+    assert raised, f"expected argparse error exit 2 for {bad_template!r}"
+
+
 # ===========================================================================
 # (e) undo --root R
 # ===========================================================================


### PR DESCRIPTION
<!--
Thanks for contributing to agentsweep! Fill in the sections below.
Keep PRs focused — one concern per PR (a CI fix and a feature should be
two PRs). See CONTRIBUTING.md for the project's conventions.
-->

## What & why

Add `--redact-with <template>` to `fix`, letting users customize the redaction placeholder (default: `[REDACTED:{rule}]`) instead of it being fixed — useful for keeping replacement length closer to the original or using a project-specific marker. `{rule}` is substituted when present but optional; the template is validated up front (no path separators, no control characters, no unresolvable placeholders).

Closes #127

## Type of change

- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [x] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing

$ pytest tests/ -q
607 passed, 12 skipped in 6.14s

$ pytest tests/test_verbs.py -q -k "redact_with or redact_template" -v
6 passed, 31 deselected

$ ruff check src/agentsweep/cli.py src/agentsweep/pipeline.py
All checks passed!

$ mypy src/agentsweep
Success: no issues found in 28 source files


## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13)
- [x] `mypy src/` is clean — it runs on every matrix leg and is the most common reason a PR goes red
- [x] No new runtime dependency, or the PR explains why one is needed (the core install is deliberately three packages)
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [x] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail)
- [ ] **New detection rule?** Added to `RULES` **and** `ROTATION_GUIDANCE` **and** a fixture/test, with every regex quantifier bounded (no unbounded `.*`), and the keyword pre-filter kept lossless
- [ ] **New source?** Registered in `SOURCES` with process markers, a menu entry, and a round-trip test (see CONTRIBUTING.md → "Adding a new source — checklist")
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths)
- [x] Did not re-introduce `force-include` in `pyproject.toml`

---

Stuck on a review comment or want to talk through an approach? [Discord](https://discord.gg/KKvtRhQvRv).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `--redact-with` option for customizing redaction replacement text.
  - Supports optional `{rule}` substitution to include the matched rule name.
  - Templates without placeholders are supported, with the existing default preserved.
  - Custom templates work across scanning and fixing workflows, including backup creation.

- **Bug Fixes**
  - Invalid templates are now rejected before processing, including path separators, control characters, malformed braces, and unresolved placeholders.

- **Documentation**
  - Added usage and validation details for `--redact-with`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `--redact-with <template>` option to `fix` (and scan), letting users supply a custom redaction placeholder instead of the hard-coded `[REDACTED:{rule}]`. The template is validated upfront — rejecting empty strings, path separators, control/line-break characters, and any placeholder other than a bare `{rule}` — so no corruption can occur mid-redaction.

- **`cli.py`**: introduces `_validate_redact_template` using `string.Formatter().parse()` to inspect placeholder fields precisely, then registers `--redact-with` in both the live parser (`_parse_run`) and the completion parser.
- **`pipeline.py`**: threads a `template` parameter through `_redact_all` → `_build_redactions` at all three call sites; falls back to `REDACT_TEMPLATE` when the arg is absent or None.
- **`tests/test_verbs.py`**: six new tests cover custom substitution, no-placeholder mode, and 13 rejection cases including the tricky Unicode line-break code points (U+0085, U+2028, U+2029).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — validation is thorough, the template is threaded correctly through all three redaction call sites, and the empty-string gap raised in a prior review is now closed.

Validation uses string.Formatter().parse() to inspect placeholder fields structurally rather than probing with a live .format() call, which correctly rejects attribute-access forms like {rule.upper} that a naive probe would miss. All three _redact_all call sites receive the template consistently. The or REDACT_TEMPLATE fallback is safe because the validator now rejects empty strings before they can reach the pipeline.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentsweep/cli.py | Adds `_validate_redact_template` for upfront template validation and `--redact-with` argument to both `_parse_run` and `_get_completion_parser`; validation correctly rejects empty strings, path separators, control/line-break characters, and non-bare `{rule}` placeholders. |
| src/agentsweep/pipeline.py | Threads the validated `template` parameter through `_redact_all` and `_build_redactions`; all three call sites use `_opt(args, "redact_with", None) or REDACT_TEMPLATE`, falling back correctly to the default. |
| tests/test_verbs.py | Adds six tests covering custom template substitution, no-placeholder templates, and thirteen rejection cases (path separators, control characters, malformed braces, invalid placeholders, empty string). |
| README.md | Adds a one-paragraph usage example for `--redact-with` with an accurate description of `{rule}` substitution and validation constraints. |

<sub>Reviews (3): Last reviewed commit: ["feat/coder-review-fixes"](https://github.com/ishannaik/agent-sweep/commit/e9c0d15449eae32c1e598a17f5f8b232729308fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49428678)</sub>

<!-- /greptile_comment -->