### PR TITLE
feat(rules): add Tavily API key detection rule and expand Neon redaction coverage (closes #178)

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -13,11 +13,9 @@ secret:
   ignored-paths:
     - "tests/**"
   ignored-matches:
-    - name: "AWS documented example access key (fixture, appears across tests)"
-      match: "AKIAIOSFODNN7EXAMPLE"
-    - name: "Fake GitHub PAT fixture"
+ - name: "GitHub personal access token (classic) (test-only synthetic, not a real secret)"
       match: "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
     - name: "Neon role-password prefix anchor (detection-rule literal, not a real secret)"
       match: "npg_"
-    - name: "Tavily API-key prefix anchor (detection-rule literal, not a real secret)"
-      match: "tvly-"
+    - name: "Tavily API-key synthetic test fixture (test-only synthetic, not a real secret)"
+      match: "tvly-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -19,3 +19,5 @@ secret:
       match: "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
     - name: "Neon role-password prefix anchor (detection-rule literal, not a real secret)"
       match: "npg_"
+    - name: "Tavily API-key prefix anchor (detection-rule literal, not a real secret)"
+      match: "tvly-"

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,8 +1,8 @@
-# GitGuardian configuration — https://docs.gitguardian.com
+# GitGuardian configuration – https://docs.gitguardian.com
 #
 # agentsweep is a secret scanner, so its test suite deliberately embeds fake and
 # documented-example credentials as fixtures (e.g. AWS's own AKIAIOSFODNN7EXAMPLE
-# appears 30+ times) — they are the inputs the detection rules are tested against,
+# appears 30+ times) – they are the inputs the detection rules are tested against,
 # not real leaks. Scoping GitGuardian's PR check to skip them removes the false
 # positives without weakening coverage: all product source under src/ is still
 # fully scanned, and every PR is additionally reviewed by hand for backdoors and
@@ -13,7 +13,9 @@ secret:
   ignored-paths:
     - "tests/**"
   ignored-matches:
- - name: "GitHub personal access token (classic) (test-only synthetic, not a real secret)"
+    - name: "AWS documented example access key (fixture, appears across tests)"
+      match: "AKIAIOSFODNN7EXAMPLE"
+    - name: "GitHub personal access token (classic) (test-only synthetic, not a real secret)"
       match: "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
     - name: "Neon role-password prefix anchor (detection-rule literal, not a real secret)"
       match: "npg_"

--- a/scripts/rules_drift.py
+++ b/scripts/rules_drift.py
@@ -71,6 +71,7 @@ OURS_TO_GITLEAKS: dict[str, str | None] = {
     "private-key-pem": "private-key",
     "db-url-with-password": None,  # no generic DB-URL rule upstream
     "neon-role-password": None,  # no gitleaks equivalent
+    "tavily-api-key": None,  # no gitleaks equivalent
     "npm-token": "npm-access-token",
     "pypi-token": "pypi-upload-token",
     "sendgrid": "sendgrid-api-token",

--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -88,6 +88,11 @@ _RAW_RULES: list[tuple[str, str, re.Pattern[str]]] = [
                    r"[^:/\s]+:[^@\s'\"]+@[^\s'\"/]+")),
     ("neon-role-password", "Neon role password",
         re.compile(r"(?<![A-Za-z0-9_-])npg_[A-Za-z0-9]{12,64}(?![A-Za-z0-9_-])")),
+    ("tavily-api-key", "Tavily API key",
+        # Dashboard API keys are tvly- followed by exactly 40 alphanumeric
+        # body chars; the quantifier is bounded so short/near-miss strings
+        # (tvly-dev-… enterprise keys included) stay silent.
+        re.compile(r"(?<![A-Za-z0-9_-])tvly-[A-Za-z0-9]{40}(?![A-Za-z0-9_-])")),
     ("npm-token", "npm access token",
         re.compile(r"\bnpm_[A-Za-z0-9]{36}\b")),
     ("pypi-token", "PyPI upload token",
@@ -663,6 +668,7 @@ _PREFILTER.update({
     "supabase-access-token": ("sbp_",),
     "supabase-secret-key":   ("sb_secret_",),
     "neon-role-password":  ("npg" "_",),
+    "tavily-api-key":      ("tvly" "-",),
     "terraform-api-token": ("atlasv1.",),
     "maxmind-license-key": ("_mmk",),
     "freemius-secret-key": ("secret_key",),
@@ -800,6 +806,7 @@ ROTATION_GUIDANCE: dict[str, str] = {
     "private-key-pem": "Regenerate the key pair and rotate any authorized_keys / cert stores that reference it.",
     "db-url-with-password": "Change the database user's password and update connection strings.",
     "neon-role-password": "Rotate: Neon console > project > Roles (reset the role's password), or POST /projects/{project_id}/branches/{branch_id}/roles/{role_name}/reset_password via the Neon API.",
+    "tavily-api-key": "Revoke: Tavily dashboard > API Keys (click regenerate on the exposed key): https://app.tavily.com/home",
     "npm-token": "Revoke: https://www.npmjs.com/settings/~/tokens",
     "pypi-token": "Revoke: https://pypi.org/manage/account/token/",
     "sendgrid": "Rotate: https://app.sendgrid.com/settings/api_keys",

--- a/tests/test_neon_rule.py
+++ b/tests/test_neon_rule.py
@@ -42,3 +42,19 @@ def test_neon_role_password_length_is_bounded():
 )
 def test_neon_role_password_rejects_word_and_dash_embeds(embedded: str):
     assert scan_text(embedded) == []
+
+
+def test_neon_role_password_redaction_replaces_the_exposed_span():
+    from agentsweep.pipeline import _build_redactions
+
+    password = _password()
+    value = "PGPASSWORD=" + password
+    findings = scan_text(value)
+    assert findings, "fixture must produce a finding"
+
+    items = [(1, [], value, f) for f in findings]
+    [(_line, _kp, new_value)] = _build_redactions(items)
+
+    assert password not in new_value
+    assert "[REDACTED:neon-role-password]" in new_value
+    assert new_value == "PGPASSWORD=[REDACTED:neon-role-password]"

--- a/tests/test_neon_rule.py
+++ b/tests/test_neon_rule.py
@@ -13,10 +13,12 @@ from agentsweep.scanner import ROTATION_GUIDANCE, scan_text  # noqa: E402
 
 
 def _password(body_length: int = 12) -> str:
+    """Generate a synthetic Neon role password fixture with a given body length."""
     return "npg_" + "a" * body_length
 
 
 def test_detects_neon_role_password_and_includes_rotation_guidance():
+    """Verify standard Neon role password detection and inclusion of rotation guidance."""
     findings = scan_text(_password())
 
     assert [finding.rule for finding in findings] == ["neon-role-password"]
@@ -24,6 +26,7 @@ def test_detects_neon_role_password_and_includes_rotation_guidance():
 
 
 def test_neon_role_password_length_is_bounded():
+    """Verify that Neon role passwords respect the minimum (12) and maximum (64) length boundaries."""
     assert scan_text(_password(11)) == []
     assert [finding.rule for finding in scan_text(_password(64))] == [
         "neon-role-password"
@@ -41,10 +44,12 @@ def test_neon_role_password_length_is_bounded():
     ],
 )
 def test_neon_role_password_rejects_word_and_dash_embeds(embedded: str):
+    """Verify that adjacent word characters and dashes prevent false positive match boundaries."""
     assert scan_text(embedded) == []
 
 
 def test_neon_role_password_redaction_replaces_the_exposed_span():
+    """Verify that detected Neon role passwords in environment variables are correctly redacted."""
     from agentsweep.pipeline import _build_redactions
 
     password = _password()

--- a/tests/test_ported_rules.py
+++ b/tests/test_ported_rules.py
@@ -199,6 +199,7 @@ FIXTURES: dict[str, str] = {
     'sourcegraph-access-token': 'sgp_a1b2c3d4e5f6a1b2_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4' 'e5f6a1b2c3d4',
     'squarespace-access-token': 'squarespace_token = "a1b2c3d4-a1b2' '-c3d4-a1b2-c3d4a1b2c3d4"',
     'supabase-secret-key': 'sb_secret_a1a1a1a1a1' 'a1a1a1a1a1a1_b2b2b2b2',
+    'tavily-api-key': 'tvly-' + 'a1b2c3' * 6 + 'a1b2',
     'travisci-access-token': 'travis_api_token = "a1b2c3d4e' '5f6a1b2c3d4e5"',
     'twitch-api-token': 'twitch_api_token = "a1b2c3d4e5f6a1b' '2c3d4e5f6a1b2c3"',
     'twitter-access-secret': 'twitter_access_secret = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4' 'e5f6a1b2c3d4e"',

--- a/tests/test_tavily_rule.py
+++ b/tests/test_tavily_rule.py
@@ -13,10 +13,12 @@ from agentsweep.scanner import ROTATION_GUIDANCE, scan_text  # noqa: E402
 
 
 def _key(body_length: int = 40) -> str:
+    """Generate a synthetic Tavily API key string with the specified body length."""
     return "tvly-" + "A" * body_length
 
 
 def test_detects_tavily_api_key_and_includes_rotation_guidance():
+    """Verify standard Tavily API key detection and presence of rotation instructions."""
     findings = scan_text(_key())
 
     assert [finding.rule for finding in findings] == ["tavily-api-key"]
@@ -25,6 +27,7 @@ def test_detects_tavily_api_key_and_includes_rotation_guidance():
 
 
 def test_tavily_api_key_length_is_bounded():
+    """Verify that Tavily keys outside the exact 40-character body boundary are ignored."""
     assert scan_text(_key(39)) == []
     assert scan_text(_key(41)) == []
 
@@ -39,10 +42,12 @@ def test_tavily_api_key_length_is_bounded():
     ],
 )
 def test_tavily_api_key_rejects_word_and_dash_embeds(embedded: str):
+    """Verify that boundary characters like adjacent words or dashes prevent false matches."""
     assert scan_text(embedded) == []
 
 
 def test_tavily_api_key_redaction_replaces_the_exposed_span():
+    """Verify that detected Tavily API keys are correctly replaced by the redaction marker."""
     from agentsweep.pipeline import _build_redactions
 
     key = _key()

--- a/tests/test_tavily_rule.py
+++ b/tests/test_tavily_rule.py
@@ -1,0 +1,58 @@
+"""Regression coverage for Tavily API keys (tvly- prefix)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.scanner import ROTATION_GUIDANCE, scan_text  # noqa: E402
+
+
+def _key(body_length: int = 40) -> str:
+    return "tvly-" + "A" * body_length
+
+
+def test_detects_tavily_api_key_and_includes_rotation_guidance():
+    findings = scan_text(_key())
+
+    assert [finding.rule for finding in findings] == ["tavily-api-key"]
+    assert findings[0].value == _key()
+    assert "app.tavily.com" in ROTATION_GUIDANCE["tavily-api-key"]
+
+
+def test_tavily_api_key_length_is_bounded():
+    assert scan_text(_key(39)) == []
+    assert scan_text(_key(41)) == []
+
+
+@pytest.mark.parametrize(
+    "embedded",
+    [
+        "z" + _key(),
+        "-" + _key(),
+        _key() + "z",
+        _key() + "-",
+    ],
+)
+def test_tavily_api_key_rejects_word_and_dash_embeds(embedded: str):
+    assert scan_text(embedded) == []
+
+
+def test_tavily_api_key_redaction_replaces_the_exposed_span():
+    from agentsweep.pipeline import _build_redactions
+
+    key = _key()
+    value = "export TAVILY_API_KEY=" + key
+    findings = scan_text(value)
+    assert findings, "fixture must produce a finding"
+
+    items = [(1, [], value, f) for f in findings]
+    [(_line, _kp, new_value)] = _build_redactions(items)
+
+    assert key not in new_value
+    assert "[REDACTED:tavily-api-key]" in new_value
+    assert new_value == "export TAVILY_API_KEY=[REDACTED:tavily-api-key]"


### PR DESCRIPTION
## Description
Closes #178. Implements the Tavily API key secret detection rule (`tavily-api-key`) with bounded length anchors and adds missing redaction test coverage for the Neon role password rule.

## Key Changes

### 1. Tavily API Key Rule (`#178`)
- **`src/agentsweep/scanner.py`**:
  - Added `tavily-api-key` rule matching `tvly-` prefix followed by exactly 40 alphanumeric characters with boundary enforcement (skips `tvly-dev-` enterprise variations).
  - Added `("tvly", "-")` prefilter anchor literal split to avoid self-flagging source files.
  - Added rotation remediation guidance linking to the Tavily dashboard.
- **`tests/test_tavily_rule.py`**: Added unit tests covering positive matches, length boundary constraints (39/41 char rejections), embed/dash boundary handling, and `_build_redactions` span replacement.
- **`tests/test_ported_rules.py`**: Added synthetic parity fixture matching the 40-character requirement.
- **`scripts/rules_drift.py` & `.gitguardian.yaml`**: Registered rule mapping and updated scanner ignore list.

### 2. Neon Redaction Coverage (`#179`)
- **`tests/test_neon_rule.py`**: Added `test_neon_role_password_redaction_replaces_the_exposed_span` to explicitly verify span-based redaction on exposed `npg_` secrets.

## Verification
- Ran full test suite via `pytest`: **745 passed, 22 skipped, 0 failed**.
- Verified rule parity check via `scripts/rules_drift.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for Tavily API keys with precise matching to reduce false positives.
  * Added rotation guidance for detected Tavily API keys.

* **Bug Fixes**
  * Confirmed Neon role-password findings are fully redacted with the appropriate marker.

* **Tests**
  * Added coverage for Tavily key detection, boundary conditions, rotation guidance, and redaction behavior.
  * Added regression coverage to verify sensitive findings are removed from displayed output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds Tavily API-key detection and remediation metadata while extending synthetic parity, boundary, and redaction coverage.
- Detects bounded `tvly-` credentials through a lossless literal prefilter.
- Registers Tavily in rule-drift checks and adds provider-specific rotation guidance.
- Adds Tavily and Neon redaction regression tests.
- Narrows the GitGuardian exception to the exact synthetic Tavily fixture.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/agentsweep/scanner.py | Adds the bounded Tavily rule, matching prefilter anchor, and rotation guidance without leaving an eligible follow-up issue. |
| .gitguardian.yaml | Uses valid YAML and restricts the Tavily ignore to the exact synthetic fixture, resolving both previous findings. |
| scripts/rules_drift.py | Registers Tavily as a scanner-specific rule with no upstream Gitleaks equivalent. |
| tests/test_tavily_rule.py | Covers detection, exact-length and embedding boundaries, guidance, and span-based redaction. |
| tests/test_neon_rule.py | Adds explicit regression coverage for Neon role-password redaction. |

<sub>Reviews (3): Last reviewed commit: ["fix(ci): fix yaml indentation in .gitgua..."](https://github.com/ishannaik/agent-sweep/commit/fd0e71fd6821d49f9197f4d20da5a67a88a083f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58275896)</sub>

<!-- /greptile_comment -->