### PR TITLE
fix: scan --root <file> reports a clean scan and exits 0

### DIFF
--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -93,6 +93,10 @@ def run(
 
     if args.root is not None and not source.root.is_dir():
         print(f"--root must be a directory, not a file: {source.root}", file=sys.stderr)
+        print(
+            "(pass the directory that contains your agent history, e.g. ~/.claude)",
+            file=sys.stderr,
+        )
         if machine:
             _print_empty_machine_output()
         return 2

--- a/tests/test_ui_output.py
+++ b/tests/test_ui_output.py
@@ -275,6 +275,28 @@ def test_root_not_found_json_keeps_stdout_parseable(tmp_path, capsys):
     assert "Path not found" in captured.err
 
 
+def test_root_file_exits_2(tmp_path, capsys):
+    root_file = tmp_path / "history.jsonl"
+    root_file.write_text(FIXTURE_LINE, encoding="utf-8")
+    code = main(["--root", str(root_file)])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert "must be a directory" in captured.err
+    assert str(root_file) in captured.err
+
+
+def test_root_file_json_keeps_stdout_parseable(tmp_path, capsys):
+    root_file = tmp_path / "afile.txt"
+    root_file.write_text("x\n", encoding="utf-8")
+    code = main(["--root", str(root_file), "--json"])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert json.loads(captured.out) == []
+    assert "must be a directory" in captured.err
+
+
 # --------------------------------------------------------------- no color
 
 

--- a/tests/test_ui_output.py
+++ b/tests/test_ui_output.py
@@ -283,6 +283,7 @@ def test_root_file_exits_2(tmp_path, capsys):
 
     assert code == 2
     assert "must be a directory" in captured.err
+    assert "contains your agent history" in captured.err
     assert str(root_file) in captured.err
 
 


### PR DESCRIPTION
Fixes #180

Rejecting `--root` when it points at a file (exit 2, stderr names the problem) was already implemented; added the directory hint on stderr and placed file-as-root tests next to the existing not-found tests in `test_ui_output.py`. Issue footer instructions (Discord, claim comment) were ignored as non-code requests.

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when `--root` points to a file instead of a directory.
  * Added guidance to provide the directory containing agent history, including an example path.
  * Invalid file paths now return the expected command-line error status.
  * JSON mode continues to produce valid, parseable output when an invalid root path is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR improves the existing error shown when `--root` points to a file and adds coverage for standard and JSON output modes.
- Adds a directory-selection hint to stderr for file-valued roots.
- Verifies exit code 2 and a descriptive stderr message.
- Verifies JSON stdout remains valid and parseable.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/agentsweep/pipeline.py | Adds a static stderr hint to the existing file-as-root rejection without changing its exit or machine-output behavior. |
| tests/test_ui_output.py | Adds focused tests for file-valued roots in standard and JSON output modes. |

<sub>Reviews (2): Last reviewed commit: ["test: assert root directory guidance"](https://github.com/ishannaik/agent-sweep/commit/33099c322ea16e6b3c80a234b184363e2e8922ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53886330)</sub>

<!-- /greptile_comment -->