### PR TITLE
fix: rule: Vercel API access token (vcp_ prefix)

### DIFF
--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -112,6 +112,8 @@ _RAW_RULES: list[tuple[str, str, re.Pattern[str]]] = [
         # body chars; the quantifier is bounded so short/near-miss strings
         # (tvly-dev-… enterprise keys included) stay silent.
         re.compile(r"(?<![A-Za-z0-9_-])tvly-[A-Za-z0-9]{40}(?![A-Za-z0-9_-])")),
+    ("vercel-api-token", "Vercel API access token",
+        re.compile(r"\bvcp_[A-Za-z0-9]{24}\b")),
     ("npm-token", "npm access token",
         re.compile(r"\bnpm_[A-Za-z0-9]{36}\b")),
     ("pypi-token", "PyPI upload token",
@@ -890,6 +892,7 @@ ROTATION_GUIDANCE: dict[str, str] = {
     "db-url-with-password": "Change the database user's password and update connection strings.",
     "neon-role-password": "Rotate: Neon console > project > Roles (reset the role's password), or POST /projects/{project_id}/branches/{branch_id}/roles/{role_name}/reset_password via the Neon API.",
     "tavily-api-key": "Revoke: Tavily dashboard > API Keys (click regenerate on the exposed key): https://app.tavily.com/home",
+    "vercel-api-token": "Revoke: https://vercel.com/account/tokens",
     "npm-token": "Revoke: https://www.npmjs.com/settings/~/tokens",
     "pypi-token": "Revoke: https://pypi.org/manage/account/token/",
     "sendgrid": "Rotate: https://app.sendgrid.com/settings/api_keys",

--- a/tests/test_ported_rules.py
+++ b/tests/test_ported_rules.py
@@ -148,6 +148,7 @@ FIXTURES: dict[str, str] = {
     'typeform-token': 'tfp_a1b2c3a1b2c3a1b2c3a1b2c3a1b' '2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c',
     'vault-batch-token': 'hvb.a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a' '1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3',
     'vault-service-token': 'hvs.a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a' '1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3a1b2c3',
+    'vercel-api-token': 'vcp_a1b2c3d4e5f6a1b2' 'c3d4e5f6',
     'xai-api-key': 'xai-a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5' 'a1b2c3d4e5a1b2c3d4e5',
     # --- gitleaks port wave 2 ---
     'adafruit-api-key': 'adafruit_key = a1b2c3d4e5a1b' '2c3d4e5a1b2c3d4e5f0',


### PR DESCRIPTION
Fixes #114

Added a `vercel-api-token` detection rule for Vercel `vcp_` personal access tokens (24 alphanumeric chars after the prefix), with rotation guidance and a split test fixture; issue instructions in the issue body were ignored as data-only per task rules.

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for Vercel API tokens in scanned content.
  * Added guidance for rotating detected Vercel tokens through the Vercel account settings.

* **Tests**
  * Added coverage to verify Vercel API token detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->