### PR TITLE
fix(scan): exit code 2 when --output write fails

### DIFF
--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -124,12 +124,21 @@ def run(
     if not files:
         print(f"No history files found under {source.root}", file=sys.stderr)
         stats_flag = getattr(args, "stats", False)
+        exit_code = 0
         if machine:
-            if args.json and stats_flag:
-                empty_stats = _stats_payload({}, source_key=source.name)
-                _emit_json_payload({"findings": [], "stats": empty_stats}, output, 0)
-            else:
-                _print_empty_machine_output()
+            if as_sarif:
+                exit_code = _emit_sarif(_json_payload({}, source), output, 0)
+            elif args.json:
+                if stats_flag:
+                    empty_stats = _stats_payload({}, source_key=source.name)
+                    exit_code = _emit_json_payload(
+                        {"findings": [], "stats": empty_stats}, output, 0
+                    )
+                else:
+                    if output is not None:
+                        exit_code = _emit_json_payload({"findings": []}, output, 0)
+                    else:
+                        _print_empty_machine_output()
         else:
             ui.stage(
                 1,
@@ -141,7 +150,7 @@ def run(
             )
             if stats_flag:
                 _show_stats(_stats_payload({}, source_key=source.name))
-        return 0
+        return exit_code
 
     ignores = (
         ignore_mod.IgnoreSet()
@@ -449,19 +458,25 @@ def run_all(args) -> int:
         )
         print(msg, file=sys.stderr)
         stats_flag = _opt(args, "stats", False)
+        exit_code = 0
         if as_json:
-            if stats_flag:
-                _emit_json_payload(
+            if as_sarif:
+                exit_code = _emit_sarif([], output, 0)
+            elif stats_flag:
+                exit_code = _emit_json_payload(
                     {"findings": [], "stats": _stats_payload_multi([])}, output, 0
                 )
             else:
-                print("[]")
+                if output is not None:
+                    exit_code = _emit_json_payload({"findings": []}, output, 0)
+                else:
+                    print("[]")
         else:
             ui.banner(__version__)
             ui.warn_line(msg)
             if stats_flag:
                 _show_stats(_stats_payload_multi([]))
-        return 0
+        return exit_code
 
     if not as_json:
         ui.banner(__version__)
@@ -547,13 +562,19 @@ def run_all(args) -> int:
     if total_files == 0:
         print("No history files found under any selected source", file=sys.stderr)
         stats_flag = _opt(args, "stats", False)
+        exit_code = 0
         if as_json:
-            if stats_flag:
-                _emit_json_payload(
+            if as_sarif:
+                exit_code = _emit_sarif([], output, 0)
+            elif stats_flag:
+                exit_code = _emit_json_payload(
                     {"findings": [], "stats": _stats_payload_multi([])}, output, 0
                 )
             else:
-                print("[]")
+                if output is not None:
+                    exit_code = _emit_json_payload({"findings": []}, output, 0)
+                else:
+                    print("[]")
         else:
             ui.stage(
                 1,
@@ -570,7 +591,7 @@ def run_all(args) -> int:
             ui.stage(4, "skip", "REDACT", "nothing to redact")
             ui.stage(5, "skip", "ROTATE", "nothing to rotate")
             ui.contribute_line()
-        return 0
+        return exit_code
 
     if not as_json:
         ui.stage(

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -215,20 +215,22 @@ def run(
 
     if not found_by_file:
         ui.stage(3, "ok", "FINDINGS", "no secrets found")
+        output_write_ok = True
         if getattr(args, "stats", False):
             empty_stats = _stats_payload(found_by_file, source_key=source.name)
             if output is not None:
-                if _write_text(
+                output_write_ok = _write_text(
                     output,
                     json.dumps({"findings": [], "stats": empty_stats}, indent=2) + "\n",
-                ):
+                )
+                if output_write_ok:
                     print(f"0 finding(s) written to {output}", file=sys.stderr)
             _show_stats(empty_stats)
         ui.stage(4, "skip", "REDACT", "nothing to redact")
         ui.stage(5, "skip", "ROTATE", "nothing to rotate")
         _warn_leftover_backups(source, as_json=False)
         ui.contribute_line()
-        return 0
+        return 0 if output_write_ok else 2
 
     total = sum(len(v) for v in found_by_file.values())
     ui.stage(
@@ -239,7 +241,7 @@ def run(
         if getattr(args, "stats", False)
         else None
     )
-    _show_findings(found_by_file, source, output, stats=stats_payload)
+    output_ok = _show_findings(found_by_file, source, output, stats=stats_payload)
     if stats_payload is not None:
         _show_stats(stats_payload)
 
@@ -256,7 +258,7 @@ def run(
         ui.contribute_line()
         if _findings_out is not None:
             _findings_out.append((source, found_by_file))
-        return 1
+        return 2 if not output_ok else 1
 
     gate_err, gate_recoverable = _preflight_gates(source, source_cls, args)
     if gate_err is not None:
@@ -277,7 +279,10 @@ def run(
     )
     if _force_recoverable_out is not None:
         _force_recoverable_out.append(recoverable)
-    return _render_redact_result(rows, errors, found_by_file)
+    fix_code = _render_redact_result(rows, errors, found_by_file)
+    if not output_ok:
+        return 2
+    return fix_code
 
 
 def _render_redact_result(rows, errors: int, found_by_file: dict) -> int:
@@ -783,20 +788,22 @@ def run_all(args) -> int:
     dirty = [(k, s, fbf) for k, s, _files, fbf, _sc, _sup, _tr in per_source if fbf]
     if not dirty:
         ui.stage(3, "ok", "FINDINGS", "no secrets found")
+        output_write_ok = True
         if getattr(args, "stats", False):
             empty_stats = _stats_payload_multi(per_source)
             if output is not None:
-                if _write_text(
+                output_write_ok = _write_text(
                     output,
                     json.dumps({"findings": [], "stats": empty_stats}, indent=2) + "\n",
-                ):
+                )
+                if output_write_ok:
                     print(f"0 finding(s) written to {output}", file=sys.stderr)
             _show_stats(empty_stats)
         ui.stage(4, "skip", "REDACT", "nothing to redact")
         ui.stage(5, "skip", "ROTATE", "nothing to rotate")
         _warn_leftover_backups_multi([s for _k, s, *_ in per_source], as_json=False)
         ui.contribute_line()
-        return 0
+        return 0 if output_write_ok else 2
 
     grand = sum(len(items) for _k, _s, fbf in dirty for items in fbf.values())
     ui.stage(3, "fail", "FINDINGS", f"{grand} secret(s) across {len(dirty)} source(s)")
@@ -837,6 +844,7 @@ def run_all(args) -> int:
     stats_payload = (
         _stats_payload_multi(per_source) if getattr(args, "stats", False) else None
     )
+    output_write_ok = True
     if output is not None:
         output_payload: JsonPayload = combined_payload
         if stats_payload is not None:
@@ -844,7 +852,10 @@ def run_all(args) -> int:
                 "findings": combined_payload,
                 "stats": stats_payload,
             }
-        if _write_text(output, json.dumps(output_payload, indent=2) + "\n"):
+        output_write_ok = _write_text(
+            output, json.dumps(output_payload, indent=2) + "\n"
+        )
+        if output_write_ok:
             ui.warn_line(f"{len(combined_payload)} finding(s) also written to {output}")
     elif needs_overflow:
         report = Path.cwd() / DEFAULT_REPORT_NAME
@@ -855,7 +866,10 @@ def run_all(args) -> int:
         _show_stats(stats_payload)
 
     if _opt(args, "fix", False):
-        return _fix_all_sources(args, dirty)
+        fix_code = _fix_all_sources(args, dirty)
+        if not output_write_ok:
+            return 2
+        return fix_code
 
     dirty_names = ", ".join(k for k, _s, _f in dirty)
     ui.stage(
@@ -870,7 +884,7 @@ def run_all(args) -> int:
     ui.rotation_panel(_rotation_items_multi(dirty))
     _warn_leftover_backups_multi([s for _k, s, *_ in per_source], as_json=False)
     ui.contribute_line()
-    return 1
+    return 2 if not output_write_ok else 1
 
 
 def _fix_all_sources(args, dirty: list[tuple[str, Source, dict]]) -> int:
@@ -1421,7 +1435,8 @@ def _emit_sarif(payload: list[dict], output: Path | None, suppressed: int) -> in
     if output is not None:
         if _write_text(output, text):
             print(f"{len(payload)} finding(s) written to {output}", file=sys.stderr)
-        return code
+            return code
+        return 2
 
     print(text, end="")
     if suppressed:
@@ -1443,7 +1458,8 @@ def _emit_json_payload(
     if output is not None:
         if _write_text(output, json.dumps(payload, indent=2) + "\n"):
             print(f"{count} finding(s) written to {output}", file=sys.stderr)
-        return code
+            return code
+        return 2
 
     flood = count > JSON_FLOOD_LIMIT and getattr(sys.stdout, "isatty", lambda: False)()
 
@@ -1512,7 +1528,7 @@ def _show_findings(
     output: Path | None,
     *,
     stats: JsonObject | None = None,
-) -> None:
+) -> bool:
     """Human findings table — capped on a real terminal so a huge scan can't
     bury the screen; the full set always goes to a report file in that case
     (or to -o if given)."""
@@ -1545,6 +1561,8 @@ def _show_findings(
         ui.findings_table(rows, source.root)
         if wrote_output:
             ui.warn_line(f"{len(rows)} finding(s) also written to {output}")
+
+    return output is None or wrote_output
 
 
 def _text_report(found_by_file: dict, source: Source) -> str:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -543,6 +543,51 @@ def test_sarif_write_failure_exits_2(tmp_path, capsys):
     assert not bad_out.exists()
 
 
+def test_json_no_history_with_output_write_failure_exits_2(tmp_path, capsys):
+    """JSON + -o on an empty root: write failure -> exit 2, stdout clean."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    bad_out = tmp_path / "no_such_dir" / "report.json"
+
+    code = main(["scan", "--root", str(empty), "--json", "-o", str(bad_out)])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert "Could not write" in captured.err
+    assert captured.out == ""
+    assert not bad_out.exists()
+
+
+def test_sarif_no_history_with_output_write_failure_exits_2(tmp_path, capsys):
+    """SARIF + -o on an empty root: write failure -> exit 2, stdout clean."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    bad_out = tmp_path / "no_such_dir" / "report.sarif"
+
+    code = main(["scan", "--root", str(empty), "--format", "sarif", "-o", str(bad_out)])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert "Could not write" in captured.err
+    assert captured.out == ""
+    assert not bad_out.exists()
+
+
+def test_json_no_history_stats_with_output_write_failure_exits_2(tmp_path, capsys):
+    """JSON + --stats + -o on an empty root: write failure -> exit 2, stdout clean."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    bad_out = tmp_path / "no_such_dir" / "report.json"
+
+    code = main(["scan", "--root", str(empty), "--json", "--stats", "-o", str(bad_out)])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert "Could not write" in captured.err
+    assert captured.out == ""
+    assert not bad_out.exists()
+
+
 def test_no_ignore_flag_skips_ignore_file(tmp_path, capsys):
     """--no-ignore means .agentsweepignore is not loaded (no suppression)."""
     # Use a file with only the AWS key so a single ignore rule covers everything.

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -452,9 +452,8 @@ def test_output_file_parent_does_not_exist_does_not_crash(tmp_path, capsys):
     code = main(["scan", "--root", str(root), "--json", "-o", str(out_file)])
     captured = capsys.readouterr()
 
-    # Exit code should still reflect findings (1) or write-error (2 via _write_text)
-    # but should not be a Python exception / unhandled crash.
-    assert code in (1, 2)
+    # Exit code should be 2 (write-error) — not a Python exception / unhandled crash.
+    assert code == 2
     # No Python traceback on stderr
     assert "Traceback" not in captured.err
 
@@ -510,7 +509,7 @@ def test_json_write_failure_no_false_written_claim(tmp_path, capsys):
     code = main(["scan", "--root", str(root), "--json", "-o", str(bad_out)])
     captured = capsys.readouterr()
 
-    assert code == 1
+    assert code == 2
     assert "Could not write" in captured.err
     assert "written to" not in captured.err
     assert not bad_out.exists()
@@ -524,9 +523,23 @@ def test_human_write_failure_no_false_written_claim(tmp_path, capsys):
     code = main(["scan", "--root", str(root), "-o", str(bad_out)])
     captured = capsys.readouterr()
 
-    assert code == 1
+    assert code == 2
     assert "Could not write" in captured.err
     assert "written to" not in (captured.out + captured.err)
+    assert not bad_out.exists()
+
+
+def test_sarif_write_failure_exits_2(tmp_path, capsys):
+    """SARIF: findings + -o write fails -> exit 2, stderr shows error, stdout clean."""
+    root = _mkroot(tmp_path)
+    bad_out = tmp_path / "no_such_dir" / "out.sarif"
+
+    code = main(["scan", "--root", str(root), "--format", "sarif", "-o", str(bad_out)])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert "Could not write" in captured.err
+    assert captured.out == ""
     assert not bad_out.exists()
 
 


### PR DESCRIPTION
## Summary

Closes #181

This completes the behavior left open by #195. When a user explicitly requests `--output` and the report cannot be written, the command now returns exit code `2` instead of potentially returning `1` for findings or `0` for a clean scan.

### What changed

- Propagate the existing `_write_text()` failure status back through the scan result.
- A failed user-requested `--output` write forces exit code `2`.
- Preserve exit code `1` for findings when the requested report is successfully written.
- Keep stdout machine-clean for JSON and SARIF output; the existing write error remains on stderr.
- Internal anti-flood/overflow report writes retain their existing semantics because they are not user-requested `--output` writes.

### Tests

- `python -m pytest -v` — 819 passed, 23 skipped
- `python -m mypy src/` — success, 30 source files
- `python -m ruff check src tests` — passed
- `python -m ruff format --check src tests` — passed
- `python -m bandit -r src/ -q` — only pre-existing nosec warnings in unchanged files
- `git diff --check` — clean

The regression coverage exercises real invalid/unwritable output paths, including JSON, human-readable, and SARIF output. No new dependencies, network calls, CI changes, or changes to the repository's safe-write mechanism are introduced.

Thanks to #195 for the preceding fix that removed the misleading success claim; this PR carries the remaining write-failure status through to the CLI exit code.
