### PR TITLE
detection-rule: add Vercel vcp_ personal access token (#114)

### DIFF
--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -112,6 +112,8 @@ _RAW_RULES: list[tuple[str, str, re.Pattern[str]]] = [
         # body chars; the quantifier is bounded so short/near-miss strings
         # (tvly-dev-… enterprise keys included) stay silent.
         re.compile(r"(?<![A-Za-z0-9_-])tvly-[A-Za-z0-9]{40}(?![A-Za-z0-9_-])")),
+    ("vercel-api-token", "Vercel API Access Token",
+        re.compile(r"\bvcp_[A-Za-z0-9]{24}\b")),
     ("npm-token", "npm access token",
         re.compile(r"\bnpm_[A-Za-z0-9]{36}\b")),
     ("pypi-token", "PyPI upload token",
@@ -890,6 +892,7 @@ ROTATION_GUIDANCE: dict[str, str] = {
     "db-url-with-password": "Change the database user's password and update connection strings.",
     "neon-role-password": "Rotate: Neon console > project > Roles (reset the role's password), or POST /projects/{project_id}/branches/{branch_id}/roles/{role_name}/reset_password via the Neon API.",
     "tavily-api-key": "Revoke: Tavily dashboard > API Keys (click regenerate on the exposed key): https://app.tavily.com/home",
+    "vercel-api-token": "Revoke and rotate at https://vercel.com/account/tokens.",
     "npm-token": "Revoke: https://www.npmjs.com/settings/~/tokens",
     "pypi-token": "Revoke: https://pypi.org/manage/account/token/",
     "sendgrid": "Rotate: https://app.sendgrid.com/settings/api_keys",

--- a/tests/test_ported_rules.py
+++ b/tests/test_ported_rules.py
@@ -200,6 +200,10 @@ FIXTURES: dict[str, str] = {
     'squarespace-access-token': 'squarespace_token = "a1b2c3d4-a1b2' '-c3d4-a1b2-c3d4a1b2c3d4"',
     'supabase-secret-key': 'sb_secret_a1a1a1a1a1' 'a1a1a1a1a1a1_b2b2b2b2',
     'tavily-api-key': 'tvly-' + 'a1b2c3' * 6 + 'a1b2',
+    "vercel-api-token": (
+        "vcp_"
+        "abcdEFGH1234ijklMNOP5678"
+    ),
     'travisci-access-token': 'travis_api_token = "a1b2c3d4e' '5f6a1b2c3d4e5"',
     'twitch-api-token': 'twitch_api_token = "a1b2c3d4e5f6a1b' '2c3d4e5f6a1b2c3"',
     'twitter-access-secret': 'twitter_access_secret = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4' 'e5f6a1b2c3d4e"',


### PR DESCRIPTION
<!--
Thanks for contributing to agentsweep! Fill in the sections below.
Keep PRs focused — one concern per PR (a CI fix and a feature should be
two PRs). See CONTRIBUTING.md for the project's conventions.
-->

## What & why

Adds detection for Vercel's `vcp_` personal access token format (prefix + 24 alphanumeric characters). `scanner.py`'s `RULES` had no Vercel coverage. Confirmed the format against Vercel's current docs (vercel.com/docs/accounts/access-tokens), not just the placeholder regex from the issue.. 

## Type of change

- [ ] Bug fix
- [ ] New agent source
- [ x] New detection rule
- [ ] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing

<!-- How did you verify this? Paste the relevant `pytest` summary. -->

```
$ python -m pytest tests/test_ported_rules.py -v
...
194 passed

$ python -m pytest -v
...
802 passed, 22 skipped
```

## Checklist

- [x ] `pytest` passes locally, and CI is green on **all** platforms (Linux **and** Windows, Python 3.11–3.13)
- [ ] `mypy src/` is clean — it runs on every matrix leg and is the most common reason a PR goes red
- [x] No new runtime dependency, or the PR explains why one is needed (the core install is deliberately three packages)
- [x ] No real secrets, tokens, or raw history-file contents are committed — tests use synthetic, non-live examples
- [ ] Redaction / write-path changes preserve the corruption-prevention invariants (path containment, atomic replace, mandatory no-clobber backup, post-write validation, line-count preservation, audit trail)
- [x] **New detection rule?** Added to `RULES` **and** `ROTATION_GUIDANCE` **and** a fixture/test, with every regex quantifier bounded (no unbounded `.*`), and the keyword pre-filter kept lossless
- [ ] **New source?** Registered in `SOURCES` with process markers, a menu entry, and a round-trip test (see CONTRIBUTING.md → "Adding a new source — checklist")
- [x] `--json` and non-tty output stay machine-clean (no banners / styling, no `ui` import on those paths)
- [x] Did not re-introduce `force-include` in `pyproject.toml`

---

Stuck on a review comment or want to talk through an approach? [Discord](https://discord.gg/KKvtRhQvRv).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection for Vercel API access tokens matching the `vcp_` format.
  - Added guidance to rotate tokens when detected.

- **Tests**
  - Added coverage to verify detection of Vercel API tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->