### PR TITLE
fix(scan): stop claiming findings were written when the -o write fails

### DIFF
--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -218,11 +218,11 @@ def run(
         if getattr(args, "stats", False):
             empty_stats = _stats_payload(found_by_file, source_key=source.name)
             if output is not None:
-                _write_text(
+                if _write_text(
                     output,
                     json.dumps({"findings": [], "stats": empty_stats}, indent=2) + "\n",
-                )
-                print(f"0 finding(s) written to {output}", file=sys.stderr)
+                ):
+                    print(f"0 finding(s) written to {output}", file=sys.stderr)
             _show_stats(empty_stats)
         ui.stage(4, "skip", "REDACT", "nothing to redact")
         ui.stage(5, "skip", "ROTATE", "nothing to rotate")
@@ -786,11 +786,11 @@ def run_all(args) -> int:
         if getattr(args, "stats", False):
             empty_stats = _stats_payload_multi(per_source)
             if output is not None:
-                _write_text(
+                if _write_text(
                     output,
                     json.dumps({"findings": [], "stats": empty_stats}, indent=2) + "\n",
-                )
-                print(f"0 finding(s) written to {output}", file=sys.stderr)
+                ):
+                    print(f"0 finding(s) written to {output}", file=sys.stderr)
             _show_stats(empty_stats)
         ui.stage(4, "skip", "REDACT", "nothing to redact")
         ui.stage(5, "skip", "ROTATE", "nothing to rotate")
@@ -844,12 +844,12 @@ def run_all(args) -> int:
                 "findings": combined_payload,
                 "stats": stats_payload,
             }
-        _write_text(output, json.dumps(output_payload, indent=2) + "\n")
-        ui.warn_line(f"{len(combined_payload)} finding(s) also written to {output}")
+        if _write_text(output, json.dumps(output_payload, indent=2) + "\n"):
+            ui.warn_line(f"{len(combined_payload)} finding(s) also written to {output}")
     elif needs_overflow:
         report = Path.cwd() / DEFAULT_REPORT_NAME
-        _write_text(report, _text_report_multi(combined_payload))
-        ui.warn_line(f"full multi-source findings ({grand}) written to {report}")
+        if _write_text(report, _text_report_multi(combined_payload)):
+            ui.warn_line(f"full multi-source findings ({grand}) written to {report}")
 
     if stats_payload is not None:
         _show_stats(stats_payload)
@@ -1419,8 +1419,8 @@ def _emit_sarif(payload: list[dict], output: Path | None, suppressed: int) -> in
     text = json.dumps(_sarif_document(payload), indent=2) + "\n"
 
     if output is not None:
-        _write_text(output, text)
-        print(f"{len(payload)} finding(s) written to {output}", file=sys.stderr)
+        if _write_text(output, text):
+            print(f"{len(payload)} finding(s) written to {output}", file=sys.stderr)
         return code
 
     print(text, end="")
@@ -1441,20 +1441,20 @@ def _emit_json_payload(
     code = 0 if count == 0 else 1
 
     if output is not None:
-        _write_text(output, json.dumps(payload, indent=2) + "\n")
-        print(f"{count} finding(s) written to {output}", file=sys.stderr)
+        if _write_text(output, json.dumps(payload, indent=2) + "\n"):
+            print(f"{count} finding(s) written to {output}", file=sys.stderr)
         return code
 
     flood = count > JSON_FLOOD_LIMIT and getattr(sys.stdout, "isatty", lambda: False)()
 
     if flood:
         target = Path.cwd() / DEFAULT_JSON_NAME
-        _write_text(target, json.dumps(payload, indent=2) + "\n")
-        print(
-            f"{count} findings — too many to print; written to {target}\n"
-            f"  view with: cat {DEFAULT_JSON_NAME} | python -m json.tool",
-            file=sys.stderr,
-        )
+        if _write_text(target, json.dumps(payload, indent=2) + "\n"):
+            print(
+                f"{count} findings — too many to print; written to {target}\n"
+                f"  view with: cat {DEFAULT_JSON_NAME} | python -m json.tool",
+                file=sys.stderr,
+            )
         return code
 
     print(json.dumps(payload, indent=2))
@@ -1520,6 +1520,7 @@ def _show_findings(
     on_tty = ui.console.is_terminal
     capped = on_tty and len(rows) > MAX_TABLE_ROWS
 
+    wrote_output = False
     if output is not None:
         findings = _json_payload(found_by_file, source)
         output_payload: JsonPayload = findings
@@ -1528,19 +1529,21 @@ def _show_findings(
                 "findings": findings,
                 "stats": stats,
             }
-        _write_text(output, json.dumps(output_payload, indent=2) + "\n")
+        wrote_output = _write_text(output, json.dumps(output_payload, indent=2) + "\n")
 
+    wrote_report = False
     if capped:
         ui.findings_table(rows[:MAX_TABLE_ROWS], source.root)
         report = output if output is not None else Path.cwd() / DEFAULT_REPORT_NAME
         if output is None:
-            _write_text(report, _text_report(found_by_file, source))
-        ui.warn_line(
-            f"…and {len(rows) - MAX_TABLE_ROWS} more — full list written to {report}"
-        )
+            wrote_report = _write_text(report, _text_report(found_by_file, source))
+        if wrote_output or wrote_report:
+            ui.warn_line(
+                f"…and {len(rows) - MAX_TABLE_ROWS} more — full list written to {report}"
+            )
     else:
         ui.findings_table(rows, source.root)
-        if output is not None:
+        if wrote_output:
             ui.warn_line(f"{len(rows)} finding(s) also written to {output}")
 
 
@@ -1567,11 +1570,19 @@ def _text_report_multi(payload: list[dict]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _write_text(path: Path, text: str) -> None:
+def _write_text(path: Path, text: str) -> bool:
+    """Write text to path; report OSError on stderr and return False on failure.
+
+    Callers use the return value to decide whether a "written to <path>"
+    summary is honest — a failed write must not be followed by a success
+    claim, or the user believes a report exists on disk when it does not.
+    """
     try:
         path.write_text(text, encoding="utf-8")
     except OSError as e:
         print(f"Could not write {path}: {e}", file=sys.stderr)
+        return False
+    return True
 
 
 # Backup patterns undo restores: JSONL transcripts, whole-file JSON and

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -498,6 +498,38 @@ def test_scan_json_warns_on_unparseable_lines_stderr_only(tmp_path, capsys):
     assert "bad.jsonl" in captured.err
 
 
+def test_json_write_failure_no_false_written_claim(tmp_path, capsys):
+    """A failed -o write must not be followed by a "written to" success claim.
+
+    _write_text already reports "Could not write …"; printing a success note
+    afterwards tells the user a report exists on disk when it does not.
+    """
+    root = _mkroot(tmp_path)
+    bad_out = tmp_path / "no_such_dir" / "findings.json"
+
+    code = main(["scan", "--root", str(root), "--json", "-o", str(bad_out)])
+    captured = capsys.readouterr()
+
+    assert code == 1
+    assert "Could not write" in captured.err
+    assert "written to" not in captured.err
+    assert not bad_out.exists()
+
+
+def test_human_write_failure_no_false_written_claim(tmp_path, capsys):
+    """scan -o FILE (human mode) must not claim findings were written on a failed write."""
+    root = _mkroot(tmp_path)
+    bad_out = tmp_path / "no_such_dir" / "report.json"
+
+    code = main(["scan", "--root", str(root), "-o", str(bad_out)])
+    captured = capsys.readouterr()
+
+    assert code == 1
+    assert "Could not write" in captured.err
+    assert "written to" not in (captured.out + captured.err)
+    assert not bad_out.exists()
+
+
 def test_no_ignore_flag_skips_ignore_file(tmp_path, capsys):
     """--no-ignore means .agentsweepignore is not loaded (no suppression)."""
     # Use a file with only the AWS key so a single ignore rule covers everything.


### PR DESCRIPTION
## What & why

`_write_text()` swallows `OSError` with no signal to its callers, so every summary line printed a success claim even when the write had just failed. A failed `-o` run today ends with both of these lines:

```
Could not write /proc/nope/out.json: [Errno 2] No such file or directory: '/proc/nope/out.json'
  ⚠ 1 finding(s) also written to /proc/nope/out.json
```

For a secrets scanner that hands users a report to act on, the second line is the dangerous half of #181: the user walks away believing the report is on disk. `_write_text()` now returns whether the write landed, and all nine call sites only print their `written to …` claim on success (single-source, `--all`, SARIF, JSON, anti-flood default file, and the empty-`--stats` paths). The `Could not write …` diagnostic, exit codes, and machine-format stdout contracts are unchanged; whether a failed write should additionally get a distinct exit code is the design question #181 raises and is intentionally left open here.

Refs #181

## Type of change

- [x] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [ ] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing

Two regression tests in `tests/test_output.py` (JSON path and human path) assert a failed `-o` write prints the `Could not write` diagnostic and **no** `written to` claim; both fail on `main` and pass with the fix. Full local suite — same 33 regex-engine failures on `main` and on this branch (missing optional native engine locally), i.e. none caused by this change; all other 719 tests pass.

```
$ pytest tests/test_output.py -q
25 passed in 0.38s
```

Manual end-to-end:

```
$ agentsweep scan --root <dir-with-planted-key> -o /proc/nope/out.json
Could not write /proc/nope/out.json: [Errno 2] No such file or directory: '/proc/nope/out.json'
$ echo $?
1                      # exit code unchanged (findings found), no false "written to" line

$ agentsweep scan --root <dir-with-planted-key> -o /tmp/good-out.json
  ⚠ 1 finding(s) also written to /tmp/good-out.json   # success path still claims, file exists
```

## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13)
- [x] `mypy src/` is clean — `Success: no issues found in 30 source files`
- [x] No new runtime dependency
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [x] Redaction / write-path changes preserve the corruption-prevention invariants (this PR only touches report emission, not redaction writes)
- [ ] N/A New detection rule?
- [ ] N/A New source?
- [x] `--json` and non-tty output stay machine-clean — stdout and exit codes are byte-identical to before; only the misleading stderr line is gone
- [x] Did not re-introduce `force-include` in `pyproject.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reporting when JSON, SARIF, statistics, and text output files cannot be written.
  * Prevented success messages and overflow notices from appearing when output generation fails.
  * Preserved the correct failure status for unsuccessful writes.
  * Added guidance for correcting invalid output paths by specifying the directory containing agent history.

* **Tests**
  * Added coverage for failed JSON and human-readable report writes.
  * Verified failed outputs do not create files or report false success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Not PR-related failures

`Ruff lint and format` is red on this PR, but both files it flags are unformatted on `main` and untouched here (`git diff main --name-only` → `src/agentsweep/pipeline.py`, `tests/test_output.py` only):

```
$ python -m ruff format --check src tests scripts
unformatted: File would be reformatted
  --> tests/test_pinecone_rule.py:2:1
unformatted: File would be reformatted
  --> tests/test_regex_engine_parity.py:25:32
2 files would be reformatted, 79 files already formatted
```

`tests/test_pinecone_rule.py` last changed in #189 (merged before the ruff gate landed in #191); `tests/test_regex_engine_parity.py` came in with #191 itself. `ruff check` passes clean. Happy to fold a two-file `ruff format` into this PR if you'd rather land the cleanup together — say the word and I'll add it, otherwise keeping it out to stay one-concern-per-PR.













<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes report-write status accurate by emitting success notices only after `_write_text()` confirms that the write completed.
- Changes `_write_text()` to return a success flag while preserving existing error diagnostics.
- Gates success and overflow-report notices across single-source, multi-source, JSON, SARIF, statistics, and human output paths.
- Adds regression coverage for failed JSON and human-mode output writes.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/agentsweep/pipeline.py | Propagates file-write success to all affected reporting paths so failed writes no longer produce misleading success notices. |
| tests/test_output.py | Adds focused regression tests confirming failed JSON and human output writes retain the error diagnostic without claiming success. |

<sub>Reviews (9): Last reviewed commit: ["fix(scan): stop claiming findings were w..."](https://github.com/ishannaik/agent-sweep/commit/aeeb0b65223d90a334280436ac27491f9413da7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53785367)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Results and output formats](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/agent-sweep/-/docs/results-and-output-formats.md)
- Knowledge Base — [Scan pipeline orchestration](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/agent-sweep/-/docs/scan-pipeline.md)
- Knowledge Base — [Command execution and scan lifecycle](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/agent-sweep/-/docs/command-execution.md)
</details>


<!-- /greptile_comment -->