### PR TITLE
feat(scanner): detect Claude Code OAuth tokens

### DIFF
--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -76,6 +76,14 @@ _RAW_RULES: list[tuple[str, str, re.Pattern[str]]] = [
         )),
     ("anthropic", "Anthropic API key",
         re.compile(r"\bsk-ant-(?:api|sid)[0-9]*-[A-Za-z0-9_-]{32,}\b")),
+    ("anthropic-oauth-token", "Anthropic OAuth token",
+        # Claude Code setup tokens use an oatNN version marker followed by a
+        # URL-safe body. Keep the body bounded without truncating a longer
+        # adjacent credential-shaped string.
+        re.compile(
+            r"(?<![A-Za-z0-9_-])sk-ant-oat[0-9]{2}-"
+            r"[A-Za-z0-9_-]{64,256}(?![A-Za-z0-9_-])"
+        )),
     ("google-api", "Google API key",
         re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b")),
     ("google-oauth-client-secret", "Google OAuth client secret",
@@ -694,6 +702,7 @@ _PREFILTER.update({
     "neon-role-password":  ("npg" "_",),
     "tavily-api-key":      ("tvly" "-",),
     "cloudflare-account-api-token": ("cfat_",),
+    "anthropic-oauth-token": ("sk-ant-oat",),
     "terraform-api-token": ("atlasv1.",),
     "maxmind-license-key": ("_mmk",),
     "freemius-secret-key": ("secret_key",),
@@ -881,6 +890,7 @@ ROTATION_GUIDANCE: dict[str, str] = {
     "stripe-webhook-secret": "Roll: https://dashboard.stripe.com/webhooks (select the endpoint, then roll its signing secret)",
     "openai": "Revoke: https://platform.openai.com/api-keys",
     "anthropic": "Revoke: https://console.anthropic.com/settings/keys",
+    "anthropic-oauth-token": "Rotate: run `claude login` again to replace the exposed Claude Code OAuth token.",
     "google-api": "Rotate: https://console.cloud.google.com/apis/credentials",
     "google-oauth-client-secret": "Rotate: https://console.cloud.google.com/apis/credentials (OAuth 2.0 Client IDs > reset secret)",
     "google-service-account-key": "Revoke: https://console.cloud.google.com/iam-admin/serviceaccounts (delete the compromised key, generate a new one)",

--- a/tests/test_anthropic_oauth_rule.py
+++ b/tests/test_anthropic_oauth_rule.py
@@ -1,0 +1,54 @@
+"""Regression coverage for Claude Code OAuth tokens (sk-ant-oatNN prefix)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.scanner import ROTATION_GUIDANCE, scan_text  # noqa: E402
+
+
+def _token(body: str | None = None, version: str = "01") -> str:
+    if body is None:
+        body = "A" * 40 + "-" + "b" * 32
+    return "sk-ant-" + f"oat{version}-" + body
+
+
+def test_detects_anthropic_oauth_token_and_includes_rotation_guidance():
+    token = _token()
+    findings = scan_text(token)
+
+    assert [finding.rule for finding in findings] == ["anthropic-oauth-token"]
+    assert findings[0].value == token
+    assert "claude login" in ROTATION_GUIDANCE["anthropic-oauth-token"]
+
+
+def test_anthropic_oauth_token_body_length_is_bounded():
+    assert scan_text(_token("a" * 64))
+    assert scan_text(_token("a" * 256))
+    assert scan_text(_token("a" * 63)) == []
+    assert scan_text(_token("a" * 257)) == []
+
+
+@pytest.mark.parametrize("version", ["1", "001", "ab"])
+def test_anthropic_oauth_token_requires_two_digit_version(version: str):
+    assert scan_text(_token(version=version)) == []
+
+
+@pytest.mark.parametrize(
+    "embedded",
+    [
+        "z" + _token(),
+        "-" + _token(),
+        "_" + _token(),
+        _token("a" * 256) + "z",
+        _token("a" * 256) + "-",
+        _token("a" * 256) + "_",
+    ],
+)
+def test_anthropic_oauth_token_rejects_word_and_dash_embeds(embedded: str):
+    assert scan_text(embedded) == []

--- a/tests/test_regex_engine_parity.py
+++ b/tests/test_regex_engine_parity.py
@@ -25,6 +25,7 @@ def _core_fixtures() -> dict[str, str]:
         "openai": "sk-proj-" + "a" * 40,
         "pinecone-api-key": "pcsk_" + "a" * 104,
         "anthropic": "sk-ant-api03-" + "a" * 32,
+        "anthropic-oauth-token": "sk-ant-" + "oat01-" + "a" * 64,
         "google-api": "AIza" + "a" * 35,
         "google-oauth-client-secret": "GOCSPX-" + "a" * 28,
         "google-service-account-key": (


### PR DESCRIPTION
## What & why

Closes #170. Adds a separate bounded detector for Claude Code `sk-ant-oatNN-` OAuth tokens so scans no longer report clean when those credentials appear in agent history. It includes `claude login` rotation guidance, a lossless prefilter anchor, boundary coverage, and regex-engine parity coverage.

## Type of change

- [x] New detection rule

## Testing

```text
839 passed, 10 skipped in 10.77s
ruff check: passed
ruff format --check: passed
mypy src/: passed
bandit -r src/ -q: passed
```

## Checklist

- [x] Tests pass locally; cross-platform CI is pending
- [x] `mypy src/` is clean
- [x] No new runtime dependency
- [x] No real secrets or tokens are committed; fixtures are synthetic and concatenated
- [x] Added `RULES`, `ROTATION_GUIDANCE`, bounded quantifiers, a lossless prefilter anchor, and fixture coverage
- [x] `--json` and non-tty output paths are unchanged
- [x] Did not re-introduce `force-include`

AI disclosure: Implemented and validated with Codex assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for Anthropic OAuth tokens used with Claude Code.
  * Added rotation guidance for detected tokens, including the `claude login` command.

* **Tests**
  * Added coverage for valid token formats, length limits, version requirements, and invalid embedded patterns.
  * Added compatibility coverage across supported scanning engines to ensure consistent detection results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->