### PR TITLE
Enforce complexity budgets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,33 @@ jobs:
       - name: Run mypy
         run: python -m mypy src/
 
+  lint:
+    name: Lint (ruff + file length)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install package and dev dependencies
+        run: pip install -e ".[dev]"
+      - name: Run ruff (style + complexity budgets)
+        run: python -m ruff check src/
+      - name: Enforce max file length
+        # Ruff has no module-length rule (pylint's C0302 was never ported),
+        # so this is the check. 700 is above today's worst (pipeline.py at
+        # 1675 is exempted below) and below the next thing that would rot.
+        run: |
+          over=$(find src -name '*.py' \
+            ! -path 'src/agentsweep/pipeline.py' \
+            ! -path 'src/agentsweep/scanner.py' \
+            ! -path 'src/agentsweep/cli.py' \
+            -exec wc -l {} + | awk '$2!="total" && $1>700 {print $1"  "$2}')
+          if [ -n "$over" ]; then
+            echo "Files over 700 lines:"; echo "$over"; exit 1
+          fi
+          echo "No new oversized files."
+
   security:
     name: Bandit SAST
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,3 +109,32 @@ exclude_dirs = ["tests"]
 # deptry), not imported by src/. Telling deptry these belong to a dev group
 # avoids false DEP002 "unused dependency" hits on every one of them.
 optional_dependencies_dev_groups = ["dev"]
+
+[tool.ruff.lint]
+# Ruff runs as a dev dependency but was never wired into CI, so none of this
+# was enforced. The `lint` job in ci.yml now runs it.
+#
+# Thresholds are deliberately looser than the textbook 10. Pydantic ships
+# max-complexity 14 for the same reason: a limit that fires constantly gets
+# ignored, and an ignored limit is worse than none.
+extend-select = ["C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 14
+
+[tool.ruff.lint.pylint]
+max-branches = 15
+max-statements = 60
+max-args = 8
+max-returns = 8
+
+[tool.ruff.lint.per-file-ignores]
+# Debt register, not an amnesty. These four files hold all 18 existing
+# violations; everything else in src/ is already clean and stays that way from
+# this commit on. cli.py and pipeline.py are also the two highest-churn files
+# in the repo (42 and 36 changes in 90 days), so they are where the next bug
+# is most likely to land. Shrink this list, do not grow it.
+"src/agentsweep/cli.py" = ["C901", "PLR0911", "PLR0912", "PLR0915"]
+"src/agentsweep/pipeline.py" = ["C901", "PLR0911", "PLR0912", "PLR0915"]
+"src/agentsweep/redactor.py" = ["C901", "PLR0912", "PLR0915"]
+"src/agentsweep/ui/picker.py" = ["C901"]


### PR DESCRIPTION
`ruff` was listed as a dev dependency with a comment claiming it covered C901, but **no workflow ever ran it**. mypy, bandit, deptry and vulture all run; ruff did not. This adds a `lint` job.

## Thresholds

```
max-complexity 14   branches 15   statements 60   args 8   returns 8
```

Looser than the textbook 10 deliberately. Pydantic ships `max-complexity = 14` for the same reason: a limit that fires constantly gets tuned out, and an ignored limit is worse than no limit.

## Debt register, not amnesty

At those thresholds `src/` has **18 violations, all inside four files**. They are listed in `per-file-ignores` so the gate is green today and every other file is held to the budget immediately. Shrink the list, don't grow it.

`cli.py` and `pipeline.py` are also the two highest-churn files in the repo (42 and 36 changes in 90 days). Complexity and churn independently point at the same two files, which makes them the likeliest home for the next bug.

## File length

Ruff has no module-length rule; pylint's `C0302` was never ported. So it is a `wc -l` step at 700 lines, with `pipeline.py` (1675), `scanner.py` (932) and `cli.py` (930) exempted.

## Not included

`ruff format --check` would reformat 27 of 29 files. That belongs in its own PR rather than buried here.

## Note

Don't add `Lint (ruff + file length)` as a required status check yet. The workflow's `paths-ignore` means a docs-only PR runs no CI, so a required check would never report and the PR would block forever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code-quality checks to the continuous integration process.
  * CI now runs Ruff linting and enforces a maximum Python file length, with approved exceptions.
  * Added configured thresholds for complexity, branching, statements, arguments, and return counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a dedicated CI lint job and configures Ruff complexity budgets with explicit debt exemptions.
- Runs Ruff against `src/` in CI.
- Enforces a 700-line ceiling for new Python modules while exempting three existing oversized files.
- Enables McCabe and pylint complexity rules with per-file ignores for existing violations.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after considering one non-blocking CI supply-chain hardening issue with the new mutable action references.

The complexity and file-length gates align with the current tree, but the lint job resolves checkout and setup-python through mutable tags rather than the immutable revisions used elsewhere.

**Files Needing Attention:** .github/workflows/ci.yml

<details open><summary><h3>Security Review</h3></summary>

The new lint job uses mutable major-version references for two GitHub Actions, allowing an upstream tag change to execute unreviewed code in CI. **How this was verified:** The changed steps use `@v4` and `@v5`, while the same actions in every existing CI job are pinned to full commit SHAs.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the Ruff and file-length lint job; its checks are coherent, but the two new action references are not pinned to immutable SHAs. |
| pyproject.toml | Adds explicit Ruff complexity thresholds and a narrowly scoped register of existing per-file violations. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  E[Push or pull request] --> L[Lint job]
  L --> C[Checkout repository]
  C --> P[Set up Python]
  P --> I[Install dev dependencies]
  I --> R[Ruff complexity checks]
  R --> F[700-line file check]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fci.yml%3A68-69%0A**Mutable%20CI%20action%20references**%0A%0AThe%20new%20lint%20job%20resolves%20%60checkout%60%20and%20%60setup-python%60%20through%20mutable%20major-version%20tags%2C%20allowing%20an%20upstream%20tag%20change%20to%20execute%20unreviewed%20code%2C%20access%20the%20checked-out%20repository%20and%20read-scoped%20token%2C%20or%20manipulate%20the%20lint%20result.%20Pin%20these%20actions%20to%20immutable%20commit%20SHAs%2C%20as%20the%20existing%20CI%20jobs%20do.%20**How%20this%20was%20verified%3A**%20The%20changed%20steps%20use%20%60%40v4%60%20and%20%60%40v5%60%2C%20while%20the%20same%20actions%20in%20every%20existing%20CI%20job%20are%20pinned%20to%20full%20commit%20SHAs.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20uses%3A%20actions%2Fcheckout%4011d5960a326750d5838078e36cf38b85af677262%20%23%20v4.4.0%0A%20%20%20%20%20%20-%20uses%3A%20actions%2Fsetup-python%40a26af69be951a213d495a4c3e4e4022e16d87065%20%23%20v5.6.0%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fagent-sweep&pr=188&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fagent-sweep%22%20on%20the%20existing%20branch%20%22lint-complexity-gate%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22lint-complexity-gate%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fci.yml%3A68-69%0A**Mutable%20CI%20action%20references**%0A%0AThe%20new%20lint%20job%20resolves%20%60checkout%60%20and%20%60setup-python%60%20through%20mutable%20major-version%20tags%2C%20allowing%20an%20upstream%20tag%20change%20to%20execute%20unreviewed%20code%2C%20access%20the%20checked-out%20repository%20and%20read-scoped%20token%2C%20or%20manipulate%20the%20lint%20result.%20Pin%20these%20actions%20to%20immutable%20commit%20SHAs%2C%20as%20the%20existing%20CI%20jobs%20do.%20**How%20this%20was%20verified%3A**%20The%20changed%20steps%20use%20%60%40v4%60%20and%20%60%40v5%60%2C%20while%20the%20same%20actions%20in%20every%20existing%20CI%20job%20are%20pinned%20to%20full%20commit%20SHAs.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20uses%3A%20actions%2Fcheckout%4011d5960a326750d5838078e36cf38b85af677262%20%23%20v4.4.0%0A%20%20%20%20%20%20-%20uses%3A%20actions%2Fsetup-python%40a26af69be951a213d495a4c3e4e4022e16d87065%20%23%20v5.6.0%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fagent-sweep&pr=188&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fci.yml%3A68-69%0A**Mutable%20CI%20action%20references**%0A%0AThe%20new%20lint%20job%20resolves%20%60checkout%60%20and%20%60setup-python%60%20through%20mutable%20major-version%20tags%2C%20allowing%20an%20upstream%20tag%20change%20to%20execute%20unreviewed%20code%2C%20access%20the%20checked-out%20repository%20and%20read-scoped%20token%2C%20or%20manipulate%20the%20lint%20result.%20Pin%20these%20actions%20to%20immutable%20commit%20SHAs%2C%20as%20the%20existing%20CI%20jobs%20do.%20**How%20this%20was%20verified%3A**%20The%20changed%20steps%20use%20%60%40v4%60%20and%20%60%40v5%60%2C%20while%20the%20same%20actions%20in%20every%20existing%20CI%20job%20are%20pinned%20to%20full%20commit%20SHAs.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20uses%3A%20actions%2Fcheckout%4011d5960a326750d5838078e36cf38b85af677262%20%23%20v4.4.0%0A%20%20%20%20%20%20-%20uses%3A%20actions%2Fsetup-python%40a26af69be951a213d495a4c3e4e4022e16d87065%20%23%20v5.6.0%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=188&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/ci.yml:68-69
**Mutable CI action references**

The new lint job resolves `checkout` and `setup-python` through mutable major-version tags, allowing an upstream tag change to execute unreviewed code, access the checked-out repository and read-scoped token, or manipulate the lint result. Pin these actions to immutable commit SHAs, as the existing CI jobs do. **How this was verified:** The changed steps use `@v4` and `@v5`, while the same actions in every existing CI job are pinned to full commit SHAs.

```suggestion
      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Enforce complexity budgets in CI"](https://github.com/ishannaik/agent-sweep/commit/9faca47bbe51fd23fbad98410ffbda7863756052) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51822662)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->