### PR TITLE
style: ruff format three test files left unformatted

### DIFF
--- a/tests/test_neon_rule.py
+++ b/tests/test_neon_rule.py
@@ -1,4 +1,5 @@
 """Regression coverage for Neon role passwords (npg_ prefix)."""
+
 from __future__ import annotations
 
 import sys
@@ -10,8 +11,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from agentsweep.scanner import ROTATION_GUIDANCE, scan_text  # noqa: E402
 
+
 def _password(body_length: int = 12) -> str:
-    return "npg" "_" + "a" * body_length
+    return "npg_" + "a" * body_length
 
 
 def test_detects_neon_role_password_and_includes_rotation_guidance():

--- a/tests/test_pinecone_rule.py
+++ b/tests/test_pinecone_rule.py
@@ -1,4 +1,5 @@
 """Regression coverage for legacy Pinecone project API keys."""
+
 from __future__ import annotations
 
 import sys
@@ -12,7 +13,7 @@ from agentsweep.scanner import ROTATION_GUIDANCE, scan_text  # noqa: E402
 
 
 def _key(body_length: int = 104) -> str:
-    return "pc" "sk_" + "A" * body_length
+    return "pcsk_" + "A" * body_length
 
 
 def test_detects_pinecone_api_key_and_includes_rotation_guidance():

--- a/tests/test_regex_engine_parity.py
+++ b/tests/test_regex_engine_parity.py
@@ -22,7 +22,7 @@ def _core_fixtures() -> dict[str, str]:
         "stripe-live": "sk_live_" + "a" * 24,
         "stripe-test": "sk_test_" + "a" * 24,
         "openai": "sk-proj-" + "a" * 40,
-        "pinecone-api-key": "pc" "sk_" + "a" * 104,
+        "pinecone-api-key": "pcsk_" + "a" * 104,
         "anthropic": "sk-ant-api03-" + "a" * 32,
         "google-api": "AIza" + "a" * 35,
         "google-oauth-client-secret": "GOCSPX-" + "a" * 28,
@@ -40,7 +40,7 @@ def _core_fixtures() -> dict[str, str]:
             "-----BEGIN PRIVATE KEY-----\nsynthetic-body\n-----END PRIVATE KEY-----"
         ),
         "db-url-with-password": "postgresql://user:password@example.test/db",
-        "neon-role-password": "npg" "_" + "a" * 12,
+        "neon-role-password": "npg_" + "a" * 12,
         "npm-token": "npm_" + "a" * 36,
         "pypi-token": "pypi-AgEIcHlwaS5vcmc" + "a" * 50,
         "sendgrid": "SG." + "a" * 22 + "." + "b" * 43,


### PR DESCRIPTION
Pre-existing CI failure: `Ruff lint and format` has been red on main since #191 landed the gate (main run 32344195549 fails on these exact three files). Every open PR inherits that red check.

- `tests/test_neon_rule.py`
- `tests/test_pinecone_rule.py`
- `tests/test_regex_engine_parity.py`

Pure `ruff format` output, no code changes. Merge this and PR checks go green again.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR applies Ruff formatting to three test files without changing test behavior.
- Adds formatter-required blank lines around module declarations and imports.
- Replaces implicitly concatenated string fragments with equivalent single string literals in Neon and Pinecone fixtures.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because all changes are semantics-preserving formatting updates to test fixtures.

The normalized string expressions evaluate to the same Neon and Pinecone fixture values, and the remaining edits only add formatter-required whitespace.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/test_neon_rule.py | Adds formatting whitespace and simplifies an equivalent Neon password prefix expression without changing the generated fixture. |
| tests/test_pinecone_rule.py | Replaces adjacent Pinecone key-prefix literals with their equivalent combined literal. |
| tests/test_regex_engine_parity.py | Applies the same semantics-preserving literal normalization to Neon and Pinecone parity fixtures. |

<sub>Reviews (1): Last reviewed commit: ["style: ruff format three test files left..."](https://github.com/ishannaik/agent-sweep/commit/12d4a7853d04f9608e2a456c1072b86dd4656cb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55844852)</sub>

<!-- /greptile_comment -->