### PR TITLE
Add GitHub Actions annotation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,9 @@ agentsweep scan --json --output /tmp/report.json
 agentsweep scan --format sarif -o agentsweep.sarif
 agentsweep scan --all --format sarif -o agentsweep.sarif
 
+# GitHub Actions annotations in the workflow log (scan only)
+agentsweep scan --all --format github
+
 # Skip .agentsweepignore files
 agentsweep scan --no-ignore
 
@@ -363,6 +366,11 @@ NO_COLOR=1 agentsweep scan
 ```
 
 `|| true` keeps the upload step reachable. `scan` exits 1 when it finds something, and you want the SARIF to report that rather than the step failing.
+
+For a lighter setup without uploading SARIF, `--format github` emits one
+`::error file=...,line=...::...` workflow command per finding. GitHub renders
+these as annotations in the Actions log and on matching files in a pull request.
+The messages contain masked previews only.
 
 ### Use with pre-commit
 

--- a/src/agentsweep/cli.py
+++ b/src/agentsweep/cli.py
@@ -370,7 +370,7 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
         "-o",
         "--output",
         type=Path,
-        help="Write findings as JSON to this file instead of flooding the terminal.",
+        help="Write machine-readable findings to this file instead of stdout.",
     )
     ap.add_argument(
         "--json",
@@ -396,10 +396,11 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
     )
     ap.add_argument(
         "--format",
-        choices=["sarif", "human"],
+        choices=["sarif", "github", "human"],
         help="Emit findings in an interchange format instead of "
         "the default report: sarif = SARIF 2.1.0 for GitHub "
-        "code scanning and SARIF viewers (scan only). Pass "
+        "code scanning and SARIF viewers; github = GitHub "
+        "Actions workflow annotations (scan only). Pass "
         "'human' to force the default report even when a "
         'config file sets format = "sarif".',
     )
@@ -476,7 +477,7 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
 
     if args.source is not None and args.source not in _sources():
         ap.error(f"argument --source: invalid choice from config file: {args.source!r}")
-    if args.format is not None and args.format not in ("sarif", "human"):
+    if args.format is not None and args.format not in ("sarif", "github", "human"):
         ap.error(f"argument --format: invalid choice from config file: {args.format!r}")
 
     # "human" is a CLI-only override that forces the default report even when
@@ -511,7 +512,9 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
 
     if args.format is not None:
         if args.json:
-            ap.error("cannot use --json with --format sarif; pick one output format")
+            ap.error(
+                f"cannot use --json with --format {args.format}; pick one output format"
+            )
         if args.fix:
             ap.error("--format is a scan output format; not valid with fix")
 
@@ -520,7 +523,8 @@ def _parse_run(verb: str, rest: list[str]) -> argparse.Namespace:
             ap.error("--report is a scan output option; not valid with fix")
         if args.format is not None:
             ap.error(
-                "cannot use --report with --format sarif; blast-radius is JSON-only"
+                f"cannot use --report with --format {args.format}; "
+                "blast-radius is JSON-only"
             )
         # Contract: --report always emits machine JSON (with blast_radius).
         args.json = True

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -1354,7 +1354,8 @@ def _emit_github(payload: list[dict], output: Path | None, suppressed: int) -> i
     if output is not None:
         if _write_text(output, text):
             print(f"{len(payload)} finding(s) written to {output}", file=sys.stderr)
-        return code
+            return code
+        return 2
 
     print(text, end="")
     if suppressed:

--- a/src/agentsweep/pipeline.py
+++ b/src/agentsweep/pipeline.py
@@ -63,23 +63,28 @@ def run(
     source: Source = source_cls(root=args.root) if args.root else source_cls()
     output: Path | None = _opt(args, "output")
 
-    as_sarif = _opt(args, "format") == "sarif"
-    if as_sarif and getattr(args, "stats", False):
+    output_format = _opt(args, "format")
+    as_sarif = output_format == "sarif"
+    as_github = output_format == "github"
+    if (as_sarif or as_github) and getattr(args, "stats", False):
+        format_label = "SARIF" if as_sarif else "GitHub"
         print(
-            "error: --stats is not supported in SARIF mode; "
+            f"error: --stats is not supported in {format_label} mode; "
             "omit --stats or use --json instead",
             file=sys.stderr,
         )
         return 2
     # Both machine formats share every no-banner/no-styling branch below; they
     # differ only in what an empty result set looks like on stdout.
-    machine = bool(args.json) or as_sarif
+    machine = bool(args.json) or as_sarif or as_github
 
     def _print_empty_machine_output() -> None:
         # stdout must stay parseable in every machine-format run, including
         # user errors — for SARIF that means a valid document, not "[]".
         if as_sarif:
             print(json.dumps(_sarif_document([]), indent=2))
+        elif as_github:
+            return
         elif args.json:
             print("[]")
 
@@ -171,6 +176,10 @@ def run(
         _warn_leftover_backups(source, as_json=True)
         if as_sarif:
             return _emit_sarif(_json_payload(found_by_file, source), output, suppressed)
+        if as_github:
+            return _emit_github(
+                _json_payload(found_by_file, source), output, suppressed
+            )
         return _output_json(
             found_by_file,
             source,
@@ -407,15 +416,18 @@ def run_all(args) -> int:
     on this machine (same signal as ``list-sources --detected``).
     """
     output: Path | None = _opt(args, "output")
-    as_sarif = _opt(args, "format") == "sarif"
-    if as_sarif and _opt(args, "stats", False):
+    output_format = _opt(args, "format")
+    as_sarif = output_format == "sarif"
+    as_github = output_format == "github"
+    if (as_sarif or as_github) and _opt(args, "stats", False):
+        format_label = "SARIF" if as_sarif else "GitHub"
         print(
-            "error: --stats is not supported in SARIF mode; "
+            f"error: --stats is not supported in {format_label} mode; "
             "omit --stats or use --json instead",
             file=sys.stderr,
         )
         return 2
-    as_json = bool(_opt(args, "json", False)) or as_sarif
+    as_json = bool(_opt(args, "json", False)) or as_sarif or as_github
     report = getattr(args, "report", False)
     detected_only = bool(_opt(args, "detected", False))
     no_ignore = bool(_opt(args, "no_ignore", False))
@@ -449,7 +461,7 @@ def run_all(args) -> int:
                 _emit_json_payload(
                     {"findings": [], "stats": _stats_payload_multi([])}, output, 0
                 )
-            else:
+            elif not as_github:
                 print("[]")
         else:
             ui.banner(__version__)
@@ -547,7 +559,7 @@ def run_all(args) -> int:
                 _emit_json_payload(
                     {"findings": [], "stats": _stats_payload_multi([])}, output, 0
                 )
-            else:
+            elif not as_github:
                 print("[]")
         else:
             ui.stage(
@@ -737,6 +749,8 @@ def run_all(args) -> int:
         _warn_leftover_backups_multi([s for _k, s, *_ in per_source], as_json=True)
         if as_sarif:
             return _emit_sarif(payload, output, total_suppressed)
+        if as_github:
+            return _emit_github(payload, output, total_suppressed)
         stats = (
             _stats_payload_multi(per_source) if getattr(args, "stats", False) else None
         )
@@ -1308,6 +1322,44 @@ def _show_stats(stats: JsonObject) -> None:
     if isinstance(by_source, dict):
         for source, count in by_source.items():
             ui.console.print(f"    source:{source}  {count}")
+
+
+def _github_escape(value: object, *, property_value: bool = False) -> str:
+    """Escape a workflow-command message or property value."""
+    text = str(value).replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    if property_value:
+        text = text.replace(":", "%3A").replace(",", "%2C")
+    return text
+
+
+def _github_annotations(payload: list[dict]) -> str:
+    """Render findings as GitHub Actions workflow-command annotations."""
+    lines = []
+    for finding in payload:
+        path = _github_escape(finding["file"], property_value=True)
+        line = max(1, int(finding["line"]))
+        message = _github_escape(
+            f"{finding['display']} found in {finding['source']} history: "
+            f"{finding['masked']}"
+        )
+        lines.append(f"::error file={path},line={line}::{message}")
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def _emit_github(payload: list[dict], output: Path | None, suppressed: int) -> int:
+    """Emit GitHub Actions annotations without banners or styling."""
+    code = 0 if not payload else 1
+    text = _github_annotations(payload)
+
+    if output is not None:
+        if _write_text(output, text):
+            print(f"{len(payload)} finding(s) written to {output}", file=sys.stderr)
+        return code
+
+    print(text, end="")
+    if suppressed:
+        print(f"({suppressed} suppressed by .agentsweepignore)", file=sys.stderr)
+    return code
 
 
 SARIF_SCHEMA = (

--- a/tests/test_github_format.py
+++ b/tests/test_github_format.py
@@ -88,6 +88,21 @@ def test_output_file_keeps_stdout_clean(tmp_path, capsys):
     assert AWS_KEY not in output.read_text(encoding="utf-8")
 
 
+@pytest.mark.parametrize("secrets", [(), (AWS_KEY,)])
+def test_output_write_failure_is_user_error(tmp_path, capsys, secrets):
+    root = _seed(tmp_path, *secrets)
+    output = tmp_path / "output-directory"
+    output.mkdir()
+
+    code = main(["scan", "--root", str(root), "--format", "github", "-o", str(output)])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert f"Could not write {output}" in captured.err
+    assert "finding(s) written" not in captured.err
+
+
 def test_all_sources_uses_same_annotation_format(_isolate_home, capsys):
     root = _isolate_home / ".claude" / "projects"
     root.mkdir(parents=True)

--- a/tests/test_github_format.py
+++ b/tests/test_github_format.py
@@ -1,0 +1,123 @@
+"""GitHub Actions annotation output shape, safety, and CLI contracts."""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.cli import main  # noqa: E402
+
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+GH_TOKEN = "ghp_1234567890abcdefghijklmnopqrstuvwxyz"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(home / ".local" / "share"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(home / ".config"))
+    monkeypatch.setenv("AGENTSWEEP_NO_UPDATE", "1")
+    return home
+
+
+def _seed(base: Path, *secrets: str) -> Path:
+    root = base / "scan_root"
+    root.mkdir(parents=True, exist_ok=True)
+    history = root / "session.jsonl"
+    history.write_text(
+        "".join(
+            '{"type":"user","message":{"content":[{"type":"text",'
+            f'"text":"key={secret}"}}]}}}}\n'
+            for secret in secrets
+        ),
+        encoding="utf-8",
+    )
+    past = time.time() - 3700
+    os.utime(history, (past, past))
+    return root
+
+
+def test_annotation_shape_and_masking(tmp_path, capsys):
+    root = _seed(tmp_path, AWS_KEY, GH_TOKEN)
+
+    code = main(["scan", "--root", str(root), "--format", "github"])
+    captured = capsys.readouterr()
+    lines = captured.out.splitlines()
+
+    assert code == 1
+    assert len(lines) == 2
+    assert all(line.startswith("::error file=") for line in lines)
+    assert ",line=1::" in lines[0]
+    assert ",line=2::" in lines[1]
+    assert "AWS access key found in claude-code history" in captured.out
+    assert AWS_KEY not in captured.out
+    assert GH_TOKEN not in captured.out
+    assert "AKIAIO" in captured.out
+    assert captured.err == ""
+
+
+def test_clean_scan_emits_nothing(tmp_path, capsys):
+    root = _seed(tmp_path)
+
+    code = main(["scan", "--root", str(root), "--format", "github"])
+    captured = capsys.readouterr()
+
+    assert code == 0
+    assert captured.out == ""
+
+
+def test_output_file_keeps_stdout_clean(tmp_path, capsys):
+    root = _seed(tmp_path, AWS_KEY)
+    output = tmp_path / "annotations.txt"
+
+    code = main(["scan", "--root", str(root), "--format", "github", "-o", str(output)])
+    captured = capsys.readouterr()
+
+    assert code == 1
+    assert captured.out == ""
+    assert output.read_text(encoding="utf-8").startswith("::error file=")
+    assert AWS_KEY not in output.read_text(encoding="utf-8")
+
+
+def test_all_sources_uses_same_annotation_format(_isolate_home, capsys):
+    root = _isolate_home / ".claude" / "projects"
+    root.mkdir(parents=True)
+    history = root / "session.jsonl"
+    history.write_text(
+        '{"type":"user","message":{"content":[{"type":"text",'
+        f'"text":"key={AWS_KEY}"}}]}}}}\n',
+        encoding="utf-8",
+    )
+
+    code = main(["scan", "--all", "--detected", "--format", "github"])
+    captured = capsys.readouterr()
+
+    assert code == 1
+    assert captured.out.startswith("::error file=")
+    assert "found in claude-code history" in captured.out
+    assert AWS_KEY not in captured.out
+
+
+def test_missing_root_is_user_error_with_clean_stdout(tmp_path, capsys):
+    code = main(["scan", "--root", str(tmp_path / "missing"), "--format", "github"])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "Path not found" in captured.err
+
+
+def test_github_format_rejects_json_and_fix(tmp_path):
+    with pytest.raises(SystemExit):
+        main(["scan", "--root", str(tmp_path), "--format", "github", "--json"])
+    with pytest.raises(SystemExit):
+        main(["fix", "--root", str(tmp_path), "--format", "github"])


### PR DESCRIPTION
Closes #64.

Adds `--format github` for masked GitHub Actions error annotations across single-source and `--all` scans, with workflow-command escaping and clean machine output.

Validation: 834 passed, 10 skipped; Ruff and mypy passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--format github` to `agentsweep scan`.
  * Scan findings now appear as GitHub Actions annotations in workflow logs and on matching pull request files.
  * Annotations include masked previews with file and line references.
  * Added documentation for the new output format.

* **Bug Fixes**
  * Improved format-specific validation and error messages.
  * Clean scans produce annotation-free output with the appropriate exit status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->