### PR TITLE
fix(scan): reject file paths passed as roots

### DIFF
--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -83,6 +83,12 @@ def run(args, *, _findings_out: list | None = None,
             _print_empty_machine_output()
         return 2
 
+    if args.root is not None and not source.root.is_dir():
+        print(f"--root must be a directory, not a file: {source.root}", file=sys.stderr)
+        if machine:
+            _print_empty_machine_output()
+        return 2
+
     if not machine:
         ui.banner(__version__)
         if getattr(source, "experimental", False):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -68,6 +68,19 @@ def _many_findings_root(tmp_path: Path, n: int) -> Path:
 
 # ------------------------------------------------------------------ (a)
 
+def test_root_file_is_rejected_without_false_clean(tmp_path, capsys):
+    """A file passed as --root must fail instead of reporting a clean scan."""
+    root_file = tmp_path / "history.jsonl"
+    root_file.write_text(FIXTURE_LINE, encoding="utf-8")
+
+    code = main(["scan", "--root", str(root_file), "--json"])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert "must be a directory" in captured.err
+    assert json.loads(captured.out) == []
+
+
 def test_json_output_to_file_writes_valid_json(tmp_path, capsys):
     """scan --json -o FILE → valid JSON written to FILE with fingerprint/rule/masked."""
     root = _mkroot(tmp_path)


### PR DESCRIPTION
## Problem

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR rejects explicitly supplied scan roots that resolve to files, preventing them from being treated as clean scans.
- Adds an early directory validation with a diagnostic and failure exit code.
- Preserves parseable empty output in JSON and SARIF modes.
- Adds a regression test for file roots in JSON mode.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The new guard rejects existing non-directory explicit roots before scanning and follows the established error and machine-output behavior of adjacent validation paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentsweep/pipeline.py | Adds a correctly ordered file-root rejection after existence validation while preserving established machine-output behavior. |
| tests/test_output.py | Covers the new file-root error path, exit status, stderr diagnostic, and parseable JSON stdout. |

<sub>Reviews (1): Last reviewed commit: ["fix(scan): reject file paths passed as r..."](https://github.com/ishannaik/agent-sweep/commit/f8b5bda7386c563aa2cccab67c712518fcc7f047) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51622228)</sub>

<!-- /greptile_comment -->