### PR TITLE
fix(scan): report unparseable lines and unreadable files instead of skipping them silently

### DIFF
--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -167,6 +167,7 @@ def run(
                 f"and were truncated",
                 file=sys.stderr,
             )
+        _warn_unscannable([source], machine=True)
         _warn_leftover_backups(source, as_json=True)
         if as_sarif:
             return _emit_sarif(_json_payload(found_by_file, source), output, suppressed)
@@ -207,6 +208,7 @@ def run(
             f"{_MAX_FILE_SCAN_CHARS // 1_000_000}MB scan budget and were "
             f"truncated (likely cache blobs, not conversation text)"
         )
+    _warn_unscannable([source], machine=False)
 
     if suppressed:
         ui.warn_line(f"{suppressed} finding(s) suppressed by .agentsweepignore")
@@ -728,6 +730,10 @@ def run_all(args) -> int:
                 f"and were truncated",
                 file=sys.stderr,
             )
+        _warn_unscannable(
+            [s for _k, s, *_ in per_source],
+            machine=True,
+        )
         _warn_leftover_backups_multi([s for _k, s, *_ in per_source], as_json=True)
         if as_sarif:
             return _emit_sarif(payload, output, total_suppressed)
@@ -770,6 +776,7 @@ def run_all(args) -> int:
             f"{len(total_truncated)} file(s) exceeded the "
             f"{_MAX_FILE_SCAN_CHARS // 1_000_000}MB scan budget and were truncated"
         )
+    _warn_unscannable([s for _k, s, *_ in per_source], machine=False)
     if total_suppressed:
         ui.warn_line(f"{total_suppressed} finding(s) suppressed by .agentsweepignore")
 
@@ -1008,6 +1015,37 @@ def _scan(
 # block Ctrl-C. Stop scanning a file once its text crosses this budget and flag
 # it as truncated so the cap is reported, never silent.
 _MAX_FILE_SCAN_CHARS = 50_000_000
+
+
+def _warn_unscannable(sources: list[Source], *, machine: bool) -> None:
+    """Report history content the scanner never saw (#196) — never silent.
+
+    Sources that skip unparseable lines or unreadable files during
+    iter_strings accumulate the account; this turns it into one stderr line
+    per source with skips so a clean report can't hide unscanned bytes.
+    """
+    for source in sources:
+        unparseable: dict[Path, int] = getattr(source, "unscannable_lines", None) or {}
+        unreadable: list[Path] = getattr(source, "unreadable_files", None) or []
+        if not unparseable and not unreadable:
+            continue
+        parts: list[str] = []
+        if unparseable:
+            parts.append(
+                f"{sum(unparseable.values())} unparseable line(s) "
+                f"in {len(unparseable)} file(s)"
+            )
+        if unreadable:
+            parts.append(f"{len(unreadable)} unreadable file(s)")
+        example = next(iter(unparseable)) if unparseable else unreadable[0]
+        msg = (
+            f"warning: {' and '.join(parts)} under {source.root} "
+            f"were not scanned (e.g. {example.name}); secrets there would be missed"
+        )
+        if machine:
+            print(msg, file=sys.stderr)
+        else:
+            ui.warn_line(msg)
 
 
 def _scan_file(

--- a/src/agentsweep/sources/_base.py
+++ b/src/agentsweep/sources/_base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Iterator
@@ -26,6 +27,38 @@ class Source(ABC):
     def __init__(self, root: Path | None = None) -> None:
         if root is not None:
             self.root = root
+
+    def _note_unscannable(
+        self, path: Path, lines: int = 0, *, unreadable: bool = False
+    ) -> None:
+        """Record history content the scanner could not parse or read (#196).
+
+        Skipping is the right robustness call for live histories, but a skip
+        the user never hears about turns a corrupt line into a false-clean
+        report. The accumulators are created lazily because several sources
+        assign attributes directly instead of calling super().__init__(); the
+        mutation runs under a per-instance lock because duplicate profile
+        roots (e.g. a repeated CLAUDE_CONFIG_DIR entry) submit the same path
+        to several file workers, and the read-modify-write on the per-path
+        count must not lose increments.
+        """
+        # Every lazy object — both containers and the lock itself — goes
+        # through __dict__.setdefault, a single GIL-atomic operation: workers
+        # always share the objects recorded first (a check-then-create race
+        # could clobber a container, and two lock instances would guard
+        # nothing).
+        unscannable_lines: dict[Path, int] = self.__dict__.setdefault(
+            "unscannable_lines", {}
+        )
+        unreadable_files: list[Path] = self.__dict__.setdefault("unreadable_files", [])
+        lock: threading.Lock = self.__dict__.setdefault(
+            "_unscannable_lock", threading.Lock()
+        )
+        with lock:
+            if unreadable:
+                unreadable_files.append(path)
+            elif lines:
+                unscannable_lines[path] = unscannable_lines.get(path, 0) + lines
 
     @abstractmethod
     def files(self) -> list[Path]:
@@ -142,6 +175,7 @@ class JsonlSource(Source):
         try:
             raw = path.read_bytes()  # ~1.5x faster than read_text on Windows
         except OSError:
+            self._note_unscannable(path, unreadable=True)
             return
         for i, bline in enumerate(raw.splitlines(), 1):
             if not bline.strip():
@@ -149,6 +183,7 @@ class JsonlSource(Source):
             try:
                 obj = json.loads(bline)  # json.loads accepts bytes natively
             except (json.JSONDecodeError, ValueError):
+                self._note_unscannable(path, lines=1)
                 continue
             yield from _walk_json(obj, [], i)
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -459,6 +459,45 @@ def test_output_file_parent_does_not_exist_does_not_crash(tmp_path, capsys):
     assert "Traceback" not in captured.err
 
 
+def test_scan_warns_on_unparseable_lines_human_mode(tmp_path, capsys):
+    """A malformed JSONL line must surface a not-scanned warning (#196)."""
+    root = tmp_path / "history"
+    root.mkdir()
+    (root / "good.jsonl").write_text(FIXTURE_LINE, encoding="utf-8")
+    (root / "bad.jsonl").write_text(
+        '{"broken line with pasted ' + GH_TOKEN + " no closing brace\n",
+        encoding="utf-8",
+    )
+
+    code = main(["scan", "--root", str(root)])
+    captured = capsys.readouterr()
+
+    assert code == 1  # the good file still has findings
+    combined = captured.out + captured.err
+    assert "not scanned" in combined
+    assert "bad.jsonl" in combined
+
+
+def test_scan_json_warns_on_unparseable_lines_stderr_only(tmp_path, capsys):
+    """Machine mode: the not-scanned warning goes to stderr; stdout stays a
+    valid JSON array (machine-clean contract unchanged)."""
+    root = tmp_path / "history"
+    root.mkdir()
+    (root / "bad.jsonl").write_text(
+        '{"broken line with pasted ' + GH_TOKEN + " no closing brace\n",
+        encoding="utf-8",
+    )
+
+    code = main(["scan", "--root", str(root), "--json"])
+    captured = capsys.readouterr()
+
+    assert code == 0  # nothing scannable found — but the skip must be visible
+    payload = json.loads(captured.out)
+    assert payload == []
+    assert "not scanned" in captured.err
+    assert "bad.jsonl" in captured.err
+
+
 def test_no_ignore_flag_skips_ignore_file(tmp_path, capsys):
     """--no-ignore means .agentsweepignore is not loaded (no suppression)."""
     # Use a file with only the AWS key so a single ignore rule covers everything.

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -71,3 +71,108 @@ def test_files_ignores_non_jsonl(tmp_path: Path) -> None:
     files = src.files()
     assert len(files) == 1
     assert files[0].name == "session.jsonl"
+
+
+def test_iter_strings_records_unparseable_lines(tmp_path: Path) -> None:
+    """A malformed JSONL line is skipped, but the skip must be counted (#196).
+
+    The scanner never sees the skipped bytes, so the account is the only
+    thing standing between a corrupt line and a false-clean report.
+    """
+    root = tmp_path / "projects"
+    root.mkdir()
+    target = root / "session.jsonl"
+    target.write_text(
+        '{"a":"valid"}\n'
+        '{"broken": no-closing-brace\n'
+        '{"b":"also valid"}\n'
+        '{"still broken\n',
+        encoding="utf-8",
+    )
+
+    src = ClaudeCodeSource(root=root)
+    list(src.iter_strings(target))
+
+    assert src.unscannable_lines == {target: 2}
+
+
+def test_iter_strings_records_unreadable_file(tmp_path: Path, monkeypatch) -> None:
+    """A file that cannot be read at all must be recorded, not just vanish.
+
+    The read failure is injected (rather than chmod-000) so the test is
+    deterministic on Windows, where chmod does not block reads.
+    """
+    root = tmp_path / "projects"
+    root.mkdir()
+    target = root / "session.jsonl"
+    target.write_text('{"a":1}\n', encoding="utf-8")
+
+    def _unreadable(self: Path) -> bytes:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_bytes", _unreadable)
+
+    src = ClaudeCodeSource(root=root)
+    list(src.iter_strings(target))
+
+    assert src.unreadable_files == [target]
+
+
+def test_unscannable_accounting_survives_concurrent_workers(tmp_path: Path) -> None:
+    """Concurrent workers must not lose skip records via lazy-init races (#197)."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    root = tmp_path / "projects"
+    root.mkdir()
+    paths = []
+    for i in range(200):
+        target = root / f"session_{i}.jsonl"
+        target.write_text('{"broken line no closing brace\n', encoding="utf-8")
+        paths.append(target)
+
+    src = ClaudeCodeSource(root=root)
+
+    def iterate(path: Path) -> None:
+        list(src.iter_strings(path))
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(iterate, paths))
+
+    assert src.unscannable_lines == {p: 1 for p in paths}, (
+        f"expected one malformed-line record per file, got "
+        f"{src.unscannable_lines} — records or counts were lost to a "
+        f"lazy-initialization race"
+    )
+
+
+def test_unscannable_counts_survive_duplicate_path_workers(tmp_path: Path) -> None:
+    """Duplicate profile roots submit the same file to several workers (#197).
+
+    A repeated CLAUDE_CONFIG_DIR entry (or overlapping profile dirs) makes
+    files() yield the same path more than once, so two file workers iterate
+    one file on the same Source instance concurrently. The per-path count is
+    a read-modify-write and must not lose increments.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    root = tmp_path / "projects"
+    root.mkdir()
+    paths = []
+    for i in range(50):
+        target = root / f"session_{i}.jsonl"
+        target.write_text('{"broken line no closing brace\n', encoding="utf-8")
+        paths.append(target)
+
+    src = ClaudeCodeSource(root=root)
+
+    def iterate(path: Path) -> None:
+        list(src.iter_strings(path))
+
+    doubled = [*paths, *paths]  # mirror duplicate-root submission
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(iterate, doubled))
+
+    assert src.unscannable_lines == {p: 2 for p in paths}, (
+        "each submission of a path must add exactly one to its count — "
+        "increments were lost to a non-atomic read-modify-write"
+    )


### PR DESCRIPTION
## What & why

**Root cause:** `Source.iter_strings` (`sources/_base.py`) skipped malformed JSONL lines with a bare `continue` and returned silently when a file couldn't be read — no trace in stdout, stderr, exit code, or any output format. Any secret living on a corrupt line (exactly what a process dying mid-write leaves behind) sat in bytes the scanner never saw while the run reported normally. Redaction already fails closed on the same corruption (`_helpers.py` raises `SafetyError: … refusing to redact`); scanning stayed silent.

**Fix:** `JsonlSource.iter_strings` now records each skipped line and each unreadable file via a lazily-created accumulator on the source (lazily because many sources assign attributes directly instead of calling `super().__init__()`). The accumulators and the lock itself are created under `__dict__.setdefault` — a single GIL-atomic op — and updated under a per-instance `threading.Lock`, because duplicate profile roots (e.g. a repeated `CLAUDE_CONFIG_DIR` entry) do submit the same path to several file workers, so the read-modify-write on the per-path count can otherwise lose increments. `_warn_unscannable()` in the pipeline turns the account into one stderr warning after the SCAN stage in every mode — human, `--json`, SARIF, single-source and `--all` — mirroring the existing scan-budget truncation warning:

```
warning: 1 unparseable line(s) in 1 file(s) under /tmp/skiptest were not scanned (e.g. bad.jsonl); secrets there would be missed
```

stdout payloads and exit codes are unchanged; whether unscannable content should additionally get a strict mode / distinct exit signal is the design question raised in the issue and left open here.

Closes #196 (for the `_base.py` JSONL walker).

**Coverage audit, as asked in review** — `_note_unscannable` is *not* reached by the other readers; confirmed by reading every `iter_strings` override. They fall into three groups:

* *Genuinely silent, same failure mode as #196* (whole file/DB lost with no trace): `OpenCodeSource._iter_strings_sqlite` and `._sqlite_text_columns` (`_core.py`), `ClineSource.iter_strings` and `ContinueSource.iter_strings` (`_extended.py` — also inherited by KiloCode/RooCode/OpenInterpreter), `_iter_sqlite_all_columns` (`_more.py`, used by Crush/Warp/GrokCli/Zed/KiroCli, incl. its per-table `PRAGMA`/`SELECT` `continue`s), `HermesSource`/`GooseSource`/`LlmSource.iter_strings` (`_community.py`, incl. Hermes' `except sqlite3.Error: pass` around the row loop), `_VSCodeSqliteSource.iter_strings` (`_vscode.py`, inherited as-is by Trae/Void; Cursor and Windsurf override it only to route their extra `.jsonl` / `.md` formats through the module-level `_helpers` readers below, then fall back to this same silent SQLite path).
* *Not reachable from this helper*: `_helpers._iter_jsonl_strings` / `_iter_json_file_strings` / `_iter_plaintext_lines` are module-level, so they have no `self` to record on — wiring them needs a reporter passed in, i.e. an interface change.
* *Intentional skips, deliberately NOT counted*: NULL / numeric / BLOB columns, empty values, and stored DB values that fail `json.loads` but are still yielded raw as text.

Accounting for the first two groups is the same pattern applied N times plus one signature change, so I'd rather land it as a follow-up once this shape is agreed (as the PR said from the start) than grow this diff past the four files it now covers.

## Type of change

- [x] Bug fix
- [ ] New agent source
- [ ] New detection rule
- [ ] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing

Regression tests: source-level accounting (`unscannable_lines` / `unreadable_files`, including a chmod-000 unreadable file), source-level concurrency (thread-pool race + duplicate-path increments) and pipeline-level warnings for both human and `--json` mode (stdout stays a valid `[]`). The accounting tests fail on `main`, pass here.

Verified on this head (a single commit on top of `main` `e395ef8`):

```
$ uv run --extra dev pytest -q
754 passed, 10 skipped in 21.44s
$ uv run --extra dev ruff format --check .
93 files already formatted
$ uv run --extra dev mypy src
Success: no issues found in 30 source files
$ uv run --extra dev bandit -r src
(no issues identified)
```

(`ruff check .` reports 12 findings on this head — the identical 12 on clean `main` `e395ef8`, none in files this PR touches.)

Manual end-to-end (the issue's repro): a history root whose only secret sits on a malformed line previously exited 0 with an empty `[]` and silent stderr; it now exits 0 with `[]` on stdout and the `were not scanned` warning naming the file on stderr.

## Ruff format (resolved — no longer touching those fixtures)

The format-vs-push-protection conflict this branch originally hit is now fixed at the source on `main` by #214 (merged as `e395ef8`), which formats `tests/test_pinecone_rule.py`, `tests/test_neon_rule.py` and `tests/test_regex_engine_parity.py` in place. So the `format.exclude` entries this branch had added are dropped — this PR no longer touches `pyproject.toml` or any of those fixture files. Locally: `ruff format --check` reports those three files clean with no exclude, `93 files already formatted` repo-wide.

## Checklist

- [x] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13)
- [x] `mypy src/` is clean — `Success: no issues found in 31 source files`
- [x] No new runtime dependency
- [x] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [x] Redaction / write-path changes preserve the corruption-prevention invariants (no redaction-path change; read-side accounting only)
- [ ] N/A New detection rule?
- [ ] N/A New source?
- [x] `--json` and non-tty output stay machine-clean — warning goes to stderr only; stdout payloads and exit codes byte-identical to before
- [x] Did not re-introduce `force-include` in `pyproject.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scan results now clearly report unreadable files and malformed history entries instead of silently skipping them.
  * Warnings include the number of affected items, an example filename, and the relevant source location.
  * Machine-readable output remains valid, with warnings sent separately to stderr.
* **Tests**
  * Added coverage for malformed files, unreadable content, duplicate processing, and concurrent scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes incomplete JSONL scan coverage visible without changing machine-readable payloads or exit statuses.
- Records malformed JSONL lines and unreadable files on each source.
- Protects lazy accumulator initialization and updates against concurrent file workers.
- Emits post-scan warnings in single-source and multi-source human, JSON, and SARIF paths.
- Adds source-level concurrency and pipeline-output regression coverage.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the shared lazy state and per-instance lock address both previously reported accounting races.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/agentsweep/sources/_base.py | Adds thread-safe lazy accounting for malformed JSONL lines and unreadable files; the changes resolve both previously reported concurrency races. |
| src/agentsweep/pipeline.py | Emits unscannable-content warnings after scan workers finish while preserving stdout payload contracts. |
| tests/test_sources.py | Covers malformed and unreadable input accounting, concurrent initialization, and duplicate-path increments. |
| tests/test_output.py | Verifies warnings in human and JSON modes and confirms JSON stdout remains parseable. |

<sub>Reviews (11): Last reviewed commit: ["fix(scan): report unparseable lines and ..."](https://github.com/ishannaik/agent-sweep/commit/c6fd2b27063bc98856ae63ac8bb081f36ff90cd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53787566)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Scan pipeline orchestration](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/agent-sweep/-/docs/scan-pipeline.md)
- Knowledge Base — [Filesystem scanning and finding collection](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/agent-sweep/-/docs/filesystem-scanning.md)
- Knowledge Base — [Source abstractions and helpers](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/agent-sweep/-/docs/source-abstractions.md)
- Knowledge Base — [Results and output formats](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/agent-sweep/-/docs/results-and-output-formats.md)
</details>


<!-- /greptile_comment -->