### PR TITLE
feat(scanner): detect Stripe webhook signing secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 > **Experimental sources** (Warp, Crush, Grok CLI, Kiro CLI, Zed, Codebuff, Plandex, Qwen Code, PearAI, Trae, Void, Junie, Mentat, JetBrains AI) have storage paths/formats derived from research but **not yet verified against a real install**. Scanning is safe: a wrong path finds nothing. They may under-report until confirmed. They're tagged `(experimental)` in the picker and print a notice on scan.
 
-**206 regex rules + seed-phrase detection:** AWS, GitHub, Stripe, OpenAI, Anthropic, Google, Slack, Discord, HuggingFace, Supabase sensitive tokens, JWT, PEM keys, DB URLs, BIP-39 seed phrases, and [many more](#whats-detected)
+**207 regex rules + seed-phrase detection:** AWS, GitHub, Stripe, OpenAI, Anthropic, Google, Slack, Discord, HuggingFace, Supabase sensitive tokens, JWT, PEM keys, DB URLs, BIP-39 seed phrases, and [many more](#whats-detected)
 
 **Alpha:** every destructive step is gated, backed up, and reversible with one command
 
@@ -73,7 +73,7 @@ agentsweep runs a fixed 5-stage pipeline. `scan` stops after stage 3; `fix` cont
 
 ```mermaid
 flowchart LR
-    A("🔍 DISCOVER\nwalk history dirs\nstream file list") --> B("⚡ SCAN\nAho-Corasick pre-filter\n206 regex rules + BIP-39")
+    A("🔍 DISCOVER\nwalk history dirs\nstream file list") --> B("⚡ SCAN\nAho-Corasick pre-filter\n207 regex rules + BIP-39")
     B --> C{"secrets\nfound?"}
     C -- "none" --> D("✅ CLEAN\nexit 0")
     C -- "found" --> E("📋 FINDINGS\nshow report\nexit 1")
@@ -446,9 +446,9 @@ agentsweep purge --yes                 # non-interactive (scripts / CI)
 
 ## What's detected
 
-206 high-confidence patterns, **plus a checksum-validated crypto seed-phrase detector**. It confirms BIP-39 mnemonics (12/15/18/21/24 words, the wallet format behind BTC, ETH, SOL, BNB, ADA, DOGE, LTC, DOT, AVAX and most major chains) and Electrum seeds cryptographically (BIP-39 checksum or Electrum version tag), so English prose that happens to use wallet words won't trigger a false positive.
+207 high-confidence patterns, **plus a checksum-validated crypto seed-phrase detector**. It confirms BIP-39 mnemonics (12/15/18/21/24 words, the wallet format behind BTC, ETH, SOL, BNB, ADA, DOGE, LTC, DOT, AVAX and most major chains) and Electrum seeds cryptographically (BIP-39 checksum or Electrum version tag), so English prose that happens to use wallet words won't trigger a false positive.
 
-The patterns: AWS access keys, GitHub tokens (PAT/OAuth/App/fine-grained), Stripe live/test, OpenAI, Anthropic, Google API, Slack bot/user/webhook, Hugging Face, Supabase sensitive tokens, JWT, PEM private keys, DB URLs with embedded passwords, and npm/PyPI/SendGrid/Twilio tokens. On top of those sit 187 rules mapped to the [gitleaks](https://github.com/gitleaks/gitleaks) pack covering GitLab, Grafana, HashiCorp Vault/Terraform, DigitalOcean, Shopify, PlanetScale, Databricks, Atlassian, Azure AD, 1Password, Sentry, New Relic, Mailgun, Datadog, Twilio, Twitter/X, Twitch, Yandex, JFrog, Snyk, Mailchimp, curl credentials on the command line, and many more. The patterns run high-precision: false positives are rare, and provider-context rules are keyword-gated so large pastes stay fast.
+The patterns: AWS access keys, GitHub tokens (PAT/OAuth/App/fine-grained), Stripe live/test and webhook signing secrets, OpenAI, Anthropic, Google API, Slack bot/user/webhook, Hugging Face, Supabase sensitive tokens, JWT, PEM private keys, DB URLs with embedded passwords, and npm/PyPI/SendGrid/Twilio tokens. On top of those sit 187 rules mapped to the [gitleaks](https://github.com/gitleaks/gitleaks) pack covering GitLab, Grafana, HashiCorp Vault/Terraform, DigitalOcean, Shopify, PlanetScale, Databricks, Atlassian, Azure AD, 1Password, Sentry, New Relic, Mailgun, Datadog, Twilio, Twitter/X, Twitch, Yandex, JFrog, Snyk, Mailchimp, curl credentials on the command line, and many more. The patterns run high-precision: false positives are rare, and provider-context rules are keyword-gated so large pastes stay fast.
 
 ## `.agentsweepignore` — suppress false positives
 
@@ -544,7 +544,7 @@ They solve different problems and compose well together. agentsweep covers the s
 | **Redacts in place** | ✅ structure-preserving, atomic, reversible (`undo`) | ❌ detection only | ❌ detection only |
 | **Rotation guidance** | ✅ per-provider revocation links | ❌ | ❌ |
 | **Verifies live keys** | ❌ | ❌ | ✅ (network) |
-| **Rules** | 206 (187 mapped to gitleaks rules) | ~150 | 800+ verified |
+| **Rules** | 207 (187 mapped to gitleaks rules) | ~150 | 800+ verified |
 | **Runs fully offline** | ✅ zero network calls | ✅ | ⚠️ verification needs network |
 
 Scan your codebase and CI with gitleaks or trufflehog, then scan the agent-history surface they don't touch with agentsweep. Running both is the intent: they overlap and cover each other's blind spots.

--- a/docs/PERF.md
+++ b/docs/PERF.md
@@ -1,6 +1,6 @@
 # Scanner performance notes
 
-Detection runs 206 regexes + a BIP-39 mnemonic check over every string
+Detection runs 207 regexes + a BIP-39 mnemonic check over every string
 value in every JSONL line. History sizes are large (900+ files, some with
 multi-MB embedded transcripts), so per-byte and per-string costs both matter.
 
@@ -8,7 +8,7 @@ multi-MB embedded transcripts), so per-byte and per-string costs both matter.
 
 - **Keyword pre-filter (approx 7.5x).** Each rule carries a required literal
   anchor (`akia`, `ghp_`, `twitter`, ...) extracted from its pattern; the
-  regex is skipped when the anchor is absent. 200/206 rules are gated.
+  regex is skipped when the anchor is absent. 201/207 rules are gated.
   Provably lossless (a match always contains its anchor); gated by the
   per-rule fixture tests. See `scanner.py:_prefilter_literals`.
 - **Mnemonic gate.** `detect_mnemonics` returns early when a string has
@@ -46,7 +46,7 @@ multi-MB embedded transcripts), so per-byte and per-string costs both matter.
 ## Evaluated and dropped
 
 - **multiprocessing across files.** On Windows `spawn` re-imports modules
-  and recompiles all 206 regexes per worker; measured ~1.1× on a 2.4 MB /
+  and recompiles all 207 regexes per worker; measured ~1.1× on a 2.4 MB /
   200-file corpus (startup cost dominates), with one run at 0.4×. It also
   risks a re-import fork bomb if an entry point isn't `__main__`-guarded.
   Not worth the risk/complexity for the gain. (Cheap, shared-memory

--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -49,12 +49,12 @@ _RAW_RULES: list[tuple[str, str, re.Pattern[str]]] = [
         # its CLI treats the body as base64 with optional padding. Keep the
         # range bounded while covering both Dashboard and CLI variants. A raw
         # slash can also delimit a URL path, so match that context separately
-        # without consuming the next path segment. Try a body-terminal slash
-        # first so the following path delimiter stays outside the finding; the
-        # generic branch retains slash as a valid base64 body character.
+        # without consuming the next path segment. The greedy URL branch keeps
+        # internal or terminal body slashes, then backtracks to the following
+        # path delimiter; the generic branch covers non-path contexts.
         re.compile(
             r"(?<![A-Za-z0-9_+])whsec_(?:"
-            r"(?:[A-Za-z0-9+/]{31,63}/|[A-Za-z0-9+]{32,64})={0,2}(?=/)"
+            r"[A-Za-z0-9+/]{32,64}={0,2}(?=/)"
             r"|[A-Za-z0-9+/]{32,64}={0,2}(?![A-Za-z0-9_+/=])"
             r")"
         )),

--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -49,11 +49,12 @@ _RAW_RULES: list[tuple[str, str, re.Pattern[str]]] = [
         # its CLI treats the body as base64 with optional padding. Keep the
         # range bounded while covering both Dashboard and CLI variants. A raw
         # slash can also delimit a URL path, so match that context separately
-        # without consuming the next path segment; the generic branch retains
-        # slash as a valid base64 body character.
+        # without consuming the next path segment. Try a body-terminal slash
+        # first so the following path delimiter stays outside the finding; the
+        # generic branch retains slash as a valid base64 body character.
         re.compile(
             r"(?<![A-Za-z0-9_+])whsec_(?:"
-            r"[A-Za-z0-9+]{32,64}={0,2}(?=/)"
+            r"(?:[A-Za-z0-9+/]{31,63}/|[A-Za-z0-9+]{32,64})={0,2}(?=/)"
             r"|[A-Za-z0-9+/]{32,64}={0,2}(?![A-Za-z0-9_+/=])"
             r")"
         )),

--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -44,6 +44,14 @@ _RAW_RULES: list[tuple[str, str, re.Pattern[str]]] = [
         re.compile(r"\b(?:sk|rk)_live_[A-Za-z0-9]{24,}\b")),
     ("stripe-test", "Stripe test secret key",
         re.compile(r"\b(?:sk|rk)_test_[A-Za-z0-9]{24,}\b")),
+    ("stripe-webhook-secret", "Stripe webhook signing secret",
+        # Stripe documents the whsec_ prefix and a 32-character example;
+        # its CLI treats the body as base64 with optional padding. Keep the
+        # range bounded while covering both Dashboard and CLI variants.
+        re.compile(
+            r"(?<![A-Za-z0-9_+/-])whsec_[A-Za-z0-9+/]{32,64}={0,2}"
+            r"(?![A-Za-z0-9_+/=-])"
+        )),
     ("openai", "OpenAI API key",
         # (?!ant-) / (?!or-v1-) keep this broad rule from shadowing Anthropic
         # and OpenRouter keys, which would otherwise tie on span and win the
@@ -657,6 +665,7 @@ _PREFILTER: dict[str, tuple[str, ...]] = {
 _PREFILTER.update({
     "stripe-live":         ("sk_live_", "rk_live_"),
     "stripe-test":         ("sk_test_", "rk_test_"),
+    "stripe-webhook-secret": ("whsec_",),
     "pinecone-api-key":    ("pcsk_",),
     "supabase-access-token": ("sbp_",),
     "supabase-secret-key":   ("sb_secret_",),
@@ -782,6 +791,7 @@ ROTATION_GUIDANCE: dict[str, str] = {
     "github-fine-grained": "Revoke: https://github.com/settings/tokens?type=beta",
     "stripe-live": "Roll: https://dashboard.stripe.com/apikeys",
     "stripe-test": "Roll: https://dashboard.stripe.com/test/apikeys",
+    "stripe-webhook-secret": "Roll: https://dashboard.stripe.com/webhooks (select the endpoint, then roll its signing secret)",
     "openai": "Revoke: https://platform.openai.com/api-keys",
     "anthropic": "Revoke: https://console.anthropic.com/settings/keys",
     "google-api": "Rotate: https://console.cloud.google.com/apis/credentials",

--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -49,14 +49,16 @@ _RAW_RULES: list[tuple[str, str, re.Pattern[str]]] = [
         # its CLI treats the body as base64 with optional padding. Keep the
         # range bounded while covering both Dashboard and CLI variants. A raw
         # slash can also delimit a URL path, so match that context separately
-        # without consuming the next path segment. Prefer the first legal path
-        # boundary so later segments stay outside the finding; try the adjacent
-        # `//` form first to retain a body-terminal slash. The generic branch
-        # covers non-path contexts.
+        # without consuming the next path segment. Check the exact upper bound
+        # before shorter candidates so late or adjacent body slashes remain in
+        # a 64-character credential. Shorter forms prefer the first legal path
+        # boundary, with adjacent `//` retaining a body-terminal slash. The
+        # generic branch covers non-path contexts.
         re.compile(
             r"(?<![A-Za-z0-9_+])whsec_(?:"
-            r"[A-Za-z0-9+/]{31,63}?/={0,2}(?=/)"
-            r"|[A-Za-z0-9+/]{32,64}?={0,2}(?=/)"
+            r"[A-Za-z0-9+/]{64}={0,2}(?=/)"
+            r"|[A-Za-z0-9+/]{31,62}?/={0,2}(?=/)"
+            r"|[A-Za-z0-9+/]{32,63}?={0,2}(?=/)"
             r"|[A-Za-z0-9+/]{32,64}={0,2}(?![A-Za-z0-9_+/=])"
             r")"
         )),

--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -49,12 +49,14 @@ _RAW_RULES: list[tuple[str, str, re.Pattern[str]]] = [
         # its CLI treats the body as base64 with optional padding. Keep the
         # range bounded while covering both Dashboard and CLI variants. A raw
         # slash can also delimit a URL path, so match that context separately
-        # without consuming the next path segment. The greedy URL branch keeps
-        # internal or terminal body slashes, then backtracks to the following
-        # path delimiter; the generic branch covers non-path contexts.
+        # without consuming the next path segment. Prefer the first legal path
+        # boundary so later segments stay outside the finding; try the adjacent
+        # `//` form first to retain a body-terminal slash. The generic branch
+        # covers non-path contexts.
         re.compile(
             r"(?<![A-Za-z0-9_+])whsec_(?:"
-            r"[A-Za-z0-9+/]{32,64}={0,2}(?=/)"
+            r"[A-Za-z0-9+/]{31,63}?/={0,2}(?=/)"
+            r"|[A-Za-z0-9+/]{32,64}?={0,2}(?=/)"
             r"|[A-Za-z0-9+/]{32,64}={0,2}(?![A-Za-z0-9_+/=])"
             r")"
         )),

--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -47,10 +47,15 @@ _RAW_RULES: list[tuple[str, str, re.Pattern[str]]] = [
     ("stripe-webhook-secret", "Stripe webhook signing secret",
         # Stripe documents the whsec_ prefix and a 32-character example;
         # its CLI treats the body as base64 with optional padding. Keep the
-        # range bounded while covering both Dashboard and CLI variants.
+        # range bounded while covering both Dashboard and CLI variants. A raw
+        # slash can also delimit a URL path, so match that context separately
+        # without consuming the next path segment; the generic branch retains
+        # slash as a valid base64 body character.
         re.compile(
-            r"(?<![A-Za-z0-9_+/-])whsec_[A-Za-z0-9+/]{32,64}={0,2}"
-            r"(?![A-Za-z0-9_+/=-])"
+            r"(?<![A-Za-z0-9_+])whsec_(?:"
+            r"[A-Za-z0-9+]{32,64}={0,2}(?=/)"
+            r"|[A-Za-z0-9+/]{32,64}={0,2}(?![A-Za-z0-9_+/=])"
+            r")"
         )),
     ("openai", "OpenAI API key",
         # (?!ant-) / (?!or-v1-) keep this broad rule from shadowing Anthropic

--- a/tests/test_regex_engine_parity.py
+++ b/tests/test_regex_engine_parity.py
@@ -21,6 +21,7 @@ def _core_fixtures() -> dict[str, str]:
         "github-fine-grained": "github_pat_" + "a" * 82,
         "stripe-live": "sk_live_" + "a" * 24,
         "stripe-test": "sk_test_" + "a" * 24,
+        "stripe-webhook-secret": "wh" + "sec_" + "a" * 40,
         "openai": "sk-proj-" + "a" * 40,
         "pinecone-api-key": "pc" "sk_" + "a" * 104,
         "anthropic": "sk-ant-api03-" + "a" * 32,

--- a/tests/test_scan_performance.py
+++ b/tests/test_scan_performance.py
@@ -81,10 +81,11 @@ def test_prefilter_literals_are_truly_present_in_fixtures():
 
 def test_prefilter_covers_anchored_and_context_rules():
     # Anchored-prefix rules are now gated on their literal anchor too, so a
-    # giant non-secret string skips ~all 205 regexes via cheap substring
+    # giant non-secret string skips ~all 207 regexes via cheap substring
     # checks instead of full regex passes.
     assert _PREFILTER.get("aws-access-key") == ("akia",)
     assert _PREFILTER.get("github-pat") == ("ghp_",)
+    assert _PREFILTER.get("stripe-webhook-secret") == ("whsec_",)
     assert _PREFILTER.get("pinecone-api-key") == ("pcsk_",)
     assert _PREFILTER.get("gitlab-pat") == ("glpat-",)
     # Context rules keep their any-of provider keywords.
@@ -94,7 +95,7 @@ def test_prefilter_covers_anchored_and_context_rules():
         "bintray",
         "xray",
     }
-    # Most of the 205 rules now have an anchor; the few without one (short or
+    # Most of the 207 rules now have an anchor; the few without one (short or
     # non-literal leads) simply always run — still correct.
     assert len(_PREFILTER) > 150
 

--- a/tests/test_stripe_webhook_rule.py
+++ b/tests/test_stripe_webhook_rule.py
@@ -1,0 +1,80 @@
+"""Regression coverage for Stripe webhook endpoint signing secrets."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.scanner import ROTATION_GUIDANCE, scan_text  # noqa: E402
+
+_PREFIX = "wh" + "sec_"
+
+
+def _secret(body_length: int = 40, *, padding: str = "") -> str:
+    return _PREFIX + "A" * body_length + padding
+
+
+def _rules(text: str) -> list[str]:
+    return [finding.rule for finding in scan_text(text)]
+
+
+def test_detects_stripe_webhook_secret_and_includes_rotation_guidance():
+    assert _rules(_secret()) == ["stripe-webhook-secret"]
+
+    guidance = ROTATION_GUIDANCE["stripe-webhook-secret"]
+    assert "Roll" in guidance
+    assert "dashboard.stripe.com/webhooks" in guidance
+
+
+@pytest.mark.parametrize("body_length", [32, 40, 64])
+def test_stripe_webhook_secret_accepts_bounded_documented_lengths(
+    body_length: int,
+):
+    assert _rules(_secret(body_length)) == ["stripe-webhook-secret"]
+
+
+@pytest.mark.parametrize("body_length", [31, 65])
+def test_stripe_webhook_secret_rejects_out_of_range_lengths(body_length: int):
+    assert scan_text(_secret(body_length)) == []
+
+
+def test_stripe_webhook_secret_accepts_base64_body_and_padding():
+    secret = _PREFIX + "Ab9/" * 8 + "=="
+
+    assert _rules(secret) == ["stripe-webhook-secret"]
+
+
+@pytest.mark.parametrize("suffix", ["===", "=A", "_", "-"])
+def test_stripe_webhook_secret_rejects_invalid_suffixes(suffix: str):
+    assert scan_text(_secret(32) + suffix) == []
+
+
+@pytest.mark.parametrize(
+    "embedded",
+    [
+        "z" + _secret(),
+        "/" + _secret(),
+        "-" + _secret(),
+        _secret(64) + "z",
+        _secret(64) + "/",
+        _secret(64) + "-",
+    ],
+)
+def test_stripe_webhook_secret_rejects_embedded_tokens(embedded: str):
+    assert scan_text(embedded) == []
+
+
+@pytest.mark.parametrize(
+    "context",
+    [
+        'STRIPE_WEBHOOK_SECRET="{secret}"',
+        "endpoint_secret = '{secret}'",
+        '{{"stripe_webhook_secret": "{secret}"}}',
+    ],
+)
+def test_stripe_webhook_secret_matches_realistic_contexts(context: str):
+    assert _rules(context.format(secret=_secret())) == ["stripe-webhook-secret"]

--- a/tests/test_stripe_webhook_rule.py
+++ b/tests/test_stripe_webhook_rule.py
@@ -74,6 +74,7 @@ def test_stripe_webhook_secret_rejects_word_like_embedding(embedded: str):
         "-{secret}",
         "{secret}-label",
         "https://example.test/hooks/{secret}/events",
+        "https://example.test/hooks/{secret}/events/more",
     ],
 )
 def test_stripe_webhook_secret_accepts_path_and_label_delimiters(context: str):
@@ -86,20 +87,25 @@ def test_stripe_webhook_secret_accepts_path_and_label_delimiters(context: str):
 
 @pytest.mark.parametrize("body_length", [32, 33, 64])
 @pytest.mark.parametrize("padding", ["", "=="])
+@pytest.mark.parametrize("path", ["/events", "/events/more"])
 def test_stripe_webhook_secret_keeps_terminal_slash_out_of_url_path(
     body_length: int,
     padding: str,
+    path: str,
 ):
     secret = _PREFIX + "A" * (body_length - 1) + "/" + padding
-    findings = scan_text(f"https://example.test/hooks/{secret}/events")
+    findings = scan_text(f"https://example.test/hooks/{secret}{path}")
 
     assert [finding.rule for finding in findings] == ["stripe-webhook-secret"]
     assert findings[0].value == secret
 
 
-def test_stripe_webhook_secret_keeps_internal_slash_and_excludes_url_path():
+@pytest.mark.parametrize("path", ["/events", "/events/more"])
+def test_stripe_webhook_secret_keeps_internal_slash_and_excludes_url_path(
+    path: str,
+):
     secret = _PREFIX + "A" * 20 + "/" + "B" * 20
-    findings = scan_text(f"https://example.test/hooks/{secret}/events")
+    findings = scan_text(f"https://example.test/hooks/{secret}{path}")
 
     assert [finding.rule for finding in findings] == ["stripe-webhook-secret"]
     assert findings[0].value == secret

--- a/tests/test_stripe_webhook_rule.py
+++ b/tests/test_stripe_webhook_rule.py
@@ -112,6 +112,24 @@ def test_stripe_webhook_secret_keeps_internal_slash_and_excludes_url_path(
 
 
 @pytest.mark.parametrize(
+    "body", ["A" * 40 + "/" + "B" * 23, "A" * 40 + "//" + "B" * 22]
+)
+@pytest.mark.parametrize("padding", ["", "=="])
+@pytest.mark.parametrize("path", ["/events", "/events/more"])
+def test_stripe_webhook_secret_keeps_late_slashes_in_max_length_body(
+    body: str,
+    padding: str,
+    path: str,
+):
+    assert len(body) == 64
+    secret = _PREFIX + body + padding
+    findings = scan_text(f"https://example.test/hooks/{secret}{path}")
+
+    assert [finding.rule for finding in findings] == ["stripe-webhook-secret"]
+    assert findings[0].value == secret
+
+
+@pytest.mark.parametrize(
     "context",
     [
         'STRIPE_WEBHOOK_SECRET="{secret}"',

--- a/tests/test_stripe_webhook_rule.py
+++ b/tests/test_stripe_webhook_rule.py
@@ -84,6 +84,19 @@ def test_stripe_webhook_secret_accepts_path_and_label_delimiters(context: str):
     assert findings[0].value == secret
 
 
+@pytest.mark.parametrize("body_length", [32, 33, 64])
+@pytest.mark.parametrize("padding", ["", "=="])
+def test_stripe_webhook_secret_keeps_terminal_slash_out_of_url_path(
+    body_length: int,
+    padding: str,
+):
+    secret = _PREFIX + "A" * (body_length - 1) + "/" + padding
+    findings = scan_text(f"https://example.test/hooks/{secret}/events")
+
+    assert [finding.rule for finding in findings] == ["stripe-webhook-secret"]
+    assert findings[0].value == secret
+
+
 @pytest.mark.parametrize(
     "context",
     [

--- a/tests/test_stripe_webhook_rule.py
+++ b/tests/test_stripe_webhook_rule.py
@@ -48,7 +48,7 @@ def test_stripe_webhook_secret_accepts_base64_body_and_padding():
     assert _rules(secret) == ["stripe-webhook-secret"]
 
 
-@pytest.mark.parametrize("suffix", ["===", "=A", "_", "-"])
+@pytest.mark.parametrize("suffix", ["===", "=A", "_"])
 def test_stripe_webhook_secret_rejects_invalid_suffixes(suffix: str):
     assert scan_text(_secret(32) + suffix) == []
 
@@ -57,15 +57,31 @@ def test_stripe_webhook_secret_rejects_invalid_suffixes(suffix: str):
     "embedded",
     [
         "z" + _secret(),
-        "/" + _secret(),
-        "-" + _secret(),
+        "_" + _secret(),
         _secret(64) + "z",
-        _secret(64) + "/",
-        _secret(64) + "-",
+        _secret(64) + "+",
+        _secret(64) + "_",
     ],
 )
-def test_stripe_webhook_secret_rejects_embedded_tokens(embedded: str):
+def test_stripe_webhook_secret_rejects_word_like_embedding(embedded: str):
     assert scan_text(embedded) == []
+
+
+@pytest.mark.parametrize(
+    "context",
+    [
+        "/{secret}",
+        "-{secret}",
+        "{secret}-label",
+        "https://example.test/hooks/{secret}/events",
+    ],
+)
+def test_stripe_webhook_secret_accepts_path_and_label_delimiters(context: str):
+    secret = _secret()
+    findings = scan_text(context.format(secret=secret))
+
+    assert [finding.rule for finding in findings] == ["stripe-webhook-secret"]
+    assert findings[0].value == secret
 
 
 @pytest.mark.parametrize(

--- a/tests/test_stripe_webhook_rule.py
+++ b/tests/test_stripe_webhook_rule.py
@@ -97,6 +97,14 @@ def test_stripe_webhook_secret_keeps_terminal_slash_out_of_url_path(
     assert findings[0].value == secret
 
 
+def test_stripe_webhook_secret_keeps_internal_slash_and_excludes_url_path():
+    secret = _PREFIX + "A" * 20 + "/" + "B" * 20
+    findings = scan_text(f"https://example.test/hooks/{secret}/events")
+
+    assert [finding.rule for finding in findings] == ["stripe-webhook-secret"]
+    assert findings[0].value == secret
+
+
 @pytest.mark.parametrize(
     "context",
     [


### PR DESCRIPTION
## What & why

AgentSweep detects Stripe live/test API keys, but not the separate `whsec_` credential used to verify webhook signatures. A leaked endpoint secret lets an attacker forge events that an application accepts as Stripe traffic.

This adds a dedicated, bounded `stripe-webhook-secret` rule and provider-specific rotation guidance. Closes #177.

### Format evidence

- Stripe's current signature-troubleshooting documentation says both Dashboard-managed and Stripe CLI endpoint secrets start with `whsec_`.
- Stripe's current Webhook Endpoint API example has a 32-character alphanumeric body.
- Stripe CLI's own reporting scrubber treats webhook-secret bodies as the Base64 alphabet with optional `=` padding.

The rule therefore accepts 32–64 Base64 characters plus at most two padding characters. The upper bound covers the issue's 40-character reproduction and CLI variants without adding an unbounded quantifier. Explicit left/right boundaries prevent a prefix or bounded substring from being extracted from a longer token.

## Changes

- add the bounded `stripe-webhook-secret` detector and a `whsec_` prefilter anchor
- add Dashboard webhook-endpoint rotation guidance
- add split synthetic fixtures for the full rule registry and mixed-engine parity
- cover minimum/maximum lengths, Base64 characters, padding, token boundaries, invalid suffixes, realistic contexts, guidance, and prefilter registration
- update documented rule and prefilter counts from 206/200 to 207/201

## Testing

```text
pytest tests/test_stripe_webhook_rule.py tests/test_regex_engine_parity.py tests/test_scan_performance.py -q
40 passed

pytest -q --basetemp <task-local-dir>
748 passed, 22 skipped

pytest tests/ -q --cov=agentsweep --cov-branch --cov-report=term-missing --basetemp <task-local-dir>
756 passed, 14 skipped; 75.73% coverage (74% required)

AGENTSWEEP_REGEX_ENGINE=auto pytest tests/test_regex_engine_parity.py tests/test_regex_engine_boundaries.py tests/test_regex_engine_concurrency.py -q --basetemp <task-local-dir>
29 passed

ruff check src tests scripts
All checks passed!

mypy src/
Success: no issues found in 30 source files

bandit -r src/ -q
No findings

deptry .
Success! No dependency issues found.

vulture src/ .vulture_whitelist.py
No findings

git diff --check
Clean
```

`ruff format --check src tests scripts` still reports the two pre-existing Pinecone fixture formatting failures in `tests/test_pinecone_rule.py` and `tests/test_regex_engine_parity.py`. The same command on clean base `c1c8fcf` reports those same two files and lines; this PR adds no formatter failure and deliberately does not fold unrelated cleanup into #177.

## Checklist

- [ ] CI is green on all platforms (pending this Draft PR's matrix)
- [x] `mypy src/` is clean
- [x] No new runtime dependency
- [x] No real secrets, tokens, or raw history-file contents are committed; fixtures are split, synthetic values
- [x] Redaction/write-path invariants are unchanged; this is scan-only
- [x] New rule has `RULES`, `ROTATION_GUIDANCE`, split fixtures, focused tests, bounded quantifiers, and a lossless prefilter anchor
- [x] New source checklist is not applicable
- [x] `--json`, SARIF, and non-TTY output paths are unchanged
- [x] `pyproject.toml` is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for Stripe webhook signing secrets in Dashboard and CLI formats.
  * Added Stripe-specific guidance for rotating detected secrets.
  * Detection coverage increased to 207 rules.

* **Bug Fixes**
  * Improved validation of webhook secret formats, lengths, padding, suffixes, and embedded tokens.
  * Improved handling of secrets appearing in URL paths and configuration contexts.

* **Documentation**
  * Updated detection counts, performance notes, and comparison tables to reflect expanded coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds detection and rotation guidance for bounded Stripe webhook signing secrets.
- Registers a losslessly prefiltered `stripe-webhook-secret` rule.
- Handles Base64 padding and URL-path boundaries while preserving exact finding spans.
- Adds focused boundary, parity, and performance-registry coverage.
- Updates documented detector and prefilter counts.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/agentsweep/scanner.py | Adds the bounded Stripe webhook-secret rule, prefilter anchor, and rotation guidance; the current alternatives address the previously reported path and span failures. |
| tests/test_stripe_webhook_rule.py | Adds comprehensive regression coverage for lengths, padding, delimiters, internal and terminal slashes, exact URL spans, and guidance. |
| tests/test_regex_engine_parity.py | Adds a split synthetic fixture so the new rule participates in mixed-engine parity checks without embedding its literal prefix. |
| tests/test_scan_performance.py | Verifies prefilter registration for the new rule and updates detector-count commentary. |
| README.md | Updates rule counts and documents Stripe webhook signing-secret coverage. |
| docs/PERF.md | Updates scanner and prefilter counts to include the new detector. |

<sub>Reviews (7): Last reviewed commit: ["Merge branch &#39;main&#39; into agent/stripe-we..."](https://github.com/ishannaik/agent-sweep/commit/ea37293dfaa7826183ebf9d04dd7f8b2024965a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54624223)</sub>

**Context used:**

- Knowledge Base — [Secret detection engine](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/agent-sweep/-/docs/secret-detection.md)
- Knowledge Base — [Regex matching engine](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/agent-sweep/-/docs/regex-matching-engine.md)

<!-- /greptile_comment -->