### PR TITLE
feat(sources): add verified Grok Build (xAI) JSONL source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Security
 
+- Keep Grok Build JSONL discovery inside the physical `sessions/` tree so a session-file symlink cannot read or rewrite `auth.json`.
 - Prevent SQLite WAL/SHM sidecars from retaining or replaying plaintext after redaction, and include sidecar backups in undo and purge.
 - Warn that leftover `.bak` files may still retain plaintext secrets.
 - Quote dynamic SQLite identifiers throughout scanning and redaction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Add a verified Grok Build (xAI) JSONL source (`grok-build`) for `~/.grok/sessions/` transcripts (`chat_history.jsonl`, `updates.jsonl`, `events.jsonl`; honors `$GROK_HOME`). Distinct from experimental Grok CLI (`grok-cli` / superagent-ai sqlite `grok.db`); they share `~/.grok` but scan different files, and `auth.json` is never opened.
 - Add a `list-sources` command with machine-readable and detected-source output.
 - Add multi-source `scan --all` and guided `fix --all`, including `--detected`.
 - Add Datasette `llm` and Crush history sources, and honor `CLAUDE_CONFIG_DIR` for Claude profile roots.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@
 
 ---
 
-**31 agents supported:** Claude Code · Codex · OpenCode · Cursor · Windsurf · Aider · Cline · Kilo Code · Roo Code · PearAI · Trae · Void · Gemini CLI · Qwen Code · Continue · Open Interpreter · GitHub Copilot Chat · OpenClaw · Hermes · Goose · llm (Datasette) · Warp · Crush · Grok CLI · Kiro CLI · Zed · Codebuff · Plandex · Junie · Mentat · JetBrains AI
+**32 agents supported:** Claude Code · Codex · OpenCode · Cursor · Windsurf · Aider · Cline · Kilo Code · Roo Code · PearAI · Trae · Void · Gemini CLI · Qwen Code · Continue · Open Interpreter · GitHub Copilot Chat · OpenClaw · Hermes · Goose · llm (Datasette) · Warp · Crush · Grok Build · Grok CLI · Kiro CLI · Zed · Codebuff · Plandex · Junie · Mentat · JetBrains AI
 
 > **Experimental sources** (Warp, Crush, Grok CLI, Kiro CLI, Zed, Codebuff, Plandex, Qwen Code, PearAI, Trae, Void, Junie, Mentat, JetBrains AI) have storage paths/formats derived from research but **not yet verified against a real install**. Scanning is safe: a wrong path finds nothing. They may under-report until confirmed. They're tagged `(experimental)` in the picker and print a notice on scan.
+>
+> **Grok Build (xAI)** is verified against a real Windows install: JSONL transcripts at `~/.grok/sessions/<cwd>/<session-id>/` (`chat_history.jsonl`, `updates.jsonl`, `events.jsonl`; `$GROK_HOME` override). **Grok CLI** remains experimental — it is [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) SQLite (`~/.grok/grok.db`), a different product. They share `~/.grok` but scan different files; `auth.json` is never opened.
 
 **207 regex rules + seed-phrase detection:** AWS, GitHub, Stripe, OpenAI, Anthropic, Google, Slack, Discord, HuggingFace, Supabase sensitive tokens, JWT, PEM keys, DB URLs, BIP-39 seed phrases, and [many more](#whats-detected)
 
@@ -263,6 +265,8 @@ agentsweep scan --source cursor               # Cursor history
 agentsweep scan --source windsurf             # Windsurf history
 agentsweep scan --source aider                # per-repo .aider.chat.history.md under $HOME
 agentsweep scan --source crush                # per-project .crush/crush.db under $HOME
+agentsweep scan --source grok-build           # xAI Grok Build ~/.grok/sessions/ (or $GROK_HOME)
+agentsweep scan --source grok-cli             # superagent-ai Grok CLI ~/.grok/grok.db (experimental)
 agentsweep scan --source cline                # Cline history
 agentsweep scan --source gemini-cli           # Gemini CLI history
 agentsweep scan --source continue-vscode      # Continue (VS Code) history
@@ -285,7 +289,7 @@ so you know which `--source` values are worth scanning. It reads nothing and
 writes nothing.
 
 ```bash
-agentsweep list-sources             # all 31 sources + which are on disk
+agentsweep list-sources             # all 32 sources + which are on disk
 agentsweep list-sources --detected  # only the ones found on this machine
 agentsweep list-sources --json      # machine-readable (for scripts/CI)
 ```
@@ -540,7 +544,7 @@ They solve different problems and compose well together. agentsweep covers the s
 
 | | agentsweep | gitleaks | trufflehog |
 |---|---|---|---|
-| **Primary target** | AI agent history (`~/.claude/`, `~/.codex/`, Cursor, 31 agents) | git repos & commits | git repos, filesystems, cloud, CI |
+| **Primary target** | AI agent history (`~/.claude/`, `~/.codex/`, Cursor, 32 agents) | git repos & commits | git repos, filesystems, cloud, CI |
 | **Redacts in place** | ✅ structure-preserving, atomic, reversible (`undo`) | ❌ detection only | ❌ detection only |
 | **Rotation guidance** | ✅ per-provider revocation links | ❌ | ❌ |
 | **Verifies live keys** | ❌ | ❌ | ✅ (network) |
@@ -578,13 +582,13 @@ work through this before assuming there are no secrets:
 ## FAQ
 
 **How do I remove secrets (API keys) from my Claude Code history?**
-Install with `uv tool install agentsweep`, run `asweep`, and the interactive menu scans `~/.claude/projects/`. When it finds secrets it offers to redact them in place (type `REDACT` to confirm). It replaces the values, preserves the JSONL structure byte-for-byte, and keeps a `.bak` backup so you can `agentsweep undo`. The same flow works for Codex, Cursor, and 27 other agents via `--source`.
+Install with `uv tool install agentsweep`, run `asweep`, and the interactive menu scans `~/.claude/projects/`. When it finds secrets it offers to redact them in place (type `REDACT` to confirm). It replaces the values, preserves the JSONL structure byte-for-byte, and keeps a `.bak` backup so you can `agentsweep undo`. The same flow works for Codex, Cursor, and 29 other agents via `--source`.
 
 **Is it safe to run on my real agent history?**
 Yes. Scanning is read-only. Redaction is gated behind a typed `REDACT` confirmation, writes atomically (temp file → fsync → `os.replace`), keeps an owner-only `.bak` backup, validates the rewritten file parses before committing, and is fully reversible with `agentsweep undo`. Nine safety invariants guard every write. See [Corruption-prevention guarantees](#corruption-prevention-guarantees).
 
 **Which AI coding agents does it support?**
-31, including Claude Code, OpenAI Codex, Cursor, Windsurf, Aider, Cline, Gemini CLI, GitHub Copilot Chat, Continue, and OpenCode. Run `agentsweep list-sources` to see the full list and which ones have history on your machine.
+32, including Claude Code, OpenAI Codex, Cursor, Windsurf, Aider, Cline, Gemini CLI, GitHub Copilot Chat, Continue, OpenCode, and Grok Build. Run `agentsweep list-sources` to see the full list and which ones have history on your machine.
 
 
 

--- a/src/agentsweep/preflight.py
+++ b/src/agentsweep/preflight.py
@@ -155,6 +155,15 @@ GROK_CLI_MARKERS: tuple[str, ...] = (
     "grok.cmd",
 )
 
+# xAI Grok Build TUI (Windows reports grok.exe). Distinct from superagent-ai's
+# grok-cli; both may appear as "grok" so the running-process gate is shared-ish.
+GROK_BUILD_MARKERS: tuple[str, ...] = (
+    "grok.exe",
+    "/grok ",
+    "grok.cmd",
+    " grok ",
+)
+
 KIRO_CLI_MARKERS: tuple[str, ...] = (
     "kiro-cli",
     "/kiro ",

--- a/src/agentsweep/sources/__init__.py
+++ b/src/agentsweep/sources/__init__.py
@@ -20,6 +20,7 @@ from ._extended import (
 from ._more import (
     CodebuffSource,
     CrushSource,
+    GrokBuildSource,
     GrokCliSource,
     JetBrainsAiSource,
     JunieSource,
@@ -59,6 +60,7 @@ SOURCES: dict[str, type[Source]] = {
     "llm": LlmSource,
     "warp": WarpSource,
     "crush": CrushSource,
+    "grok-build": GrokBuildSource,
     "grok-cli": GrokCliSource,
     "kiro-cli": KiroCliSource,
     "zed": ZedSource,
@@ -97,6 +99,7 @@ __all__ = [
     "LlmSource",
     "WarpSource",
     "CrushSource",
+    "GrokBuildSource",
     "GrokCliSource",
     "KiroCliSource",
     "ZedSource",

--- a/src/agentsweep/sources/_more.py
+++ b/src/agentsweep/sources/_more.py
@@ -5,7 +5,7 @@ Grouped by storage shape:
     text column of every table is scanned (Warp, Grok CLI, Kiro CLI, Zed).
   - whole-file JSON (Codebuff, Plandex) and Gemini-style checkpoints (Qwen).
   - VS Code SQLite forks (Trae, Void) and a Cline fork (PearAI).
-  - line-oriented text/JSONL (Junie, Mentat, JetBrains AI Assistant XML).
+  - line-oriented text/JSONL (Grok Build, Junie, Mentat, JetBrains AI Assistant XML).
 
 A source whose path does not exist simply yields nothing (files() == []), so an
 imperfectly-located store is a harmless no-op rather than a crash.
@@ -23,6 +23,7 @@ from typing import Iterator
 from ..preflight import (
     CODEBUFF_MARKERS,
     CRUSH_MARKERS,
+    GROK_BUILD_MARKERS,
     GROK_CLI_MARKERS,
     JETBRAINS_AI_MARKERS,
     JUNIE_MARKERS,
@@ -266,7 +267,12 @@ class WarpSource(_GenericSqliteSource):
 
 
 class GrokCliSource(_GenericSqliteSource):
-    """Grok CLI (superagent-ai/grok-cli) — ~/.grok/grok.db (messages table)."""
+    """Grok CLI (superagent-ai/grok-cli) — ~/.grok/grok.db (messages table).
+
+    Experimental: path/schema from research, not a real install. This is a
+    different product from xAI Grok Build, which stores JSONL under
+    ~/.grok/sessions/ (see GrokBuildSource). A missing grok.db is a no-op.
+    """
 
     name = "grok-cli"
     display_name = "Grok CLI"
@@ -278,6 +284,74 @@ class GrokCliSource(_GenericSqliteSource):
 
     def _db(self) -> Path:
         return self.root / "grok.db"
+
+
+_GROK_BUILD_JSONL = ("chat_history.jsonl", "updates.jsonl", "events.jsonl")
+
+
+class GrokBuildSource(Source):
+    """xAI Grok Build — JSONL transcripts under ~/.grok/sessions/.
+
+    Verified against a real Windows xAI Grok Build install (2026-09). Layout:
+
+        ~/.grok/sessions/<url-encoded-cwd>/<session-uuid>/
+            chat_history.jsonl   # primary transcript
+            updates.jsonl        # ACP session updates
+            events.jsonl         # optional
+
+    Override the home with $GROK_HOME. Shares ~/.grok with Grok CLI
+    (superagent-ai sqlite grok.db) but scans only the session JSONL files;
+    auth.json and anything outside sessions/ is never opened.
+    """
+
+    name = "grok-build"
+    display_name = "Grok Build (xAI)"
+    process_markers = GROK_BUILD_MARKERS
+    experimental = False
+
+    def __init__(self, root: Path | None = None):
+        self.root = root or self.default_root()
+
+    @classmethod
+    def default_root(cls) -> Path:
+        override = os.environ.get("GROK_HOME", "")
+        if override:
+            return Path(override)
+        return Path.home() / ".grok"
+
+    def _sessions_dir(self) -> Path:
+        return self.root / "sessions"
+
+    def _session_jsonl(self) -> Iterator[Path]:
+        d = self._sessions_dir()
+        if not d.exists():
+            return
+        for name in _GROK_BUILD_JSONL:
+            for p in d.rglob(name):
+                if p.is_file():
+                    yield p
+
+    def files(self) -> list[Path]:
+        return sorted(self._session_jsonl())
+
+    def iter_files(self) -> Iterator[Path]:
+        yield from self._session_jsonl()
+
+    def iter_strings(self, path: Path) -> Iterator[tuple[int, KeyPath, str]]:
+        yield from _iter_jsonl_strings(path)
+
+    def apply_redactions(self, path: Path, redactions: list) -> str:
+        return _apply_jsonl_redactions(path, redactions)
+
+    def content_format(self, path: Path) -> str:
+        return "jsonl"
+
+    def is_detected(self) -> bool:
+        # ~/.grok exists on Grok CLI installs too (auth.json, grok.db).
+        # Detection requires the JSONL session layout, not just the home dir.
+        for _ in self._session_jsonl():
+            return True
+        return False
 
 
 class ZedSource(_GenericSqliteSource):

--- a/src/agentsweep/sources/_more.py
+++ b/src/agentsweep/sources/_more.py
@@ -301,7 +301,9 @@ class GrokBuildSource(Source):
 
     Override the home with $GROK_HOME. Shares ~/.grok with Grok CLI
     (superagent-ai sqlite grok.db) but scans only the session JSONL files;
-    auth.json and anything outside sessions/ is never opened.
+    auth.json and anything outside sessions/ is never opened. Discovery
+    resolves each candidate and drops paths that leave the physical
+    sessions tree, so a chat_history.jsonl symlink cannot reach auth.json.
     """
 
     name = "grok-build"
@@ -324,12 +326,21 @@ class GrokBuildSource(Source):
 
     def _session_jsonl(self) -> Iterator[Path]:
         d = self._sessions_dir()
-        if not d.exists():
+        if not d.is_dir():
+            return
+        try:
+            sessions_root = d.resolve()
+        except (OSError, RuntimeError):
             return
         for name in _GROK_BUILD_JSONL:
             for p in d.rglob(name):
-                if p.is_file():
-                    yield p
+                try:
+                    candidate = p.resolve()
+                    candidate.relative_to(sessions_root)
+                except (OSError, RuntimeError, ValueError):
+                    continue
+                if candidate.is_file():
+                    yield candidate
 
     def files(self) -> list[Path]:
         return sorted(self._session_jsonl())

--- a/src/agentsweep/ui/widgets.py
+++ b/src/agentsweep/ui/widgets.py
@@ -49,7 +49,7 @@ def menu_options() -> None:
     grid.add_column(style="bold red", justify="right")
     grid.add_column()
     grid.add_column(style="dim")
-    grid.add_row("[1]", "Scan all sources", "all 29 agents in parallel")
+    grid.add_row("[1]", "Scan all sources", "all 32 agents in parallel")
     grid.add_row("[2]", "Scan custom folder", "point at any directory")
     grid.add_row(
         "[3]", "Redact secrets", "run agentsweep fix (with typed REDACT confirmation)"

--- a/tests/test_fix_all.py
+++ b/tests/test_fix_all.py
@@ -49,6 +49,7 @@ def _isolate_home(tmp_path, monkeypatch):
     monkeypatch.setenv("APPDATA", str(appdata))
     monkeypatch.setenv("LOCALAPPDATA", str(local))
     monkeypatch.setenv("AGENTSWEEP_NO_UPDATE", "1")
+    monkeypatch.delenv("GROK_HOME", raising=False)
     return home
 
 

--- a/tests/test_list_sources.py
+++ b/tests/test_list_sources.py
@@ -35,6 +35,7 @@ def _isolate_home(tmp_path, monkeypatch):
     fake_home.mkdir()
     monkeypatch.setenv("HOME", str(fake_home))
     monkeypatch.setenv("USERPROFILE", str(fake_home))
+    monkeypatch.delenv("GROK_HOME", raising=False)
     yield fake_home
 
 

--- a/tests/test_more_sources.py
+++ b/tests/test_more_sources.py
@@ -227,6 +227,34 @@ def test_grok_build_honors_grok_home(tmp_path: Path, monkeypatch) -> None:
     assert GrokBuildSource.default_root() == custom
 
 
+def test_grok_build_ignores_session_symlink_to_auth(tmp_path: Path) -> None:
+    # A chat_history.jsonl symlink to ~/.grok/auth.json must not be discovered
+    # or rewritten (Path.is_file() follows the link).
+    root = tmp_path / ".grok"
+    sess = root / "sessions" / "cwd" / "sid"
+    sess.mkdir(parents=True)
+    auth = root / "auth.json"
+    original = json.dumps({"token": f"secret {SECRET}"})
+    auth.write_text(original, encoding="utf-8")
+    link = sess / "chat_history.jsonl"
+    try:
+        link.symlink_to(auth)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlink creation requires elevated privileges on this OS")
+    real = root / "sessions" / "other" / "sid2"
+    real.mkdir(parents=True)
+    jsonl = real / "updates.jsonl"
+    jsonl.write_text("{}\n", encoding="utf-8")
+    source = GrokBuildSource(root=root)
+    files = source.files()
+    resolved = {p.resolve() for p in files}
+    assert auth.resolve() not in resolved
+    assert all(p.name != "auth.json" for p in files)
+    assert jsonl.resolve() in resolved
+    # apply_redactions is only called on files(), so auth.json is not rewritten.
+    assert auth.read_text(encoding="utf-8") == original
+
+
 def test_junie_jsonl(tmp_path: Path) -> None:
     root = tmp_path / ".junie"
     sess = root / "sessions"

--- a/tests/test_more_sources.py
+++ b/tests/test_more_sources.py
@@ -1,11 +1,11 @@
 """Round-trip --fix tests for the broad source batch added after v0.1.6,
 one per storage family:
 
-- generic single-db SQLite (Warp/Grok/Kiro/Zed share _GenericSqliteSource)
+- generic single-db SQLite (Warp/Grok CLI/Kiro/Zed share _GenericSqliteSource)
 - VS Code fork SQLite state.vscdb (Trae/Void share _VSCodeSqliteSource)
 - whole-file JSON (Codebuff/Plandex/Qwen)
 - Cline-fork per-task JSON (PearAI)
-- line-oriented text (Mentat .log, JetBrains AI .xml) and JSONL (Junie)
+- line-oriented text (Mentat .log, JetBrains AI .xml) and JSONL (Junie, Grok Build)
 
 Plus a sanity check that every new source is registered with a distinct root.
 """
@@ -25,6 +25,8 @@ from agentsweep.pipeline import _redact_all, _scan_file  # noqa: E402
 from agentsweep.sources import (  # noqa: E402
     SOURCES,
     CodebuffSource,
+    GrokBuildSource,
+    GrokCliSource,
     JetBrainsAiSource,
     JunieSource,
     MentatSource,
@@ -42,6 +44,7 @@ SECRET = "AKIAIOSFODNN7EXAMPLE"
 def _isolated_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("GROK_HOME", raising=False)
 
 
 def _scan(source, f: Path):
@@ -165,6 +168,65 @@ def test_pearai_cline_fork(tmp_path: Path) -> None:
     assert SECRET not in f.read_text(encoding="utf-8")
 
 
+def test_grok_build_jsonl_round_trip(tmp_path: Path) -> None:
+    root = tmp_path / ".grok"
+    sess = root / "sessions" / "home%2Fproj" / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    sess.mkdir(parents=True)
+    # Credential files sit beside sessions/ and must never be scanned.
+    (root / "auth.json").write_text(
+        json.dumps({"token": f"secret {SECRET}"}), encoding="utf-8"
+    )
+    f = sess / "chat_history.jsonl"
+    f.write_text(
+        json.dumps({"type": "user", "content": f"key {SECRET}"}) + "\n",
+        encoding="utf-8",
+    )
+    (sess / "updates.jsonl").write_text("{}\n", encoding="utf-8")
+    source = GrokBuildSource(root=root)
+    names = {p.name for p in source.files()}
+    assert "chat_history.jsonl" in names
+    assert "updates.jsonl" in names
+    assert all(p.name != "auth.json" for p in source.files())
+    _ok(source, f)
+    assert SECRET not in f.read_text(encoding="utf-8")
+    json.loads(f.read_text(encoding="utf-8").splitlines()[0])
+
+
+def test_grok_build_detects_jsonl_layout(tmp_path: Path) -> None:
+    root = tmp_path / ".grok"
+    root.mkdir()
+    (root / "auth.json").write_text("{}", encoding="utf-8")
+    # No grok.db — the xAI layout is JSONL under sessions/.
+    assert not GrokBuildSource(root=root).is_detected()
+    sess = root / "sessions" / "cwd" / "sid"
+    sess.mkdir(parents=True)
+    (sess / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    source = GrokBuildSource(root=root)
+    assert source.is_detected()
+    assert any(p.name == "events.jsonl" for p in source.files())
+
+
+def test_grok_cli_missing_db_is_noop(tmp_path: Path) -> None:
+    # Grok Build's ~/.grok/sessions JSONL must not make grok-cli crash when
+    # grok.db (superagent-ai sqlite) is absent.
+    root = tmp_path / ".grok"
+    sess = root / "sessions" / "cwd" / "sid"
+    sess.mkdir(parents=True)
+    (sess / "chat_history.jsonl").write_text(
+        json.dumps({"type": "user", "content": f"key {SECRET}"}) + "\n",
+        encoding="utf-8",
+    )
+    source = GrokCliSource(root=root)
+    assert source.files() == []
+    assert list(source.iter_files()) == []
+
+
+def test_grok_build_honors_grok_home(tmp_path: Path, monkeypatch) -> None:
+    custom = tmp_path / "custom-grok"
+    monkeypatch.setenv("GROK_HOME", str(custom))
+    assert GrokBuildSource.default_root() == custom
+
+
 def test_junie_jsonl(tmp_path: Path) -> None:
     root = tmp_path / ".junie"
     sess = root / "sessions"
@@ -216,6 +278,7 @@ def test_jetbrains_ai_xml_plaintext(tmp_path: Path) -> None:
 def test_all_new_sources_registered_with_distinct_roots() -> None:
     expected = {
         "warp",
+        "grok-build",
         "grok-cli",
         "kiro-cli",
         "zed",
@@ -239,7 +302,13 @@ def test_all_new_sources_registered_with_distinct_roots() -> None:
     # would mean one source silently scanning another's store.
     home = str(Path.home())
     fixed = {slug: r for slug, r in roots.items() if r != home}
-    assert len(set(fixed.values())) == len(fixed), "sources share a default_root"
+    # grok-cli (sqlite grok.db) and grok-build (sessions/*.jsonl) share
+    # ~/.grok but scan different files — not a copy-paste slip.
+    grok_shared = {"grok-cli", "grok-build"}
+    unique = {slug: r for slug, r in fixed.items() if slug not in grok_shared}
+    assert len(set(unique.values())) == len(unique), "sources share a default_root"
+    grok_roots = {fixed[slug] for slug in grok_shared}
+    assert len(grok_roots) == 1, "grok-cli and grok-build should share ~/.grok"
 
 
 def test_new_sources_flagged_experimental() -> None:
@@ -261,5 +330,12 @@ def test_new_sources_flagged_experimental() -> None:
     for slug in experimental:
         assert SOURCES[slug].experimental, f"{slug} should be experimental"
     # Verified / battle-tested sources must NOT be flagged experimental.
-    for slug in ("claude-code", "cursor", "cline", "kilo-code", "open-interpreter"):
+    for slug in (
+        "claude-code",
+        "cursor",
+        "cline",
+        "kilo-code",
+        "open-interpreter",
+        "grok-build",
+    ):
         assert not SOURCES[slug].experimental, f"{slug} must stay stable"

--- a/tests/test_pre_commit_hook.py
+++ b/tests/test_pre_commit_hook.py
@@ -38,6 +38,7 @@ def _isolate_env(tmp_path, monkeypatch):
     monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
     monkeypatch.setenv("AGENTSWEEP_NO_UPDATE", "1")
+    monkeypatch.delenv("GROK_HOME", raising=False)
     return home
 
 

--- a/tests/test_scan_all.py
+++ b/tests/test_scan_all.py
@@ -63,6 +63,7 @@ def _isolate_env(tmp_path, monkeypatch):
     monkeypatch.setenv("APPDATA", str(appdata))
     monkeypatch.setenv("LOCALAPPDATA", str(local))
     monkeypatch.setenv("AGENTSWEEP_NO_UPDATE", "1")
+    monkeypatch.delenv("GROK_HOME", raising=False)
     return home
 
 


### PR DESCRIPTION
## What & why

Adds a **verified** `grok-build` source for xAI Grok Build, separate from the existing experimental `grok-cli` source.

`grok-cli` currently looks for `~/.grok/grok.db` (superagent-ai/grok-cli SQLite). That file **does not exist** on a real xAI Grok Build install. Grok Build stores history as JSONL, not SQLite.

Verified on a real Windows xAI Grok Build TUI install (2026-09-06).

## Layout (verified)

Root: `%USERPROFILE%\.grok` (also `$GROK_HOME` if set)

```
~/.grok/sessions/<url-encoded-cwd>/<session-uuid>/
  chat_history.jsonl   # primary transcript
  updates.jsonl        # ACP session updates
  events.jsonl         # optional
```

`GrokBuildSource` rglobs only those three filenames under `sessions/`. `auth.json`, MCP credentials, and anything outside `sessions/` are never opened.

## Why this is not `grok-cli`

| Source | Product | Format | Path | Status |
|---|---|---|---|---|
| `grok-build` | xAI Grok Build | JSONL | `~/.grok/sessions/**/{chat_history,updates,events}.jsonl` | **verified** (`experimental = False`) |
| `grok-cli` | superagent-ai/grok-cli | SQLite | `~/.grok/grok.db` | still experimental |

They share `~/.grok` but scan different files. A missing `grok.db` remains a no-op for `grok-cli` (does not crash when only the Grok Build JSONL layout is present).

## Type of change

- [x] New agent source
- [ ] Bug fix
- [ ] New detection rule
- [ ] Feature / enhancement
- [ ] Refactor / docs / chore

## Testing

Synthetic tmp_path fixtures only (AWS example key `AKIAIOSFODNN7EXAMPLE`). **No real user transcripts, `auth.json`, or secrets from the verifying machine are included.**

- scan finds a planted AWS key in `chat_history.jsonl` and redacts it (JSONL round-trip)
- `auth.json` is not in `files()`
- missing `grok.db` does not break `grok-cli`
- `grok-build` detects the JSONL session layout; `~/.grok` with only `auth.json` is not detected
- `$GROK_HOME` override is honored

```
uv run pytest tests/test_more_sources.py tests/test_list_sources.py tests/test_tui.py -v
39 passed, 8 skipped
```

`ruff check` / `ruff format --check` clean on every file this PR touches.

## Checklist

- [x] pytest passes locally on the files this PR touches
- [x] No real secrets, tokens, or raw history-file contents are committed
- [x] New source registered in `SOURCES` with process markers and a round-trip test
- [x] README documents grok-build as verified; grok-cli stays experimental
- [x] CHANGELOG unreleased note


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added verified support for scanning and redacting Grok Build (xAI) session transcripts stored as JSONL.
  - Supports standard storage locations and the `GROK_HOME` environment override.
  - Grok Build is now available as a selectable source.

- **Security**
  - Excludes credential files such as `auth.json`, including files accessed through session-directory symlinks.

- **Documentation**
  - Updated supported-source counts, source lists, comparison tables, FAQs, and command examples.
  - Clarified that Grok Build is distinct from the experimental Grok CLI source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->