### PR TITLE
feat(scanner): detect Neon role passwords (npg_ prefix)

### DIFF
--- a/scripts/rules_drift.py
+++ b/scripts/rules_drift.py
@@ -70,6 +70,7 @@ OURS_TO_GITLEAKS: dict[str, str | None] = {
     "jwt": "jwt",
     "private-key-pem": "private-key",
     "db-url-with-password": None,  # no generic DB-URL rule upstream
+    "neon-role-password": None,  # no gitleaks equivalent
     "npm-token": "npm-access-token",
     "pypi-token": "pypi-upload-token",
     "sendgrid": "sendgrid-api-token",

--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -86,6 +86,11 @@ _RAW_RULES: list[tuple[str, str, re.Pattern[str]]] = [
     ("db-url-with-password", "Database URL with password",
         re.compile(r"\b(?:postgres|postgresql|mysql|mongodb(?:\+srv)?|redis|amqp)://"
                    r"[^:/\s]+:[^@\s'\"]+@[^\s'\"/]+")),
+    ("neon-role-password", "Neon role password",
+        # Neon generates role passwords as npg_ followed by a fixed 12-char
+        # alphanumeric body; they often appear bare (env vars, chat text)
+        # rather than inside a full postgres:// URL.
+        re.compile(r"(?<![A-Za-z0-9_-])npg_[A-Za-z0-9]{12}(?![A-Za-z0-9_-])")),
     ("npm-token", "npm access token",
         re.compile(r"\bnpm_[A-Za-z0-9]{36}\b")),
     ("pypi-token", "PyPI upload token",
@@ -660,6 +665,7 @@ _PREFILTER.update({
     "pinecone-api-key":    ("pcsk_",),
     "supabase-access-token": ("sbp_",),
     "supabase-secret-key":   ("sb_secret_",),
+    "neon-role-password":  ("npg_",),
     "terraform-api-token": ("atlasv1.",),
     "maxmind-license-key": ("_mmk",),
     "freemius-secret-key": ("secret_key",),
@@ -796,6 +802,7 @@ ROTATION_GUIDANCE: dict[str, str] = {
     "jwt": "Invalidate at the issuing service; short-lived tokens may expire naturally.",
     "private-key-pem": "Regenerate the key pair and rotate any authorized_keys / cert stores that reference it.",
     "db-url-with-password": "Change the database user's password and update connection strings.",
+    "neon-role-password": "Rotate: Neon console > project > Roles (reset the role's password), or `neonctl roles reset-password`.",
     "npm-token": "Revoke: https://www.npmjs.com/settings/~/tokens",
     "pypi-token": "Revoke: https://pypi.org/manage/account/token/",
     "sendgrid": "Rotate: https://app.sendgrid.com/settings/api_keys",

--- a/tests/test_neon_rule.py
+++ b/tests/test_neon_rule.py
@@ -1,0 +1,40 @@
+"""Regression coverage for Neon role passwords (npg_ prefix)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.scanner import ROTATION_GUIDANCE, scan_text  # noqa: E402
+
+
+def _password(body_length: int = 12) -> str:
+    return "npg" "_" + "aB3dE6gH9jKm"[:body_length]
+
+
+def test_detects_neon_role_password_and_includes_rotation_guidance():
+    findings = scan_text(_password())
+
+    assert [finding.rule for finding in findings] == ["neon-role-password"]
+    assert "Neon" in ROTATION_GUIDANCE["neon-role-password"]
+
+
+def test_neon_role_password_length_is_bounded():
+    assert scan_text(_password(11)) == []
+    assert scan_text(_password(12) + "z") == []
+
+
+@pytest.mark.parametrize(
+    "embedded",
+    [
+        "z" + _password(),
+        "-" + _password(),
+        _password() + "z",
+        _password() + "-",
+    ],
+)
+def test_neon_role_password_rejects_word_and_dash_embeds(embedded: str):
+    assert scan_text(embedded) == []

--- a/tests/test_regex_engine_parity.py
+++ b/tests/test_regex_engine_parity.py
@@ -40,6 +40,7 @@ def _core_fixtures() -> dict[str, str]:
             "-----BEGIN PRIVATE KEY-----\nsynthetic-body\n-----END PRIVATE KEY-----"
         ),
         "db-url-with-password": "postgresql://user:password@example.test/db",
+        "neon-role-password": "npg_" + "aB3dE6gH9jKm",
         "npm-token": "npm_" + "a" * 36,
         "pypi-token": "pypi-AgEIcHlwaS5vcmc" + "a" * 50,
         "sendgrid": "SG." + "a" * 22 + "." + "b" * 43,


### PR DESCRIPTION
## Summary
- Adds a `neon-role-password` rule matching bare Neon role passwords (`npg_` + the fixed 12-char alphanumeric body Neon generates), which the existing `db-url-with-password` rule misses since it requires a full `postgres://user:pass@host` URL.
- Wires in the required prefilter anchor (manual override, since the pattern uses lookaround), rotation guidance, and gitleaks-drift mapping (`None` — no upstream gitleaks equivalent).
- 12-char body length confirmed against Neon's docs plus ~30 real-world `.env` leaks found via `gh search code "neondb_owner:npg_"` — no length/charset variation observed.

Closes #179

## Test plan
- [x] `python -c "from agentsweep.scanner import scan_text; print(scan_text('npg_' + '0123456789ab'))"` returns a finding instead of `[]`
- [x] `pytest -q` — 746 passed, 10 skipped
- [x] `mypy src/` — no issues
- [x] New `tests/test_neon_rule.py`: detection + rotation guidance, exact-length boundary, word/dash-embedding rejection (mirrors `tests/test_pinecone_rule.py`)

