### PR TITLE
feat: detect relocated Codex session roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ The legacy flag form `agentsweep --fix` is still accepted and behaves identicall
 Pick which agent's history to target with `--source`. The default is `claude-code`.
 
 ```bash
-agentsweep scan --source claude-code          # ~/.claude/projects/ (or $CLAUDE_CONFIG_DIR)
-agentsweep scan --source codex                # ~/.codex/sessions/
+agentsweep scan --source claude-code          # ~/.claude/projects/ or $CLAUDE_CONFIG_DIR/projects/
+agentsweep scan --source codex                # ~/.codex/ or $CODEX_HOME/
 agentsweep scan --source opencode             # OpenCode SQLite store
 agentsweep scan --source cursor               # Cursor history
 agentsweep scan --source windsurf             # Windsurf history
@@ -289,11 +289,20 @@ agentsweep scan --all --json          # aggregated JSON (each finding has "sourc
 agentsweep scan --all --json -o out.json
 ```
 
-Override the default root directory to scan any arbitrary folder:
+Claude Code and Codex relocated homes are detected automatically when `--root`
+is omitted:
 
 ```bash
-agentsweep scan --root ~/backups/claude-history
-agentsweep fix  --root /tmp/history-copy --allow-production
+CLAUDE_CONFIG_DIR="$HOME/.claude-work" agentsweep scan --source claude-code
+CODEX_HOME="$HOME/.codex-work" agentsweep scan --source codex
+```
+
+An explicit `--root` takes precedence over these defaults and can target any
+arbitrary folder:
+
+```bash
+agentsweep scan --source claude-code --root ~/backups/claude-history
+agentsweep fix  --source codex --root /tmp/codex-history-copy
 ```
 
 ### Scan / fix flags

--- a/src/agentsweep/sources/_core.py
+++ b/src/agentsweep/sources/_core.py
@@ -1,4 +1,5 @@
 """Core sources: ClaudeCode, Codex, OpenCode, Aider."""
+
 from __future__ import annotations
 
 import json
@@ -87,8 +88,8 @@ class ClaudeCodeSource(JsonlSource):
 
 
 class CodexSource(JsonlSource):
-    """OpenAI Codex CLI — rollout JSONL under ~/.codex/sessions/YYYY/MM/DD/,
-    plus history.jsonl and session_index.jsonl at the root."""
+    """OpenAI Codex CLI — rollout JSONL under $CODEX_HOME/sessions/YYYY/MM/DD/
+    (default ~/.codex), plus history.jsonl and session_index.jsonl at the root."""
 
     name = "codex"
     display_name = "Codex"
@@ -96,7 +97,9 @@ class CodexSource(JsonlSource):
 
     @classmethod
     def default_root(cls) -> Path:
-        return Path.home() / ".codex"
+        """CODEX_HOME relocates the whole Codex home; else ~/.codex."""
+        relocated = os.environ.get("CODEX_HOME")
+        return Path(relocated) if relocated else Path.home() / ".codex"
 
 
 class OpenCodeSource(Source):
@@ -273,7 +276,6 @@ _AIDER_HISTORY_NAME = ".aider.chat.history.md"
 # deep inside nested vendor trees. Users with odd layouts can pass --root.
 # Hitting the cap is surfaced on stderr (never silent) — see below.
 _AIDER_MAX_DEPTH = 12
-
 
 class AiderSource(Source):
     """Aider CLI — per-repo Markdown history files named .aider.chat.history.md.

--- a/tests/test_codex_source.py
+++ b/tests/test_codex_source.py
@@ -1,4 +1,5 @@
 """Codex CLI source adapter: discovery, scanning, redaction, gates."""
+
 from __future__ import annotations
 
 import json
@@ -24,6 +25,7 @@ def _isolated_home(tmp_path, monkeypatch):
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.delenv("CODEX_HOME", raising=False)
     return home
 
 
@@ -38,13 +40,31 @@ def _mk_codex_root(tmp_path: Path) -> Path:
         json.dumps({"session_id": "x", "ts": 1, "text": "hello"}) + "\n",
         encoding="utf-8",
     )
-    (root / "auth.json").write_text('{"OPENAI_API_KEY": "not-scanned"}',
-                                    encoding="utf-8")
+    (root / "auth.json").write_text(
+        '{"OPENAI_API_KEY": "not-scanned"}', encoding="utf-8"
+    )
     return root
 
 
 def test_default_root_is_dot_codex(_isolated_home):
     assert CodexSource().root == _isolated_home / ".codex"
+
+
+def test_codex_home_env_selects_that_root(tmp_path, monkeypatch):
+    relocated = tmp_path / "relocated-codex"
+    monkeypatch.setenv("CODEX_HOME", str(relocated))
+    assert CodexSource().root == relocated
+
+
+def test_empty_codex_home_falls_back_to_dot_codex(_isolated_home, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", "")
+    assert CodexSource().root == _isolated_home / ".codex"
+
+
+def test_explicit_root_beats_codex_home_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "relocated-codex"))
+    explicit = tmp_path / "explicit"
+    assert CodexSource(root=explicit).root == explicit
 
 
 def test_files_finds_jsonl_but_never_auth_json(tmp_path):
@@ -66,8 +86,7 @@ def test_iter_strings_walks_codex_payloads(tmp_path):
 
 def test_cli_scan_and_fix_codex_source(tmp_path, monkeypatch, capsys):
     root = _mk_codex_root(tmp_path)
-    monkeypatch.setattr(pipeline, "is_agent_running",
-                        lambda markers: (False, ""))
+    monkeypatch.setattr(pipeline, "is_agent_running", lambda markers: (False, ""))
 
     assert main(["--source", "codex", "--root", str(root)]) == 1
 
@@ -79,17 +98,40 @@ def test_cli_scan_and_fix_codex_source(tmp_path, monkeypatch, capsys):
     assert "[REDACTED:aws-access-key]" in content
     # Line-by-line structure preserved (codex shape intact).
     for line in content.splitlines():
-        assert json.loads(line)["type"] in {"session_meta", "event_msg",
-                                            "response_item"}
+        assert json.loads(line)["type"] in {
+            "session_meta",
+            "event_msg",
+            "response_item",
+        }
     assert rollout.with_name(rollout.name + ".bak").exists()
-    assert (root / "auth.json").read_text(encoding="utf-8") == \
-        '{"OPENAI_API_KEY": "not-scanned"}'
+    assert (root / "auth.json").read_text(
+        encoding="utf-8"
+    ) == '{"OPENAI_API_KEY": "not-scanned"}'
+
+
+def test_cli_fix_refuses_codex_home_without_allow_production(
+    tmp_path, monkeypatch, capsys
+):
+    root = _mk_codex_root(tmp_path)
+    monkeypatch.setenv("CODEX_HOME", str(root))
+    monkeypatch.setattr(pipeline, "is_agent_running", lambda markers: (False, ""))
+
+    code = main(["fix", "--source", "codex"])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert "default production root" in captured.err
+    assert "--allow-production" in captured.err
+    rollout = next((root / "sessions").rglob("rollout-*.jsonl"))
+    assert AWS_KEY in rollout.read_text(encoding="utf-8")
+    assert not rollout.with_name(rollout.name + ".bak").exists()
 
 
 def test_active_session_gate_names_codex(tmp_path, monkeypatch, capsys):
     root = _mk_codex_root(tmp_path)
-    monkeypatch.setattr(pipeline, "is_agent_running",
-                        lambda markers: (True, "codex.exe"))
+    monkeypatch.setattr(
+        pipeline, "is_agent_running", lambda markers: (True, "codex.exe")
+    )
 
     code = main(["--source", "codex", "--root", str(root), "--fix"])
     captured = capsys.readouterr()
@@ -100,7 +142,8 @@ def test_active_session_gate_names_codex(tmp_path, monkeypatch, capsys):
 
 def test_preflight_detects_codex_tasklist(monkeypatch):
     monkeypatch.setattr(
-        preflight, "_list_process_cmdlines",
+        preflight,
+        "_list_process_cmdlines",
         lambda: ['"codex.exe","51234","Console","1","180,000 K"'],
     )
     running, marker = preflight.is_agent_running(preflight.CODEX_MARKERS)


### PR DESCRIPTION
## Summary

- honor `CODEX_HOME` when discovering Codex sessions while preserving explicit `--root` precedence
- keep environment-relocated Codex roots behind the existing production-root redaction gate
- document relocated-home scanning for both Codex and Claude Code
- add regression coverage for unset, empty, overridden, and protected Codex roots

## Verification

- [x] `uv run pytest -q` — 682 passed after merging current `main`
- [x] CLI smoke test found a synthetic secret from both relocated Claude Code and Codex session layouts without `--root`
- [x] Focused production-gate test confirms `fix` refuses an environment-relocated Codex root without `--allow-production`

## Compatibility

The Codex default remains `~/.codex` when `CODEX_HOME` is unset or empty. Explicit `--root` remains highest precedence, and no new CLI flags or filesystem-wide discovery are introduced.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR teaches the Codex source to discover sessions under a non-empty `CODEX_HOME` while retaining `~/.codex` fallback, explicit-root precedence, and the existing production-root protection.
- Updates Codex default-root selection to honor `CODEX_HOME`.
- Adds regression coverage for unset, empty, explicit, and protected relocated roots.
- Documents automatic relocated-home discovery for Codex and Claude Code.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentsweep/sources/_core.py | Selects a non-empty `CODEX_HOME` as the Codex default root and otherwise preserves the existing `~/.codex` fallback. |
| tests/test_codex_source.py | Covers environment-root selection, empty-value fallback, explicit-root precedence, and production-root refusal for destructive fixes. |
| README.md | Documents automatic Claude Code and Codex relocated-home discovery and clarifies explicit-root precedence. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Create Codex source] --> B{Explicit --root supplied?}
    B -->|Yes| C[Use explicit root]
    B -->|No| D{CODEX_HOME non-empty?}
    D -->|Yes| E[Use CODEX_HOME]
    D -->|No| F[Use ~/.codex]
    E --> G{Fix operation?}
    F --> G
    G -->|Yes| H[Apply production-root gate]
    G -->|No| I[Scan sessions]
    H --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat: detect relocated Codex session roo..."](https://github.com/ishannaik/agent-sweep/commit/7d555e2fc1c6f43012dcf2fece2266f6ad6715d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51936001)</sub>

<!-- /greptile_comment -->