### PR TITLE
feat: read-only MCP server (agentsweep[mcp])

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ dev = [
     "bandit>=1.7",     # Python SAST — fitting for a secrets-redaction tool
     "pip-audit>=2.7",  # dependency CVE scanning (SCA)
     "deptry>=0.20",    # unused / missing dependency detection
+    # tests/test_mcp_server.py guards the whole MCP surface; without fastmcp
+    # installed, its importorskip skips it silently (CI installs .[dev]).
+    "fastmcp>=2.3.4",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
 [project.scripts]
 agentsweep = "agentsweep.cli:main"
 asweep = "agentsweep.cli:main"
-agentsweep-mcp = "agentsweep.mcp_server:main"
+agentsweep-mcp = "agentsweep.mcp_cli:main"
 
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 dependencies = ["rich>=13.0", "pyahocorasick>=2.0", "argcomplete>=3.0.0"]
 
 [project.optional-dependencies]
+mcp = ["fastmcp>=2.3.4"]
 # Native RE2 is optional: the default install retains the stdlib scanner on
 # platforms without a compatible wheel. Install with `.[fast]` to enable the
 # per-rule mixed engine selected by scanner.py.
@@ -60,6 +61,8 @@ dev = [
 [project.scripts]
 agentsweep = "agentsweep.cli:main"
 asweep = "agentsweep.cli:main"
+agentsweep-mcp = "agentsweep.mcp_server:main"
+
 
 [project.urls]
 Homepage = "https://github.com/Ishannaik/agent-sweep"

--- a/src/agentsweep/mcp_cli.py
+++ b/src/agentsweep/mcp_cli.py
@@ -1,0 +1,23 @@
+"""Console-script shim for ``agentsweep-mcp``.
+
+Lives in its own module so the entry point never imports ``mcp_server``
+(and therefore ``fastmcp``) at load time: a base install without the
+``mcp`` extra still gets a clear message instead of a traceback.
+"""
+
+from __future__ import annotations
+
+
+def main() -> None:
+    try:
+        from agentsweep.mcp_server import mcp
+    except ImportError as exc:
+        raise SystemExit(
+            "agentsweep-mcp requires the optional MCP extra.\n"
+            "Install it with: pip install 'agentsweep[mcp]'"
+        ) from exc
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agentsweep/mcp_cli.py
+++ b/src/agentsweep/mcp_cli.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 def main() -> None:
     try:
         from agentsweep.mcp_server import mcp
-    except ImportError as exc:
+    except ModuleNotFoundError as exc:
+        if exc.name != "fastmcp":
+            raise
         raise SystemExit(
             "agentsweep-mcp requires the optional MCP extra.\n"
             "Install it with: pip install 'agentsweep[mcp]'"

--- a/src/agentsweep/mcp_server.py
+++ b/src/agentsweep/mcp_server.py
@@ -116,6 +116,8 @@ def scan_history(
         )
     if exclude_rules and only_rules:
         raise ValueError("pass either exclude_rules or only_rules, not both")
+    if limit < 0:
+        raise ValueError(f"limit must be >= 0, got {limit}")
 
     exclude, only = _parse_rules(exclude_rules, only_rules)
 
@@ -127,14 +129,15 @@ def scan_history(
     for key in _parse_source(source):
         cls = SOURCES[key]
         src = cls(root=Path(root)) if root is not None else cls()
-        if not src.is_detected():
-            skipped_sources.append(key)
-            continue
 
+        # Validate path= before the detection skip: with the default root
+        # absent, is_detected() would otherwise swallow a bad path into a
+        # "skipped" result instead of the documented error.
+        resolved_path: Path | None = None
         if path is not None:
-            p = Path(path).resolve()
+            resolved_path = Path(path).resolve()
             root_dir = src.root.resolve()
-            if not p.is_relative_to(root_dir):
+            if not resolved_path.is_relative_to(root_dir):
                 # Keep the scan inside the source root: the server otherwise
                 # becomes an arbitrary-file oracle (readable-file metadata +
                 # masked findings) for any path the caller names.
@@ -142,12 +145,19 @@ def scan_history(
                     f"path {path!r} is outside the source root {src.root!s}; "
                     "pass root= to scan a different tree"
                 )
-            if p.is_file():
-                files = [p]
-            elif p.is_dir():
-                files = sorted(f for f in p.rglob("*") if f.is_file())
-            else:
+            if not (resolved_path.is_file() or resolved_path.is_dir()):
                 raise ValueError(f"path {path!r} is not a file or directory")
+
+        if not src.is_detected():
+            skipped_sources.append(key)
+            continue
+
+        if resolved_path is not None:
+            files = (
+                [resolved_path]
+                if resolved_path.is_file()
+                else sorted(f for f in resolved_path.rglob("*") if f.is_file())
+            )
         else:
             files = list(src.iter_files())
         if glob:

--- a/src/agentsweep/mcp_server.py
+++ b/src/agentsweep/mcp_server.py
@@ -84,7 +84,6 @@ def scan_history(
     source: str | None = None,
     path: str | None = None,
     glob: str | None = None,
-    root: str | None = None,
     exclude_rules: str | None = None,
     only_rules: str | None = None,
     limit: int = 200,
@@ -97,19 +96,14 @@ def scan_history(
 
     Args:
         source: source key (see list_sources) or "all"/None for every source.
-        path: scan exactly this file or directory (inside the source root)
-            instead of the full source root walk.
+        path: scan exactly this file or directory (inside the registered
+            source root) instead of the full source root walk.
         glob: shell-style filter on file paths, e.g. "*.jsonl". None = all.
-        root: override the source's default root directory (like --root).
         exclude_rules: comma-separated rule ids to skip (e.g. "bip39-mnemonic,openai").
         only_rules: comma-separated rule ids to keep.
         limit: max findings returned (default 200); the counts in "summary"
             always reflect the full scan. Raise it for big sweeps.
     """
-    if root is not None and source in (None, "", "all"):
-        raise ValueError(
-            "root= requires an explicit source; use list_sources to pick one"
-        )
     if path is not None and source in (None, "", "all"):
         raise ValueError(
             "path= requires an explicit source; use list_sources to pick one"
@@ -128,7 +122,7 @@ def scan_history(
 
     for key in _parse_source(source):
         cls = SOURCES[key]
-        src = cls(root=Path(root)) if root is not None else cls()
+        src = cls()
 
         # Validate path= before the detection skip: with the default root
         # absent, is_detected() would otherwise swallow a bad path into a
@@ -142,8 +136,7 @@ def scan_history(
                 # becomes an arbitrary-file oracle (readable-file metadata +
                 # masked findings) for any path the caller names.
                 raise ValueError(
-                    f"path {path!r} is outside the source root {src.root!s}; "
-                    "pass root= to scan a different tree"
+                    f"path {path!r} is outside the source root {src.root!s}"
                 )
             if not (resolved_path.is_file() or resolved_path.is_dir()):
                 raise ValueError(f"path {path!r} is not a file or directory")

--- a/src/agentsweep/mcp_server.py
+++ b/src/agentsweep/mcp_server.py
@@ -1,0 +1,198 @@
+"""Optional MCP server exposing agentsweep as read-only tools.
+
+Run with ``agentsweep-mcp`` (installed only with the ``mcp`` extra) or
+``python -m agentsweep.mcp_server``. Speaks stdio, same trust domain as
+the CLI: local child process of the MCP client, fully offline.
+
+Tool surface (read-only; the destructive fix path stays CLI-only):
+
+  list_sources          which agents are installed here
+  scan_history          scan one or all sources, masked findings only
+  get_rotation_guidance provider-specific rotation steps
+
+The plaintext secret boundary is the core invariant: ``Finding.value``
+never leaves this process. Every payload is built with the same masked
+fields the JSON CLI already emits (``_json_payload``).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+from typing import Any
+
+from fastmcp import FastMCP
+
+from . import __version__
+from .pipeline import _scan_all, _source_rows
+from .scanner import ROTATION_GUIDANCE, RULES
+from .sources import SOURCES
+
+mcp = FastMCP("agentsweep", version=__version__)
+
+# All tools are read-only by design: they scan and report, never modify.
+_READ_ONLY = {"readOnlyHint": True}
+
+
+def _parse_source(source: str | None) -> list[str]:
+    """Resolve the ``source`` argument to a list of registered source keys."""
+    if source in (None, "", "all"):
+        return sorted(SOURCES)
+    if source not in SOURCES:
+        known = ", ".join(sorted(SOURCES))
+        raise ValueError(f"unknown source {source!r}; known sources: {known}")
+    return [source]
+
+
+def _parse_rules(exclude_rules, only_rules) -> tuple[set[str] | None, set[str] | None]:
+    def _split(raw) -> set[str] | None:
+        if raw in (None, "", []):
+            return None
+        items = {r.strip() for r in raw.split(",") if r.strip()} if isinstance(raw, str) else set(raw)
+        known_rules = {r[0] for r in RULES}
+        unknown = items - known_rules
+        if unknown:
+            known = ", ".join(sorted(known_rules))
+            raise ValueError(f"unknown rule(s): {', '.join(sorted(unknown))}; known rules: {known}")
+        return items
+
+    return _split(exclude_rules), _split(only_rules)
+
+
+@mcp.tool(annotations=_READ_ONLY)
+def list_sources(detected_only: bool = False) -> list[dict[str, Any]]:
+    """List every supported agent history source and whether it is installed.
+
+    Read-only: reads no history files, touches nothing on disk.
+    """
+    rows = _source_rows()
+    if detected_only:
+        rows = [r for r in rows if r["detected"]]
+    return rows
+
+
+@mcp.tool(annotations=_READ_ONLY)
+def scan_history(
+    source: str | None = None,
+    path: str | None = None,
+    glob: str | None = None,
+    root: str | None = None,
+    exclude_rules: str | None = None,
+    only_rules: str | None = None,
+    limit: int = 200,
+) -> dict[str, Any]:
+    """Scan agent history files for leaked secrets. Read-only.
+
+    Findings are masked (``sk-…abcd``); the plaintext never leaves the
+    server process. Tell the human to run ``agentsweep fix`` in a
+    terminal when this reports anything.
+
+    Args:
+        source: source key (see list_sources) or "all"/None for every source.
+        path: scan exactly this file or directory instead of a source root.
+        glob: shell-style filter on file paths, e.g. "*.jsonl". None = all.
+        root: override the source's default root directory (like --root).
+        exclude_rules: comma-separated rule ids to skip (e.g. "bip39,openai-key").
+        only_rules: comma-separated rule ids to keep.
+        limit: max findings returned (default 200); the counts in "summary"
+            always reflect the full scan. Raise it for big sweeps.
+    """
+    if root is not None and source in (None, "", "all"):
+        raise ValueError("root= requires an explicit source; use list_sources to pick one")
+    if exclude_rules and only_rules:
+        raise ValueError("pass either exclude_rules or only_rules, not both")
+
+    exclude, only = _parse_rules(exclude_rules, only_rules)
+
+    results: list[dict[str, Any]] = []
+    files_scanned = 0
+    strings_scanned = 0
+    skipped_sources: list[str] = []
+
+    for key in _parse_source(source):
+        cls = SOURCES[key]
+        src = cls(root=Path(root)) if root is not None else cls()
+        if not src.is_detected():
+            skipped_sources.append(key)
+            continue
+
+        if path is not None:
+            p = Path(path)
+            files = [p] if p.is_file() else list(src.iter_files())
+        else:
+            files = list(src.iter_files())
+        if glob:
+            files = [f for f in files if fnmatch.fnmatch(str(f), glob)]
+
+        if not files:
+            skipped_sources.append(key)
+            continue
+
+        found_by_file, sc, _suppressed, _truncated = _scan_all(
+            src, files, exclude_rules=exclude, only_rules=only
+        )
+        strings_scanned += sc
+        for f, items in found_by_file.items():
+            rel = _relpath(f, src.root)
+            for line_num, keypath, _val, finding in items:
+                results.append(
+                    {
+                        "source": key,
+                        "file": rel,
+                        "line": line_num,
+                        "keypath": keypath,
+                        "rule": finding.rule,
+                        "display": finding.display,
+                        "masked": finding.masked,
+                    }
+                )
+        files_scanned += len(files)
+
+    by_rule: dict[str, int] = {}
+    for f in results:
+        by_rule[f["rule"]] = by_rule.get(f["rule"], 0) + 1
+
+    truncated = len(results) > limit
+    return {
+        "version": __version__,
+        "files_scanned": files_scanned,
+        "strings_scanned": strings_scanned,
+        "summary": {
+            "total_findings": len(results),
+            "by_rule": dict(sorted(by_rule.items())),
+        },
+        "findings": results[:limit],
+        "findings_truncated": truncated,
+        "skipped_sources": skipped_sources,
+    }
+
+
+def _relpath(f: Path, root: Path) -> str:
+    try:
+        return str(f.relative_to(root))
+    except ValueError:
+        return str(f)
+
+
+@mcp.tool(annotations=_READ_ONLY)
+def get_rotation_guidance(rule: str | None = None) -> dict[str, str] | list[dict[str, Any]]:
+    """Provider-specific steps for rotating a leaked credential.
+
+    Pass a rule id from scan_history findings for one provider's steps;
+    omit it for the full mapping. Read-only reference data.
+    """
+    if rule is None:
+        return ROTATION_GUIDANCE
+    if rule not in ROTATION_GUIDANCE:
+        known = ", ".join(sorted(ROTATION_GUIDANCE))
+        raise ValueError(f"no rotation guidance for rule {rule!r}; known rules: {known}")
+    return {rule: ROTATION_GUIDANCE[rule]}
+
+
+def main() -> None:
+    """Entry point for the ``agentsweep-mcp`` console script."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agentsweep/mcp_server.py
+++ b/src/agentsweep/mcp_server.py
@@ -25,7 +25,7 @@ from fastmcp import FastMCP
 
 from . import __version__
 from .pipeline import _scan_all, _source_rows
-from .scanner import ROTATION_GUIDANCE, RULES
+from .scanner import DETECTOR_IDS, ROTATION_GUIDANCE, RULES
 from .sources import SOURCES
 
 mcp = FastMCP("agentsweep", version=__version__)
@@ -48,12 +48,20 @@ def _parse_rules(exclude_rules, only_rules) -> tuple[set[str] | None, set[str] |
     def _split(raw) -> set[str] | None:
         if raw in (None, "", []):
             return None
-        items = {r.strip() for r in raw.split(",") if r.strip()} if isinstance(raw, str) else set(raw)
-        known_rules = {r[0] for r in RULES}
+        items = (
+            {r.strip() for r in raw.split(",") if r.strip()}
+            if isinstance(raw, str)
+            else set(raw)
+        )
+        # Same validation set as the CLI: RULES ids plus detector ids (scan_text
+        # emits e.g. "bip39-mnemonic", which is not a RULES entry).
+        known_rules = {r[0] for r in RULES} | set(DETECTOR_IDS)
         unknown = items - known_rules
         if unknown:
             known = ", ".join(sorted(known_rules))
-            raise ValueError(f"unknown rule(s): {', '.join(sorted(unknown))}; known rules: {known}")
+            raise ValueError(
+                f"unknown rule(s): {', '.join(sorted(unknown))}; known rules: {known}"
+            )
         return items
 
     return _split(exclude_rules), _split(only_rules)
@@ -89,16 +97,23 @@ def scan_history(
 
     Args:
         source: source key (see list_sources) or "all"/None for every source.
-        path: scan exactly this file or directory instead of a source root.
+        path: scan exactly this file or directory (inside the source root)
+            instead of the full source root walk.
         glob: shell-style filter on file paths, e.g. "*.jsonl". None = all.
         root: override the source's default root directory (like --root).
-        exclude_rules: comma-separated rule ids to skip (e.g. "bip39,openai-key").
+        exclude_rules: comma-separated rule ids to skip (e.g. "bip39-mnemonic,openai").
         only_rules: comma-separated rule ids to keep.
         limit: max findings returned (default 200); the counts in "summary"
             always reflect the full scan. Raise it for big sweeps.
     """
     if root is not None and source in (None, "", "all"):
-        raise ValueError("root= requires an explicit source; use list_sources to pick one")
+        raise ValueError(
+            "root= requires an explicit source; use list_sources to pick one"
+        )
+    if path is not None and source in (None, "", "all"):
+        raise ValueError(
+            "path= requires an explicit source; use list_sources to pick one"
+        )
     if exclude_rules and only_rules:
         raise ValueError("pass either exclude_rules or only_rules, not both")
 
@@ -117,8 +132,22 @@ def scan_history(
             continue
 
         if path is not None:
-            p = Path(path)
-            files = [p] if p.is_file() else list(src.iter_files())
+            p = Path(path).resolve()
+            root_dir = src.root.resolve()
+            if not p.is_relative_to(root_dir):
+                # Keep the scan inside the source root: the server otherwise
+                # becomes an arbitrary-file oracle (readable-file metadata +
+                # masked findings) for any path the caller names.
+                raise ValueError(
+                    f"path {path!r} is outside the source root {src.root!s}; "
+                    "pass root= to scan a different tree"
+                )
+            if p.is_file():
+                files = [p]
+            elif p.is_dir():
+                files = sorted(f for f in p.rglob("*") if f.is_file())
+            else:
+                raise ValueError(f"path {path!r} is not a file or directory")
         else:
             files = list(src.iter_files())
         if glob:
@@ -175,7 +204,9 @@ def _relpath(f: Path, root: Path) -> str:
 
 
 @mcp.tool(annotations=_READ_ONLY)
-def get_rotation_guidance(rule: str | None = None) -> dict[str, str] | list[dict[str, Any]]:
+def get_rotation_guidance(
+    rule: str | None = None,
+) -> dict[str, str] | list[dict[str, Any]]:
     """Provider-specific steps for rotating a leaked credential.
 
     Pass a rule id from scan_history findings for one provider's steps;
@@ -185,7 +216,9 @@ def get_rotation_guidance(rule: str | None = None) -> dict[str, str] | list[dict
         return ROTATION_GUIDANCE
     if rule not in ROTATION_GUIDANCE:
         known = ", ".join(sorted(ROTATION_GUIDANCE))
-        raise ValueError(f"no rotation guidance for rule {rule!r}; known rules: {known}")
+        raise ValueError(
+            f"no rotation guidance for rule {rule!r}; known rules: {known}"
+        )
     return {rule: ROTATION_GUIDANCE[rule]}
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -135,6 +135,40 @@ def test_scan_history_limit_truncates_but_counts_full(fake_history):
     assert "github-pat" in result["summary"]["by_rule"]
 
 
+def test_scan_history_rejects_negative_limit():
+    with pytest.raises(ValueError, match="limit must be"):
+        scan_history(source="claude-code", limit=-1)
+
+
+def test_scan_history_bad_path_errors_even_when_root_absent(tmp_path, monkeypatch):
+    # Default claude-code root doesn't exist under the isolated HOME; a bad
+    # path= must still raise, not silently land in skipped_sources.
+    fake_root = tmp_path / "elsewhere"
+    fake_root.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path / "home-empty"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home-empty"))
+    (tmp_path / "home-empty").mkdir(exist_ok=True)
+    with pytest.raises(ValueError, match="outside the source root"):
+        scan_history(source="claude-code", path=str(fake_root / "x.jsonl"))
+
+
+def test_mcp_cli_shim_missing_extra_message(monkeypatch, capsys):
+    import builtins
+    from agentsweep import mcp_cli
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "agentsweep.mcp_server":
+            raise ImportError("No module named 'fastmcp'")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(SystemExit) as exc_info:
+        mcp_cli.main()
+    assert "agentsweep[mcp]" in str(exc_info.value)
+
+
 def test_scan_history_rejects_exclude_and_only(fake_history):
     root, _secret = fake_history
     with pytest.raises(ValueError, match="not both"):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -28,6 +28,12 @@ from agentsweep.mcp_server import (  # noqa: E402
 from agentsweep.scanner import ROTATION_GUIDANCE, scan_text  # noqa: E402
 from agentsweep.sources import SOURCES  # noqa: E402
 
+# FastMCP 2.x binds each decorated name to a non-callable FunctionTool
+# (.fn is the wrapped function); 3.x+ returns the original function.
+scan_history = getattr(scan_history, "fn", scan_history)
+list_sources = getattr(list_sources, "fn", list_sources)
+get_rotation_guidance = getattr(get_rotation_guidance, "fn", get_rotation_guidance)
+
 
 # ---------------------------------------------------------------------------
 # Plaintext boundary helper: the one rule the whole module exists to enforce.
@@ -39,7 +45,9 @@ def _collect_plaintexts() -> None:
     """Scan one string containing a real-looking fake secret per rule family."""
     if PLAINTEXTS:
         return
-    sample = "token=ghp_" + "A" * 36 + " key=AKIA" + "B" * 16 + " sk=sk-proj-" + "C" * 40
+    sample = (
+        "token=ghp_" + "A" * 36 + " key=AKIA" + "B" * 16 + " sk=sk-proj-" + "C" * 40
+    )
     for f in scan_text(sample):
         PLAINTEXTS.append(f.value)
 
@@ -112,7 +120,9 @@ def test_scan_history_masks_plaintext(fake_history):
 
 def test_scan_history_only_rules_filters(fake_history):
     root, _secret = fake_history
-    result = scan_history(source="claude-code", root=str(root), only_rules="aws-access-key")
+    result = scan_history(
+        source="claude-code", root=str(root), only_rules="aws-access-key"
+    )
     assert result["findings"] == []
 
 
@@ -129,7 +139,10 @@ def test_scan_history_rejects_exclude_and_only(fake_history):
     root, _secret = fake_history
     with pytest.raises(ValueError, match="not both"):
         scan_history(
-            source="claude-code", root=str(root), exclude_rules="github-pat", only_rules="aws-access-key"
+            source="claude-code",
+            root=str(root),
+            exclude_rules="github-pat",
+            only_rules="aws-access-key",
         )
 
 
@@ -143,6 +156,41 @@ def test_scan_history_empty_root_lands_in_skipped(tmp_path):
     result = scan_history(source="claude-code", root=str(tmp_path))
     assert result["skipped_sources"] == ["claude-code"]
     assert result["findings"] == []
+
+
+def test_scan_history_path_requires_explicit_source(fake_history):
+    root, _secret = fake_history
+    with pytest.raises(ValueError, match="requires an explicit source"):
+        scan_history(source="all", path=str(root / "history.jsonl"))
+
+
+def test_scan_history_path_directory_is_scanned(fake_history):
+    root, secret = fake_history
+    result = scan_history(source="claude-code", root=str(root), path=str(root))
+    assert result["findings"], (
+        "directory path= must scan the tree, not fall back to nothing"
+    )
+    blob = json.dumps(result)
+    assert secret not in blob
+
+
+def test_scan_history_path_outside_root_rejected(fake_history, tmp_path):
+    root, _secret = fake_history
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (outside / "other.jsonl").write_text("x\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="outside the source root"):
+        scan_history(
+            source="claude-code", root=str(root), path=str(outside / "other.jsonl")
+        )
+
+
+def test_scan_history_nonexistent_path_rejected(fake_history):
+    root, _secret = fake_history
+    with pytest.raises(ValueError, match="not a file or directory"):
+        scan_history(
+            source="claude-code", root=str(root), path=str(root / "nope.jsonl")
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +227,13 @@ def test_parse_rules_roundtrip():
     exclude, only = _parse_rules("github-pat,aws-access-key", None)
     assert exclude == {"github-pat", "aws-access-key"}
     assert only is None
+
+
+def test_parse_rules_accepts_detector_ids():
+    # scan_text emits "bip39-mnemonic", which is a DETECTOR_IDS entry, not a
+    # RULES regex id — the CLI validates against both sets; MCP must too.
+    exclude, _ = _parse_rules("bip39-mnemonic", None)
+    assert exclude == {"bip39-mnemonic"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -160,13 +160,31 @@ def test_mcp_cli_shim_missing_extra_message(monkeypatch, capsys):
 
     def fake_import(name, *a, **k):
         if name == "agentsweep.mcp_server":
-            raise ImportError("No module named 'fastmcp'")
+            raise ModuleNotFoundError("No module named 'fastmcp'", name="fastmcp")
         return real_import(name, *a, **k)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
     with pytest.raises(SystemExit) as exc_info:
         mcp_cli.main()
     assert "agentsweep[mcp]" in str(exc_info.value)
+
+
+def test_mcp_cli_shim_reraises_other_import_errors(monkeypatch):
+    import builtins
+    from agentsweep import mcp_cli
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "agentsweep.mcp_server":
+            raise ModuleNotFoundError(
+                "No module named 'agentsweep.scanner'", name="agentsweep.scanner"
+            )
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ModuleNotFoundError, match="agentsweep.scanner"):
+        mcp_cli.main()
 
 
 def test_scan_history_rejects_exclude_and_only(fake_history):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -98,10 +98,10 @@ def test_scan_history_unknown_source_lists_known():
 
 
 @pytest.fixture
-def fake_history(tmp_path):
-    """A leaky JSONL tree shaped like a claude-code projects dir."""
+def fake_history(_isolate_home):
+    """A leaky JSONL tree under the isolated HOME's default claude-code root."""
     secret = "ghp_" + "A" * 36
-    root = tmp_path / "claude" / "projects"
+    root = _isolate_home / ".claude" / "projects"
     root.mkdir(parents=True)
     (root / "history.jsonl").write_text(
         json.dumps({"prompt": f"deploy with {secret}"}) + "\n", encoding="utf-8"
@@ -110,8 +110,8 @@ def fake_history(tmp_path):
 
 
 def test_scan_history_masks_plaintext(fake_history):
-    root, secret = fake_history
-    result = scan_history(source="claude-code", root=str(root))
+    _root, secret = fake_history
+    result = scan_history(source="claude-code")
     assert result["findings"], "expected at least one finding"
     blob = json.dumps(result)
     assert secret not in blob
@@ -119,16 +119,12 @@ def test_scan_history_masks_plaintext(fake_history):
 
 
 def test_scan_history_only_rules_filters(fake_history):
-    root, _secret = fake_history
-    result = scan_history(
-        source="claude-code", root=str(root), only_rules="aws-access-key"
-    )
+    result = scan_history(source="claude-code", only_rules="aws-access-key")
     assert result["findings"] == []
 
 
 def test_scan_history_limit_truncates_but_counts_full(fake_history):
-    root, _secret = fake_history
-    result = scan_history(source="claude-code", root=str(root), limit=0)
+    result = scan_history(source="claude-code", limit=0)
     assert result["findings"] == []
     assert result["findings_truncated"] is True
     assert result["summary"]["total_findings"] >= 1
@@ -188,24 +184,16 @@ def test_mcp_cli_shim_reraises_other_import_errors(monkeypatch):
 
 
 def test_scan_history_rejects_exclude_and_only(fake_history):
-    root, _secret = fake_history
     with pytest.raises(ValueError, match="not both"):
         scan_history(
             source="claude-code",
-            root=str(root),
             exclude_rules="github-pat",
             only_rules="aws-access-key",
         )
 
 
-def test_scan_history_root_requires_explicit_source(tmp_path):
-    # root= only makes sense for one source; "all" + root must be rejected.
-    with pytest.raises(ValueError, match="requires an explicit source"):
-        scan_history(source="all", root=str(tmp_path))
-
-
-def test_scan_history_empty_root_lands_in_skipped(tmp_path):
-    result = scan_history(source="claude-code", root=str(tmp_path))
+def test_scan_history_missing_source_lands_in_skipped():
+    result = scan_history(source="claude-code")
     assert result["skipped_sources"] == ["claude-code"]
     assert result["findings"] == []
 
@@ -218,7 +206,7 @@ def test_scan_history_path_requires_explicit_source(fake_history):
 
 def test_scan_history_path_directory_is_scanned(fake_history):
     root, secret = fake_history
-    result = scan_history(source="claude-code", root=str(root), path=str(root))
+    result = scan_history(source="claude-code", path=str(root))
     assert result["findings"], (
         "directory path= must scan the tree, not fall back to nothing"
     )
@@ -227,22 +215,17 @@ def test_scan_history_path_directory_is_scanned(fake_history):
 
 
 def test_scan_history_path_outside_root_rejected(fake_history, tmp_path):
-    root, _secret = fake_history
     outside = tmp_path / "elsewhere"
     outside.mkdir()
     (outside / "other.jsonl").write_text("x\n", encoding="utf-8")
     with pytest.raises(ValueError, match="outside the source root"):
-        scan_history(
-            source="claude-code", root=str(root), path=str(outside / "other.jsonl")
-        )
+        scan_history(source="claude-code", path=str(outside / "other.jsonl"))
 
 
 def test_scan_history_nonexistent_path_rejected(fake_history):
     root, _secret = fake_history
     with pytest.raises(ValueError, match="not a file or directory"):
-        scan_history(
-            source="claude-code", root=str(root), path=str(root / "nope.jsonl")
-        )
+        scan_history(source="claude-code", path=str(root / "nope.jsonl"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,194 @@
+"""Tests for the optional MCP server (agentsweep[mcp]).
+
+Covers the read-only tool surface with the plaintext boundary as the
+core invariant: no tool output may carry ``Finding.value``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+fastmcp = pytest.importorskip("fastmcp")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agentsweep.mcp_server import (  # noqa: E402
+    _parse_rules,
+    _parse_source,
+    get_rotation_guidance,
+    list_sources,
+    mcp as mcp_app,
+    scan_history,
+)
+from agentsweep.scanner import ROTATION_GUIDANCE, scan_text  # noqa: E402
+from agentsweep.sources import SOURCES  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Plaintext boundary helper: the one rule the whole module exists to enforce.
+
+PLAINTEXTS: list[str] = []
+
+
+def _collect_plaintexts() -> None:
+    """Scan one string containing a real-looking fake secret per rule family."""
+    if PLAINTEXTS:
+        return
+    sample = "token=ghp_" + "A" * 36 + " key=AKIA" + "B" * 16 + " sk=sk-proj-" + "C" * 40
+    for f in scan_text(sample):
+        PLAINTEXTS.append(f.value)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    """Point HOME at an empty dir so scans can't touch real agent histories."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    yield fake_home
+
+
+# ---------------------------------------------------------------------------
+# list_sources
+
+
+def test_list_sources_matches_registry():
+    rows = list_sources()
+    assert {r["source"] for r in rows} == set(SOURCES)
+
+
+def test_list_sources_detected_only_is_subset():
+    every = list_sources()
+    detected = list_sources(detected_only=True)
+    assert {r["source"] for r in detected} <= {r["source"] for r in every}
+    assert all(r["detected"] for r in detected)
+
+
+# ---------------------------------------------------------------------------
+# scan_history
+
+
+def test_scan_history_unknown_source_raises():
+    with pytest.raises(ValueError, match="unknown source"):
+        scan_history(source="definitely-not-a-source")
+
+
+def test_scan_history_unknown_rule_raises():
+    with pytest.raises(ValueError, match="unknown rule"):
+        scan_history(source="claude-code", only_rules="not-a-rule")
+
+
+def test_scan_history_unknown_source_lists_known():
+    with pytest.raises(ValueError, match="claude-code"):
+        scan_history(source="definitely-not-a-source")
+
+
+@pytest.fixture
+def fake_history(tmp_path):
+    """A leaky JSONL tree shaped like a claude-code projects dir."""
+    secret = "ghp_" + "A" * 36
+    root = tmp_path / "claude" / "projects"
+    root.mkdir(parents=True)
+    (root / "history.jsonl").write_text(
+        json.dumps({"prompt": f"deploy with {secret}"}) + "\n", encoding="utf-8"
+    )
+    return root, secret
+
+
+def test_scan_history_masks_plaintext(fake_history):
+    root, secret = fake_history
+    result = scan_history(source="claude-code", root=str(root))
+    assert result["findings"], "expected at least one finding"
+    blob = json.dumps(result)
+    assert secret not in blob
+    assert all(f["masked"] for f in result["findings"])
+
+
+def test_scan_history_only_rules_filters(fake_history):
+    root, _secret = fake_history
+    result = scan_history(source="claude-code", root=str(root), only_rules="aws-access-key")
+    assert result["findings"] == []
+
+
+def test_scan_history_limit_truncates_but_counts_full(fake_history):
+    root, _secret = fake_history
+    result = scan_history(source="claude-code", root=str(root), limit=0)
+    assert result["findings"] == []
+    assert result["findings_truncated"] is True
+    assert result["summary"]["total_findings"] >= 1
+    assert "github-pat" in result["summary"]["by_rule"]
+
+
+def test_scan_history_rejects_exclude_and_only(fake_history):
+    root, _secret = fake_history
+    with pytest.raises(ValueError, match="not both"):
+        scan_history(
+            source="claude-code", root=str(root), exclude_rules="github-pat", only_rules="aws-access-key"
+        )
+
+
+def test_scan_history_root_requires_explicit_source(tmp_path):
+    # root= only makes sense for one source; "all" + root must be rejected.
+    with pytest.raises(ValueError, match="requires an explicit source"):
+        scan_history(source="all", root=str(tmp_path))
+
+
+def test_scan_history_empty_root_lands_in_skipped(tmp_path):
+    result = scan_history(source="claude-code", root=str(tmp_path))
+    assert result["skipped_sources"] == ["claude-code"]
+    assert result["findings"] == []
+
+
+# ---------------------------------------------------------------------------
+# get_rotation_guidance
+
+
+def test_rotation_guidance_full_mapping():
+    guidance = get_rotation_guidance()
+    assert isinstance(guidance, dict)
+    assert guidance == ROTATION_GUIDANCE
+
+
+def test_rotation_guidance_single_rule():
+    rule = sorted(ROTATION_GUIDANCE)[0]
+    guidance = get_rotation_guidance(rule)
+    assert guidance == {rule: ROTATION_GUIDANCE[rule]}
+
+
+def test_rotation_guidance_unknown_rule():
+    with pytest.raises(ValueError, match="no rotation guidance"):
+        get_rotation_guidance("not-a-rule")
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing helpers
+
+
+def test_parse_source_none_means_all():
+    assert _parse_source(None) == sorted(SOURCES)
+    assert _parse_source("all") == sorted(SOURCES)
+
+
+def test_parse_rules_roundtrip():
+    exclude, only = _parse_rules("github-pat,aws-access-key", None)
+    assert exclude == {"github-pat", "aws-access-key"}
+    assert only is None
+
+
+# ---------------------------------------------------------------------------
+# Server wiring
+
+
+async def _tool_names() -> set[str]:
+    return {t.name for t in await mcp_app.list_tools()}
+
+
+def test_tools_registered():
+    tools = asyncio.run(_tool_names())
+    assert {"list_sources", "scan_history", "get_rotation_guidance"} <= tools


### PR DESCRIPTION
First slice of #160.

`pip install agentsweep[mcp]` adds an `agentsweep-mcp` stdio server (FastMCP) with three read-only tools:

- `list_sources` — which agents are installed here (wraps `pipeline._source_rows`)
- `scan_history` — scan one source or all, same detection logic as the CLI via `pipeline._scan_all`; findings carry `source/file/line/keypath/rule/display/masked`, where `file` is relative to the source root and `display` is the rule's display name. Supports `glob`, `root` override (like `--root`; rejected with `all`), `exclude_rules`/`only_rules` (mutually exclusive), and a `limit` (default 200) with `findings_truncated` + a `summary` block that always counts the full scan so a big sweep doesn't dump thousands of rows into a client's context.
- `get_rotation_guidance` — the provider rotation steps

Plaintext boundary: `Finding.value` never leaves the process — only `masked` goes out. That's tested directly: the fixture embeds a fake `ghp_` token inside a longer JSON line and asserts the plaintext is absent from the entire JSON response.

All three tools are annotated `readOnlyHint=True`. Redaction (`agentsweep fix`) stays CLI-only on purpose — the destructive path shouldn't be one hallucination away.

Things I'd suggest as follow-ups rather than baking in now: an upper bound on `fastmcp` once its API settles, a CI job installing `.[mcp]`, typed response models, and symlink-escape hardening for `root=`. Happy to do any of them if you want.

Tests: `pytest tests/test_mcp_server.py -q` — 17 passed (importorskip'd on fastmcp, so a base install skips cleanly); `ruff check` clean on the new files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional MCP server for compatible tool integrations.
  * Added read-only tools to list sources, scan agent histories, and provide credential rotation guidance.
  * Scan results mask sensitive values and support source, rule, path, glob, and result-limit filtering.
  * Added validation for scan paths and rule filters.
  * Added the `agentsweep-mcp` command to start the server.

* **Tests**
  * Added coverage for validation, filtering, masking, truncation, and tool registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->