### PR TITLE
enhancement: config file for persistent default flags (agentsweep.toml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,34 @@ Copy-paste path: run a scan, copy the fingerprint printed beside the false
 positive, paste it into `.agentsweepignore`, re-scan — it will be gone. Use
 `--no-ignore` to bypass both files when you want a completely fresh pass.
 
+## Config file — persistent default flags
+
+Repeating the same flags on every invocation gets old. agentsweep reads an
+optional config file for four flags that are safe to default silently:
+`source`, `no_color`, `format`, `no_ignore`.
+
+```toml
+# agentsweep.toml (or .agentsweeprc, same format) in the current directory
+source = "codex"
+no_color = true
+format = "sarif"
+no_ignore = false
+```
+
+Lookup order (first file found wins, values are never merged across files):
+
+1. `./agentsweep.toml`
+2. `./.agentsweeprc`
+3. `~/.config/agentsweep/config.toml`
+
+Precedence: **CLI flag > config file > built-in default.** Any flag you pass
+on the command line always overrides the config file.
+
+`--allow-production`, `--force`, and `--no-backup` can **never** be set from
+a config file, even if present in one (agentsweep drops them with a warning)
+— those safety gates must stay explicit on every invocation so a stale or
+shared config file can't silently weaken a redaction safety check.
+
 ## What's NOT detected
 
 - Custom/proprietary secrets without a recognizable prefix.

--- a/README.md
+++ b/README.md
@@ -449,8 +449,15 @@ positive, paste it into `.agentsweepignore`, re-scan — it will be gone. Use
 ## Config file — persistent default flags
 
 Repeating the same flags on every invocation gets old. agentsweep reads an
-optional config file for four flags that are safe to default silently:
-`source`, `no_color`, `format`, `no_ignore`.
+optional config file for four flags that are safe to default silently. TOML
+keys drop the CLI flag's leading `--` and use underscores instead of hyphens:
+
+| CLI flag | TOML key |
+| --- | --- |
+| `--source` | `source` |
+| `--no-color` | `no_color` |
+| `--format` | `format` |
+| `--no-ignore` | `no_ignore` |
 
 ```toml
 # agentsweep.toml (or .agentsweeprc, same format) in the current directory
@@ -466,8 +473,12 @@ Lookup order (first file found wins, values are never merged across files):
 2. `./.agentsweeprc`
 3. `~/.config/agentsweep/config.toml`
 
-Precedence: **CLI flag > config file > built-in default.** Any flag you pass
-on the command line always overrides the config file.
+Precedence: **CLI flag > config file > built-in default, applied per option.**
+A flag you pass on the command line always overrides the config file's value
+for *that same option* — it does not clear other configured options. A
+configured `format = "sarif"` is skipped entirely (not merged, not erroring)
+on `fix`, `--json`, or `--report` invocations, since those are incompatible
+with SARIF output; it only ever applies to a plain `scan`.
 
 `--allow-production`, `--force`, and `--no-backup` can **never** be set from
 a config file, even if present in one (agentsweep drops them with a warning)

--- a/docs/agentsweep.1
+++ b/docs/agentsweep.1
@@ -170,6 +170,15 @@ if set).
 .TP
 .I ~/.agentsweep/audit.jsonl
 Append\-only audit log of every write agentsweep performs.
+.TP
+.I ./agentsweep.toml ,\ ./.agentsweeprc ,\ ~/.config/agentsweep/config.toml
+Optional config file for persistent default flags. The first one found
+(in that order) wins; values are never merged across files. Only
+.BR --source ", " --no-color ", " --format ", and " --no-ignore
+may be set this way; CLI flags always override the config file.
+.B --allow-production ,\ --force ,\ and\ --no-backup
+can never be set from a config file, even if present \(em these safety
+gates must stay explicit on every invocation.
 .SH SEE ALSO
 Full documentation, the 193 detection rules, and the safety\-invariant list:
 .UR https://github.com/Ishannaik/agent\-sweep

--- a/docs/agentsweep.1
+++ b/docs/agentsweep.1
@@ -175,7 +175,22 @@ Append\-only audit log of every write agentsweep performs.
 Optional config file for persistent default flags. The first one found
 (in that order) wins; values are never merged across files. Only
 .BR --source ", " --no-color ", " --format ", and " --no-ignore
-may be set this way; CLI flags always override the config file.
+may be set this way, as the TOML keys
+.BR source ", " no_color ", " format ", and " no_ignore
+respectively (drop the flag's leading
+.B --
+and use an underscore in place of the hyphen). A CLI flag always overrides
+the config file's value for that same option, per invocation \(em it does
+not clear other configured options. A configured
+.B format\ =\ \(dqsarif\(dq
+is skipped (not merged, not an error) on
+.BR fix ,
+.BR --json ,
+or
+.B --report
+invocations, since SARIF is incompatible with those; it only ever applies
+to a plain
+.BR scan .
 .B --allow-production ,\ --force ,\ and\ --no-backup
 can never be set from a config file, even if present \(em these safety
 gates must stay explicit on every invocation.

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -380,7 +380,7 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
     from .config import load_config
 
     cfg = load_config()
-    if args.source is None and "source" in cfg:
+    if args.source is None and "source" in cfg and not args.all:
         args.source = cfg["source"]
     if args.no_color is None and "no_color" in cfg:
         args.no_color = cfg["no_color"]

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -217,6 +217,12 @@ def main(argv: list[str] | None = None) -> int:
             return purge(_parse_purge(rest))
 
         args = _parse_run(verb, rest)
+        # Merged in from a config file (--no-color wasn't itself passed): the
+        # earlier apply_no_color() call above only saw raw argv/env, so layer
+        # the config-derived value on top. One-directional, so this is a
+        # no-op if color was already stripped.
+        if args.no_color:
+            ui.apply_no_color(True)
         _background_update_notice(args)
         from .pipeline import run, run_all
         from .menu import offer_redaction
@@ -321,6 +327,7 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
     ap.add_argument(
         "--no-color",
         action="store_true",
+        default=None,
         help="Disable ANSI colors/styling in human output "
         "(also honored via the NO_COLOR env var).",
     )
@@ -332,7 +339,10 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
         "code scanning and SARIF viewers (scan only).",
     )
     ap.add_argument(
-        "--no-ignore", action="store_true", help="Ignore any .agentsweepignore files."
+        "--no-ignore",
+        action="store_true",
+        default=None,
+        help="Ignore any .agentsweepignore files.",
     )
     ap.add_argument(
         "--exclude-rule",
@@ -366,6 +376,26 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
     )
     args = ap.parse_args(rest)
     args.fix = verb == "fix"
+
+    from .config import load_config
+
+    cfg = load_config()
+    if args.source is None and "source" in cfg:
+        args.source = cfg["source"]
+    if args.no_color is None and "no_color" in cfg:
+        args.no_color = cfg["no_color"]
+    if args.format is None and "format" in cfg:
+        args.format = cfg["format"]
+    if args.no_ignore is None and "no_ignore" in cfg:
+        args.no_ignore = cfg["no_ignore"]
+
+    if args.source is not None and args.source not in _sources():
+        ap.error(f"argument --source: invalid choice from config file: {args.source!r}")
+    if args.format is not None and args.format not in ("sarif",):
+        ap.error(f"argument --format: invalid choice from config file: {args.format!r}")
+
+    args.no_color = bool(args.no_color)
+    args.no_ignore = bool(args.no_ignore)
 
     if args.exclude_rule and args.only_rule:
         ap.error("cannot use --exclude-rule with --only-rule")

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -89,6 +89,8 @@ def _background_update_notice(args: argparse.Namespace) -> None:
             return
         if getattr(args, "json", False):
             return
+        if getattr(args, "format", None):
+            return
         if not sys.stdout.isatty():
             return
     except Exception:
@@ -333,16 +335,24 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
     )
     ap.add_argument(
         "--format",
-        choices=["sarif"],
+        choices=["sarif", "human"],
         help="Emit findings in an interchange format instead of "
         "the default report: sarif = SARIF 2.1.0 for GitHub "
-        "code scanning and SARIF viewers (scan only).",
+        "code scanning and SARIF viewers (scan only). Pass "
+        "'human' to force the default report even when a "
+        "config file sets format = \"sarif\".",
     )
     ap.add_argument(
         "--no-ignore",
         action="store_true",
         default=None,
         help="Ignore any .agentsweepignore files.",
+    )
+    ap.add_argument(
+        "--ignore",
+        action="store_true",
+        help="Force .agentsweepignore suppression on, even if a "
+        "config file sets no_ignore = true.",
     )
     ap.add_argument(
         "--exclude-rule",
@@ -397,11 +407,22 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
 
     if args.source is not None and args.source not in _sources():
         ap.error(f"argument --source: invalid choice from config file: {args.source!r}")
-    if args.format is not None and args.format not in ("sarif",):
+    if args.format is not None and args.format not in ("sarif", "human"):
         ap.error(f"argument --format: invalid choice from config file: {args.format!r}")
+
+    # "human" is a CLI-only override that forces the default report even when
+    # a config file sets format = "sarif" — resolve it to the same "no format"
+    # state as never having set one, before it reaches any downstream check.
+    if args.format == "human":
+        args.format = None
 
     args.no_color = bool(args.no_color)
     args.no_ignore = bool(args.no_ignore)
+    # --ignore is the CLI-only override for a config file's no_ignore = true —
+    # the config-set flags need a way back to the built-in default, same as
+    # --format human does for a config-set format.
+    if getattr(args, "ignore", False):
+        args.no_ignore = False
 
     if args.exclude_rule and args.only_rule:
         ap.error("cannot use --exclude-rule with --only-rule")

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -384,7 +384,13 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
         args.source = cfg["source"]
     if args.no_color is None and "no_color" in cfg:
         args.no_color = cfg["no_color"]
-    if args.format is None and "format" in cfg:
+    if (
+        args.format is None
+        and "format" in cfg
+        and verb != "fix"
+        and not args.json
+        and not args.report
+    ):
         args.format = cfg["format"]
     if args.no_ignore is None and "no_ignore" in cfg:
         args.no_ignore = cfg["no_ignore"]

--- a/src/agentsweep/config.py
+++ b/src/agentsweep/config.py
@@ -25,6 +25,16 @@ _PROJECT_FILENAMES = ("agentsweep.toml", ".agentsweeprc")
 ALLOWED_KEYS = frozenset({"source", "no_color", "format", "no_ignore"})
 FORBIDDEN_KEYS = frozenset({"allow_production", "force", "no_backup"})
 
+# Expected TOML type per allowed key. A value of the wrong type (e.g.
+# no_color = "false", a truthy non-empty string) is dropped with a warning
+# rather than silently coerced — bool("false") is True in Python.
+_EXPECTED_TYPES: dict[str, type] = {
+    "source": str,
+    "no_color": bool,
+    "format": str,
+    "no_ignore": bool,
+}
+
 
 def _user_config_path() -> Path:
     # Resolved lazily (not at import time) so tests can monkeypatch
@@ -71,4 +81,18 @@ def load_config() -> dict:
             file=sys.stderr,
         )
 
-    return {key: data[key] for key in ALLOWED_KEYS if key in data}
+    result = {}
+    for key in ALLOWED_KEYS:
+        if key not in data:
+            continue
+        value = data[key]
+        expected = _EXPECTED_TYPES[key]
+        if not isinstance(value, expected):
+            print(
+                f"agentsweep: warning: {path} sets {key} = {value!r}, expected "
+                f"a {expected.__name__}; ignoring this key.",
+                file=sys.stderr,
+            )
+            continue
+        result[key] = value
+    return result

--- a/src/agentsweep/config.py
+++ b/src/agentsweep/config.py
@@ -1,0 +1,74 @@
+"""Optional persistent default flags: ``agentsweep.toml`` / ``.agentsweeprc``.
+
+Read, in order, from the current directory (``agentsweep.toml`` then
+``.agentsweeprc``) and finally ``~/.config/agentsweep/config.toml``. The first
+file found wins in full; values are never merged across files.
+
+Only four keys are ever honored: ``source``, ``no_color``, ``format``,
+``no_ignore`` — the flags the issue scoped as "safe to default silently".
+CLI flags always win over the config file, and the config file over the
+built-in default; see ``cli.py::_parse_run`` for the precedence merge.
+
+``allow_production``, ``force``, and ``no_backup`` are never read from a
+config file, even if present — those safety-gating flags must stay explicit
+on every invocation so a stale or malicious config file can never silently
+weaken a redaction safety gate.
+"""
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+_PROJECT_FILENAMES = ("agentsweep.toml", ".agentsweeprc")
+
+ALLOWED_KEYS = frozenset({"source", "no_color", "format", "no_ignore"})
+FORBIDDEN_KEYS = frozenset({"allow_production", "force", "no_backup"})
+
+
+def _user_config_path() -> Path:
+    # Resolved lazily (not at import time) so tests can monkeypatch
+    # HOME/USERPROFILE and so a long-lived process picks up a changed home.
+    return Path.home() / ".config" / "agentsweep" / "config.toml"
+
+
+def _find_config_path() -> Path | None:
+    for name in _PROJECT_FILENAMES:
+        candidate = Path.cwd() / name
+        if candidate.is_file():
+            return candidate
+    user_path = _user_config_path()
+    if user_path.is_file():
+        return user_path
+    return None
+
+
+def load_config() -> dict:
+    """Return the allowed config keys found in the first config file located.
+
+    Never raises: a missing, unreadable, or malformed file yields ``{}`` (with
+    a warning on stderr for the malformed/unreadable case) so a broken config
+    file can never break a normal scan.
+    """
+    path = _find_config_path()
+    if path is None:
+        return {}
+
+    try:
+        with path.open("rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        print(f"agentsweep: warning: ignoring unreadable config file {path}: {exc}",
+              file=sys.stderr)
+        return {}
+
+    forbidden_present = sorted(FORBIDDEN_KEYS & data.keys())
+    if forbidden_present:
+        joined = ", ".join(forbidden_present)
+        print(
+            f"agentsweep: warning: {path} sets {joined}, which a config file "
+            "can never control — pass these on the command line instead.",
+            file=sys.stderr,
+        )
+
+    return {key: data[key] for key in ALLOWED_KEYS if key in data}

--- a/src/agentsweep/config.py
+++ b/src/agentsweep/config.py
@@ -89,8 +89,9 @@ def load_config() -> dict:
         expected = _EXPECTED_TYPES[key]
         if not isinstance(value, expected):
             print(
-                f"agentsweep: warning: {path} sets {key} = {value!r}, expected "
-                f"a {expected.__name__}; ignoring this key.",
+                f"agentsweep: warning: {path} sets {key} to a "
+                f"{type(value).__name__}, expected a {expected.__name__}; "
+                "ignoring this key.",
                 file=sys.stderr,
             )
             continue

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,143 @@
+"""Tests for the optional agentsweep.toml / .agentsweeprc config file.
+
+Covers:
+  - config.load_config() precedence (project file over user file) and the
+    forbidden-key guard
+  - cli._parse_run() merging config values in for --source/--no-color/
+    --format/--no-ignore, with CLI flags always winning
+  - malformed config never crashes parsing
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep import config as config_mod  # noqa: E402
+from agentsweep.cli import _parse_run  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    return workdir
+
+
+def _write_project_config(workdir: Path, text: str, filename: str = "agentsweep.toml") -> Path:
+    path = workdir / filename
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_user_config(home: Path, text: str) -> Path:
+    cfg_dir = home / ".config" / "agentsweep"
+    cfg_dir.mkdir(parents=True)
+    path = cfg_dir / "config.toml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class TestLoadConfig:
+    def test_no_file_returns_empty(self):
+        assert config_mod.load_config() == {}
+
+    def test_project_file_read(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, 'source = "codex"\n')
+        assert config_mod.load_config() == {"source": "codex"}
+
+    def test_agentsweeprc_alt_filename(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, 'no_color = true\n', filename=".agentsweeprc")
+        assert config_mod.load_config() == {"no_color": True}
+
+    def test_project_file_wins_over_user_file(self, _isolated_cwd, _isolated_home):
+        _write_user_config(_isolated_home, 'source = "aider"\n')
+        _write_project_config(_isolated_cwd, 'source = "codex"\n')
+        assert config_mod.load_config() == {"source": "codex"}
+
+    def test_user_file_used_when_no_project_file(self, _isolated_home):
+        _write_user_config(_isolated_home, 'source = "aider"\n')
+        assert config_mod.load_config() == {"source": "aider"}
+
+    def test_unknown_key_ignored(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, 'made_up_flag = "x"\nsource = "codex"\n')
+        assert config_mod.load_config() == {"source": "codex"}
+
+    def test_forbidden_keys_never_returned(self, _isolated_cwd, capsys):
+        _write_project_config(
+            _isolated_cwd,
+            'allow_production = true\nforce = true\nno_backup = true\nsource = "codex"\n',
+        )
+        result = config_mod.load_config()
+        assert result == {"source": "codex"}
+        assert "allow_production" not in result
+        assert "force" not in result
+        assert "no_backup" not in result
+        err = capsys.readouterr().err
+        assert "allow_production" in err
+        assert "force" in err
+        assert "no_backup" in err
+
+    def test_malformed_toml_does_not_raise(self, _isolated_cwd, capsys):
+        _write_project_config(_isolated_cwd, "this is not [ valid toml")
+        assert config_mod.load_config() == {}
+        assert "warning" in capsys.readouterr().err
+
+
+class TestParseRunMergesConfig:
+    def test_source_from_config_applies_when_flag_omitted(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, 'source = "codex"\n')
+        args = _parse_run("scan", [])
+        assert args.source == "codex"
+
+    def test_cli_flag_overrides_config_source(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, 'source = "codex"\n')
+        args = _parse_run("scan", ["--source", "claude-code"])
+        assert args.source == "claude-code"
+
+    def test_no_color_from_config(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, "no_color = true\n")
+        args = _parse_run("scan", [])
+        assert args.no_color is True
+
+    def test_no_color_defaults_false_without_config_or_flag(self):
+        args = _parse_run("scan", [])
+        assert args.no_color is False
+
+    def test_no_ignore_from_config(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, "no_ignore = true\n")
+        args = _parse_run("scan", [])
+        assert args.no_ignore is True
+
+    def test_format_from_config(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, 'format = "sarif"\n')
+        args = _parse_run("scan", [])
+        assert args.format == "sarif"
+
+    def test_invalid_source_in_config_errors(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, 'source = "not-a-real-source"\n')
+        with pytest.raises(SystemExit):
+            _parse_run("scan", [])
+
+    def test_forbidden_keys_in_config_never_set_args(self, _isolated_cwd):
+        _write_project_config(
+            _isolated_cwd,
+            "allow_production = true\nforce = true\nno_backup = true\n",
+        )
+        args = _parse_run("fix", [])
+        assert args.allow_production is False
+        assert args.force is False
+        assert args.no_backup is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,8 @@ Covers:
 """
 from __future__ import annotations
 
+import argparse
+import json as json_mod
 import sys
 from pathlib import Path
 
@@ -16,6 +18,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
+from agentsweep import cli  # noqa: E402
 from agentsweep import config as config_mod  # noqa: E402
 from agentsweep.cli import _parse_run  # noqa: E402
 
@@ -116,6 +119,18 @@ class TestLoadConfig:
         assert "source" not in result
         assert "source" in capsys.readouterr().err
 
+    def test_type_mismatch_warning_never_echoes_the_value(self, _isolated_cwd, capsys):
+        # agentsweep redacts secrets; a mistyped config line must not get its
+        # content printed to stderr on every run. no_color expects a bool, so
+        # a string value here triggers the type-mismatch warning path.
+        secret_looking_value = "AKIAIOSFODNN7EXAMPLE"
+        _write_project_config(_isolated_cwd, f'no_color = "{secret_looking_value}"\n')
+        config_mod.load_config()
+        err = capsys.readouterr().err
+        assert secret_looking_value not in err
+        assert "no_color" in err
+        assert "str" in err
+
     def test_valid_bool_no_color_still_applies(self, _isolated_cwd):
         _write_project_config(_isolated_cwd, "no_color = false\n")
         assert config_mod.load_config() == {"no_color": False}
@@ -152,6 +167,14 @@ class TestParseRunMergesConfig:
         args = _parse_run("scan", [])
         assert args.no_ignore is True
 
+    def test_ignore_flag_overrides_config_no_ignore(self, _isolated_cwd):
+        # no_ignore=true in config is otherwise a one-way door with no CLI
+        # route back to the built-in default (there's no bare --ignore-less
+        # way to force it False) — --ignore is that route.
+        _write_project_config(_isolated_cwd, "no_ignore = true\n")
+        args = _parse_run("scan", ["--ignore"])
+        assert args.no_ignore is False
+
     def test_format_from_config(self, _isolated_cwd):
         _write_project_config(_isolated_cwd, 'format = "sarif"\n')
         args = _parse_run("scan", [])
@@ -177,6 +200,14 @@ class TestParseRunMergesConfig:
         # --report always implies JSON output regardless of the config file.
         assert args.json is True
 
+    def test_format_human_overrides_config_sarif(self, _isolated_cwd):
+        # format="sarif" in config is otherwise a one-way door: choices are
+        # ["sarif"] only downstream, so there was no CLI route back to the
+        # human report on a plain `scan`. --format human is that route.
+        _write_project_config(_isolated_cwd, 'format = "sarif"\n')
+        args = _parse_run("scan", ["--format", "human"])
+        assert args.format is None
+
     def test_invalid_source_in_config_errors(self, _isolated_cwd):
         _write_project_config(_isolated_cwd, 'source = "not-a-real-source"\n')
         with pytest.raises(SystemExit):
@@ -191,3 +222,32 @@ class TestParseRunMergesConfig:
         assert args.allow_production is False
         assert args.force is False
         assert args.no_backup is False
+
+
+class TestUpdateNoticeSkipsConfigSarif:
+    """format="sarif" is machine-readable output just like --json, and the
+    update-available banner must not get interleaved into it on a tty run
+    where the user never passed --json."""
+
+    def test_update_notice_skipped_when_format_is_sarif(self, monkeypatch, capsys):
+        import urllib.request
+
+        class _FakeResp:
+            def read(self):
+                return json_mod.dumps({"info": {"version": "99.0.0"}}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.delenv("AGENTSWEEP_NO_UPDATE", raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+        monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _FakeResp())
+
+        args = argparse.Namespace(json=False, format="sarif")
+        cli._background_update_notice(args)
+        out = capsys.readouterr().out
+
+        assert "agentsweep 99.0.0 available" not in out

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,6 +96,30 @@ class TestLoadConfig:
         assert config_mod.load_config() == {}
         assert "warning" in capsys.readouterr().err
 
+    def test_string_no_color_is_rejected_not_coerced(self, _isolated_cwd, capsys):
+        # bool("false") is True in Python — a string value must never reach
+        # args.no_color, or it silently inverts the user's intent.
+        _write_project_config(_isolated_cwd, 'no_color = "false"\n')
+        result = config_mod.load_config()
+        assert "no_color" not in result
+        assert "no_color" in capsys.readouterr().err
+
+    def test_string_no_ignore_is_rejected_not_coerced(self, _isolated_cwd, capsys):
+        _write_project_config(_isolated_cwd, 'no_ignore = "false"\n')
+        result = config_mod.load_config()
+        assert "no_ignore" not in result
+        assert "no_ignore" in capsys.readouterr().err
+
+    def test_non_string_source_is_rejected(self, _isolated_cwd, capsys):
+        _write_project_config(_isolated_cwd, "source = 42\n")
+        result = config_mod.load_config()
+        assert "source" not in result
+        assert "source" in capsys.readouterr().err
+
+    def test_valid_bool_no_color_still_applies(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, "no_color = false\n")
+        assert config_mod.load_config() == {"no_color": False}
+
 
 class TestParseRunMergesConfig:
     def test_source_from_config_applies_when_flag_omitted(self, _isolated_cwd):
@@ -106,6 +130,12 @@ class TestParseRunMergesConfig:
     def test_cli_flag_overrides_config_source(self, _isolated_cwd):
         _write_project_config(_isolated_cwd, 'source = "codex"\n')
         args = _parse_run("scan", ["--source", "claude-code"])
+        assert args.source == "claude-code"
+
+    def test_config_source_does_not_conflict_with_all(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, 'source = "codex"\n')
+        args = _parse_run("scan", ["--all"])
+        assert args.all is True
         assert args.source == "claude-code"
 
     def test_no_color_from_config(self, _isolated_cwd):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -157,6 +157,26 @@ class TestParseRunMergesConfig:
         args = _parse_run("scan", [])
         assert args.format == "sarif"
 
+    def test_config_format_does_not_conflict_with_fix(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, 'format = "sarif"\n')
+        args = _parse_run("fix", [])
+        assert args.fix is True
+        assert args.format is None
+
+    def test_config_format_does_not_conflict_with_json(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, 'format = "sarif"\n')
+        args = _parse_run("scan", ["--json"])
+        assert args.json is True
+        assert args.format is None
+
+    def test_config_format_does_not_conflict_with_report(self, _isolated_cwd):
+        _write_project_config(_isolated_cwd, 'format = "sarif"\n')
+        args = _parse_run("scan", ["--report"])
+        assert args.report is True
+        assert args.format is None
+        # --report always implies JSON output regardless of the config file.
+        assert args.json is True
+
     def test_invalid_source_in_config_errors(self, _isolated_cwd):
         _write_project_config(_isolated_cwd, 'source = "not-a-real-source"\n')
         with pytest.raises(SystemExit):


### PR DESCRIPTION
<!--
Thanks for contributing to agentsweep! Fill in the sections below.
Keep PRs focused — one concern per PR (a CI fix and a feature should be
two PRs). See CONTRIBUTING.md for the project's conventions.
-->

## What & why

Add an optional `agentsweep.toml` (or `.agentsweeprc`) / `~/.config/agentsweep/config.toml` so `--source`, `--no-color`, `--format`, and `--no-ignore` don't have to be repeated on every invocation. Lookup order: project file in cwd, then user config, first one found wins. CLI flags always override the config file. `--allow-production`, `--force`, and `--no-backup` can never be set from a config file — enforced in code (dropped with a warning even if present), not just by convention, so a stale or shared config file can't silently weaken a redaction safety gate.

Closes #121

## Type of change

- [ ] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [x] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing
$ pytest -v tests/test_config.py
16 passed in 0.42s

$ pytest -q
617 passed, 12 skipped in 6.59s

$ ruff check src/agentsweep/config.py src/agentsweep/cli.py tests/test_config.py
All checks passed!

$ mypy src/
Success: no issues found in 29 source files

$ bandit -r src/agentsweep/config.py -q
(no findings)

## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13)
- [x] `mypy src/` is clean — it runs on every matrix leg and is the most common reason a PR goes red
- [x] No new runtime dependency, or the PR explains why one is needed (the core install is deliberately three packages) — uses stdlib `tomllib` (Python ≥3.11, matches `requires-python`)
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [ ] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail) — N/A, no write-path changes
- [ ] **New detection rule?** — N/A
- [ ] **New source?** — N/A
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths)
- [x] Did not re-introduce `force-include` in `pyproject.toml`

---

Stuck on a review comment or want to talk through an approach? [Discord](https://discord.gg/KKvtRhQvRv).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent TOML configuration support at project and user locations.
  * Configurable defaults include source, output format, color, and ignore behavior.
  * Command-line options override saved configuration, with predictable handling of conflicting settings.
  * Added SARIF output support through configuration, including suppression of update notices for formatted output.

* **Bug Fixes**
  * Improved validation and warnings for malformed, unsupported, incorrectly typed, or unsafe settings.

* **Documentation**
  * Documented configuration locations, lookup precedence, supported settings, restrictions, and CLI precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds optional `agentsweep.toml` / `.agentsweeprc` / `~/.config/agentsweep/config.toml` support for persisting four flags (`source`, `no_color`, `format`, `no_ignore`). CLI flags always override the config, forbidden safety-gate keys (`allow_production`, `force`, `no_backup`) are explicitly rejected with a warning, and type mismatches are rejected rather than silently coerced.

- **`src/agentsweep/config.py`** — new loader: first-file-wins lookup, per-key type validation using `_EXPECTED_TYPES`, and defensive error handling so a broken config file never interrupts a scan.
- **`src/agentsweep/cli.py`** — post-parse config merge with guards for `--all`, `fix` verb, `--json`, and `--report`; two override escapes added (`--format human`, `--ignore`) to give users a CLI route back from config-set-only values; `_background_update_notice` extended to skip on `format="sarif"`.
- **`tests/test_config.py`** — 16 new tests covering precedence, forbidden-key rejection, type-mismatch warnings (including the secret-value-not-echoed invariant), and all merge/override paths in `_parse_run`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the config file is read-only and defensive, the merge logic is well-guarded, and the safety-gate flags are enforced in code rather than by convention.

The config loader never raises, type mismatches are caught explicitly, forbidden keys are dropped with warnings, and all four merge paths in _parse_run have guards that prevent them from clobbering explicitly-set CLI flags or conflicting with incompatible verb modes. Previous review issues around --all conflicts and bool-coercion are both addressed. The test suite covers all edge cases including the secret-not-echoed invariant.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentsweep/config.py | New config loader: finds project or user TOML file, validates types, drops forbidden keys with warnings; never raises. |
| src/agentsweep/cli.py | Merges config values into parsed args after argparse, with correct guards for --all, fix verb, --json, and --report; validates config-derived source/format and resolves "human" sentinel to None before downstream checks. |
| tests/test_config.py | Comprehensive tests covering load_config precedence, forbidden-key guard, type-mismatch rejection, and _parse_run merge semantics including override escapes (--format human, --ignore). |
| README.md | Documents config file feature: lookup order, TOML key mapping, precedence rules, and forbidden keys — accurate and concise. |
| docs/agentsweep.1 | Man-page entry for the three config file paths and feature description; no issues. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[agentsweep scan] --> B[argparse: parse CLI flags\nno_color/no_ignore default=None]
    B --> C[load_config: find first config file]
    C --> D{File found?}
    D -->|No| E[cfg equals empty dict]
    D -->|Yes| F[Parse TOML, type-check keys,\ndrop forbidden and mistyped]
    F --> E
    E --> G[Merge cfg into args\nonly where args.attr is None\nand verb guards pass]
    G --> H{args.format == human?}
    H -->|Yes| I[args.format = None]
    H -->|No| J[Validate config-derived source/format]
    I --> J
    J --> K[bool-coerce no_color and no_ignore]
    K --> L{--ignore passed?}
    L -->|Yes| M[args.no_ignore = False]
    L -->|No| N[Return args]
    M --> N
    N --> O{args.no_color is True?}
    O -->|Yes| P[ui.apply_no_color True]
    O -->|No| Q[Proceed to pipeline]
    P --> Q
```
</details>

<sub>Reviews (4): Last reviewed commit: ["feat/coder-review-fixes"](https://github.com/ishannaik/agent-sweep/commit/c2c42ad8d6cd1ca46da23fbf3073d312c5c940c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49432581)</sub>

<!-- /greptile_comment -->