### PR TITLE
feat(scanner): detect LangSmith API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 >
 > **Grok Build (xAI)** is verified against a real Windows install: JSONL transcripts at `~/.grok/sessions/<cwd>/<session-id>/` (`chat_history.jsonl`, `updates.jsonl`, `events.jsonl`; `$GROK_HOME` override). **Grok CLI** remains experimental — it is [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) SQLite (`~/.grok/grok.db`), a different product. They share `~/.grok` but scan different files; `auth.json` is never opened.
 
-**207 regex rules + seed-phrase detection:** AWS, GitHub, Stripe, OpenAI, Anthropic, Google, Slack, Discord, HuggingFace, Supabase sensitive tokens, JWT, PEM keys, DB URLs, BIP-39 seed phrases, and [many more](#whats-detected)
+**208 regex rules + seed-phrase detection:** AWS, GitHub, Stripe, OpenAI, Anthropic, Google, Slack, Discord, HuggingFace, LangSmith, Supabase sensitive tokens, JWT, PEM keys, DB URLs, BIP-39 seed phrases, and [many more](#whats-detected)
 
 **Alpha:** every destructive step is gated, backed up, and reversible with one command
 
@@ -450,9 +450,9 @@ agentsweep purge --yes                 # non-interactive (scripts / CI)
 
 ## What's detected
 
-207 high-confidence patterns, **plus a checksum-validated crypto seed-phrase detector**. It confirms BIP-39 mnemonics (12/15/18/21/24 words, the wallet format behind BTC, ETH, SOL, BNB, ADA, DOGE, LTC, DOT, AVAX and most major chains) and Electrum seeds cryptographically (BIP-39 checksum or Electrum version tag), so English prose that happens to use wallet words won't trigger a false positive.
+208 high-confidence patterns, **plus a checksum-validated crypto seed-phrase detector**. It confirms BIP-39 mnemonics (12/15/18/21/24 words, the wallet format behind BTC, ETH, SOL, BNB, ADA, DOGE, LTC, DOT, AVAX and most major chains) and Electrum seeds cryptographically (BIP-39 checksum or Electrum version tag), so English prose that happens to use wallet words won't trigger a false positive.
 
-The patterns: AWS access keys, GitHub tokens (PAT/OAuth/App/fine-grained), Stripe live/test and webhook signing secrets, OpenAI, Anthropic, Google API, Slack bot/user/webhook, Hugging Face, Supabase sensitive tokens, JWT, PEM private keys, DB URLs with embedded passwords, and npm/PyPI/SendGrid/Twilio tokens. On top of those sit 187 rules mapped to the [gitleaks](https://github.com/gitleaks/gitleaks) pack covering GitLab, Grafana, HashiCorp Vault/Terraform, DigitalOcean, Shopify, PlanetScale, Databricks, Atlassian, Azure AD, 1Password, Sentry, New Relic, Mailgun, Datadog, Twilio, Twitter/X, Twitch, Yandex, JFrog, Snyk, Mailchimp, curl credentials on the command line, and many more. The patterns run high-precision: false positives are rare, and provider-context rules are keyword-gated so large pastes stay fast.
+The patterns: AWS access keys, GitHub tokens (PAT/OAuth/App/fine-grained), Stripe live/test and webhook signing secrets, OpenAI, Anthropic, Google API, Slack bot/user/webhook, Hugging Face, LangSmith personal and service keys, Supabase sensitive tokens, JWT, PEM private keys, DB URLs with embedded passwords, and npm/PyPI/SendGrid/Twilio tokens. On top of those sit 187 rules mapped to the [gitleaks](https://github.com/gitleaks/gitleaks) pack covering GitLab, Grafana, HashiCorp Vault/Terraform, DigitalOcean, Shopify, PlanetScale, Databricks, Atlassian, Azure AD, 1Password, Sentry, New Relic, Mailgun, Datadog, Twilio, Twitter/X, Twitch, Yandex, JFrog, Snyk, Mailchimp, curl credentials on the command line, and many more. The patterns run high-precision: false positives are rare, and provider-context rules are keyword-gated so large pastes stay fast.
 
 ## `.agentsweepignore` — suppress false positives
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ agentsweep runs a fixed 5-stage pipeline. `scan` stops after stage 3; `fix` cont
 
 ```mermaid
 flowchart LR
-    A("🔍 DISCOVER\nwalk history dirs\nstream file list") --> B("⚡ SCAN\nAho-Corasick pre-filter\n207 regex rules + BIP-39")
+    A("🔍 DISCOVER\nwalk history dirs\nstream file list") --> B("⚡ SCAN\nAho-Corasick pre-filter\n208 regex rules + BIP-39")
     B --> C{"secrets\nfound?"}
     C -- "none" --> D("✅ CLEAN\nexit 0")
     C -- "found" --> E("📋 FINDINGS\nshow report\nexit 1")

--- a/src/agentsweep/scanner.py
+++ b/src/agentsweep/scanner.py
@@ -116,6 +116,15 @@ _RAW_RULES: list[tuple[str, str, re.Pattern[str]]] = [
         re.compile(r"\bvcp_[A-Za-z0-9]{24}\b")),
     ("cloudflare-account-api-token", "Cloudflare account API token",
         re.compile(r"(?<![A-Za-z0-9_-])cfat_[A-Za-z0-9]{40}[0-9a-fA-F]{8}(?![A-Za-z0-9_-])")),
+    ("langsmith-api-key", "LangSmith API key",
+        # LangSmith's SDK anonymizer recognizes both personal (pt) and service
+        # (sk) keys as a 32+ character alphanumeric segment followed by
+        # optional alphanumeric segments. Cap every segment and the segment
+        # count so malformed input cannot make this rule open-ended.
+        re.compile(
+            r"(?<![A-Za-z0-9_-])lsv2_(?:pt|sk)_[A-Za-z0-9]{32,256}"
+            r"(?:_[A-Za-z0-9]{1,256}){0,4}(?![A-Za-z0-9_-])"
+        )),
     ("npm-token", "npm access token",
         re.compile(r"\bnpm_[A-Za-z0-9]{36}\b")),
     ("pypi-token", "PyPI upload token",
@@ -694,6 +703,7 @@ _PREFILTER.update({
     "neon-role-password":  ("npg" "_",),
     "tavily-api-key":      ("tvly" "-",),
     "cloudflare-account-api-token": ("cfat_",),
+    "langsmith-api-key": ("lsv2_",),
     "terraform-api-token": ("atlasv1.",),
     "maxmind-license-key": ("_mmk",),
     "freemius-secret-key": ("secret_key",),
@@ -897,6 +907,7 @@ ROTATION_GUIDANCE: dict[str, str] = {
     "tavily-api-key": "Revoke: Tavily dashboard > API Keys (click regenerate on the exposed key): https://app.tavily.com/home",
     "vercel-api-token": "Revoke and rotate at https://vercel.com/account/tokens.",
     "cloudflare-account-api-token": "Rotate: Cloudflare dashboard > Manage Account > Account API Tokens (roll or revoke the token).",
+    "langsmith-api-key": "Rotate: LangSmith Settings > API Keys (delete the exposed key and create a replacement).",
     "npm-token": "Revoke: https://www.npmjs.com/settings/~/tokens",
     "pypi-token": "Revoke: https://pypi.org/manage/account/token/",
     "sendgrid": "Rotate: https://app.sendgrid.com/settings/api_keys",

--- a/tests/test_langsmith_rule.py
+++ b/tests/test_langsmith_rule.py
@@ -1,0 +1,55 @@
+"""Regression coverage for LangSmith personal and service API keys."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.scanner import (  # noqa: E402
+    ROTATION_GUIDANCE,
+    _PREFILTER,
+    scan_text,
+)
+
+
+def _key(kind: str = "pt", body: str = "a" * 36, tail: str = "b" * 10) -> str:
+    return "lsv2_" + kind + "_" + body + "_" + tail
+
+
+@pytest.mark.parametrize("kind", ["pt", "sk"])
+def test_detects_langsmith_personal_and_service_keys(kind: str) -> None:
+    findings = scan_text(_key(kind))
+
+    assert [finding.rule for finding in findings] == ["langsmith-api-key"]
+    assert "LangSmith" in ROTATION_GUIDANCE["langsmith-api-key"]
+
+
+def test_detects_single_segment_128_character_key_from_issue() -> None:
+    key = "lsv2_" + "pt_" + "0123456789abcdef" * 8
+
+    assert [finding.rule for finding in scan_text(key)] == ["langsmith-api-key"]
+
+
+@pytest.mark.parametrize(
+    "near_miss",
+    [
+        _key(body="a" * 31, tail=""),
+        _key(kind="xx"),
+        _key(body="a" * 257, tail=""),
+        _key(tail="b" * 257),
+        "z" + _key(),
+        _key() + "-suffix",
+    ],
+)
+def test_langsmith_key_rejects_invalid_or_out_of_bounds_values(
+    near_miss: str,
+) -> None:
+    assert scan_text(near_miss) == []
+
+
+def test_langsmith_prefilter_uses_shared_prefix() -> None:
+    assert _PREFILTER["langsmith-api-key"] == ("lsv2_",)

--- a/tests/test_regex_engine_parity.py
+++ b/tests/test_regex_engine_parity.py
@@ -43,6 +43,7 @@ def _core_fixtures() -> dict[str, str]:
         "db-url-with-password": "postgresql://user:password@example.test/db",
         "neon-role-password": "npg_" + "a" * 12,
         "cloudflare-account-api-token": "cfat" + "_" + "a" * 40 + "0" * 8,
+        "langsmith-api-key": "lsv2_" + "pt_" + "a" * 36 + "_" + "b" * 10,
         "npm-token": "npm_" + "a" * 36,
         "pypi-token": "pypi-AgEIcHlwaS5vcmc" + "a" * 50,
         "sendgrid": "SG." + "a" * 22 + "." + "b" * 43,


### PR DESCRIPTION
Closes #175.

Adds bounded detection for LangSmith personal and service API keys, a lossless `lsv2_` prefilter, rotation guidance, and boundary tests.

Validated with the full test suite (838 passed, 10 skipped), Ruff, mypy, and Bandit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detection for LangSmith personal and service API keys.
  - Added rotation guidance for detected LangSmith keys.

- **Documentation**
  - Updated supported secret types to include LangSmith.
  - Updated the documented detection rule count to 208.
  - Synchronized the “How it works” documentation with the latest rule count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->